### PR TITLE
build: rename ado-base to ado-core

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -172,7 +172,7 @@ uv add pydantic
 
 ### Adding optional dependencies
 
-Dependencies may be optional, making them available only when using extras, such as `ado-base[my-extra]`. To add
+Dependencies may be optional, making them available only when using extras, such as `ado-core[my-extra]`. To add
 these kind of dependencies, use the [
 `uv add --optional` command](https://docs.astral.sh/uv/concepts/projects/dependencies/#optional-dependencies):
 

--- a/orchestrator/cli/commands/version.py
+++ b/orchestrator/cli/commands/version.py
@@ -9,7 +9,7 @@ from orchestrator.cli.utils.output.prints import console_print
 def print_version():
     from importlib.metadata import version
 
-    console_print(version("ado-base"))
+    console_print(version("ado-core"))
 
 
 def register_version_command(app: typer.Typer):

--- a/orchestrator/core/operation/config.py
+++ b/orchestrator/core/operation/config.py
@@ -145,7 +145,7 @@ class BaseOperationRunConfiguration(pydantic.BaseModel):
     model_config = ConfigDict(
         extra="forbid",
         json_schema_extra={
-            "version": importlib.metadata.version(distribution_name="ado-base")
+            "version": importlib.metadata.version(distribution_name="ado-core")
         },
     )
 

--- a/orchestrator/modules/operators/randomwalk.py
+++ b/orchestrator/modules/operators/randomwalk.py
@@ -802,7 +802,7 @@ class RandomWalk(Characterize):
 
         from importlib.metadata import version
 
-        version = version("ado-base")
+        version = version("ado-core")
 
         return "randomwalk-%s" % version
 

--- a/orchestrator/schema/entity.py
+++ b/orchestrator/schema/entity.py
@@ -69,7 +69,7 @@ class Entity(pydantic.BaseModel):
     model_config = ConfigDict(
         extra="forbid",
         json_schema_extra={
-            "version": importlib.metadata.version(distribution_name="ado-base")
+            "version": importlib.metadata.version(distribution_name="ado-core")
         },
     )
 

--- a/orchestrator/schema/experiment.py
+++ b/orchestrator/schema/experiment.py
@@ -71,7 +71,7 @@ class Experiment(pydantic.BaseModel):
         frozen=True,
         extra="forbid",
         json_schema_extra={
-            "version": importlib.metadata.version(distribution_name="ado-base")
+            "version": importlib.metadata.version(distribution_name="ado-core")
         },
     )
     optionalProperties: typing.Tuple[ConstitutiveProperty, ...] = pydantic.Field(

--- a/plugins/actuators/sfttrainer/ado_actuators/sfttrainer/actuators.py
+++ b/plugins/actuators/sfttrainer/ado_actuators/sfttrainer/actuators.py
@@ -761,8 +761,8 @@ class SFTTrainer(ActuatorBase):
         additional_wheels = [
             x
             for x in packages
-            # VV: Do not install the ado_base wheel. Its dependencies may conflict with those in fms-hf-tuning
-            if x.endswith(".whl") and not os.path.basename(x).startswith("ado_base-")
+            # VV: Do not install the ado_core wheel. Its dependencies may conflict with those in fms-hf-tuning
+            if x.endswith(".whl") and not os.path.basename(x).startswith("ado_core-")
         ]
 
         if additional_wheels:

--- a/plugins/actuators/sfttrainer/examples/build_wheels.sh
+++ b/plugins/actuators/sfttrainer/examples/build_wheels.sh
@@ -31,7 +31,7 @@ rm -rf build dist
 cd ${my_working_dir}
 
 sftrainer_wheel_prefix="ado_sfttrainer"
-ado_wheel_prefix="ado_base"
+ado_wheel_prefix="ado_core"
 
 cat <<EOF >ray_runtime_env.yaml
 pip:

--- a/plugins/operators/ray_tune/ado_ray_tune/operator.py
+++ b/plugins/operators/ray_tune/ado_ray_tune/operator.py
@@ -841,7 +841,7 @@ class RayTune(Search):
     def operatorIdentifier(cls):
         from importlib.metadata import version
 
-        version = version("ado-base")
+        version = version("ado-core")
 
         return "raytune-%s" % version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ado-base"
+name = "ado-core"
 description = """ado is a unified platform for executing computational experiments at scale and analysing their results.
 It can be easily extended with new experiments or new analysis tools. It allows distributed teams of
 researchers and engineers to collaborate on projects, execute experiments, and share data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,7 +144,7 @@ bleach==6.2.0 \
 build==1.3.0 \
     --hash=sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397 \
     --hash=sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4
-    # via ado-base
+    # via ado-core
 cachetools==6.2.0 \
     --hash=sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6 \
     --hash=sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32
@@ -258,7 +258,7 @@ colorful==0.5.7 \
 colorlog==6.9.0 \
     --hash=sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff \
     --hash=sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2
-    # via ado-base
+    # via ado-core
 comm==0.2.3 \
     --hash=sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971 \
     --hash=sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417
@@ -597,7 +597,7 @@ json5==0.12.1 \
 jsonpath-ng==1.7.0 \
     --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
     --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
-    # via ado-base
+    # via ado-core
 jsonpointer==3.0.0 \
     --hash=sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942 \
     --hash=sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef
@@ -617,7 +617,7 @@ jsonschema-specifications==2025.4.1 \
 jupyter==1.1.1 \
     --hash=sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83 \
     --hash=sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a
-    # via ado-base
+    # via ado-core
 jupyter-client==8.6.3 \
     --hash=sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419 \
     --hash=sha256:e8a19cc986cc45905ac3362915f410f3af85424b4c0905e94fa5f2cb08e8f23f
@@ -891,7 +891,7 @@ numpy==1.26.4 \
     --hash=sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef \
     --hash=sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f
     # via
-    #   ado-base
+    #   ado-core
     #   pandas
     #   scipy
 opencensus==0.11.4 \
@@ -966,7 +966,7 @@ pandas==2.3.2 \
     --hash=sha256:d25c20a03e8870f6339bcf67281b946bd20b86f1a544ebbebb87e66a8d642cba \
     --hash=sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4 \
     --hash=sha256:e190b738675a73b581736cc8ec71ae113d6c3768d0bd18bffa5b9a0927b0b6ea
-    # via ado-base
+    # via ado-core
 pandocfilters==1.5.1 \
     --hash=sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e \
     --hash=sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc
@@ -1092,7 +1092,7 @@ pure-eval==0.2.3 \
 py-markdown-table==1.3.0 \
     --hash=sha256:b8740b57e466f343dbb1e9c7ca4e2d1b4281d96fb922bf1ed60b6c496c8725c4 \
     --hash=sha256:be63f6bcbe32e10a9a68575eb48a648949df067b54b48ad6d993b0e5748f57d6
-    # via ado-base
+    # via ado-core
 py-spy==0.4.1 \
     --hash=sha256:1fb8bf71ab8df95a95cc387deed6552934c50feef2cf6456bc06692a5508fd0c \
     --hash=sha256:4972c21890b6814017e39ac233c22572c4a61fd874524ebc5ccab0f2237aee0a \
@@ -1121,7 +1121,7 @@ pydantic==2.11.7 \
     --hash=sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db \
     --hash=sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b
     # via
-    #   ado-base
+    #   ado-core
     #   fastapi
     #   ray
 pydantic-core==2.33.2 \
@@ -1198,7 +1198,7 @@ pygments==2.19.2 \
 pymysql==1.1.2 \
     --hash=sha256:4961d3e165614ae65014e361811a724e2044ad3ea3739de9903ae7c21f539f03 \
     --hash=sha256:e6b1d89711dd51f8f74b1631fe08f039e7d76cf67a42a323d3178f0f25762ed9
-    # via ado-base
+    # via ado-core
 pyproject-hooks==1.2.0 \
     --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
     --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
@@ -1274,7 +1274,7 @@ pyyaml==6.0.2 \
     --hash=sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
-    #   ado-base
+    #   ado-core
     #   jupyter-events
     #   ray
     #   uvicorn
@@ -1341,7 +1341,7 @@ ray==2.49.0 \
     --hash=sha256:e42a4187a90e897afb95517cb8aa4fc0c24718bd428bdec0b260aa2d18ece6c8 \
     --hash=sha256:e908e6f7b46429d26f4594579458298844d1a485c288cfe58914fa7a294fd3a4 \
     --hash=sha256:f943a9c2ae049636b126a194047fdf9101060a9985d1db614b17b27061f8e9f3
-    # via ado-base
+    # via ado-core
 referencing==0.36.2 \
     --hash=sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa \
     --hash=sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0
@@ -1483,7 +1483,7 @@ scipy==1.15.3 ; python_full_version < '3.11' \
     --hash=sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45 \
     --hash=sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf \
     --hash=sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e
-    # via ado-base
+    # via ado-core
 scipy==1.16.1 ; python_full_version >= '3.11' \
     --hash=sha256:0a55ffe0ba0f59666e90951971a884d1ff6f4ec3275a48f472cfb64175570f77 \
     --hash=sha256:15240c3aac087a522b4eaedb09f0ad061753c5eebf1ea430859e5bf8640d5919 \
@@ -1504,7 +1504,7 @@ scipy==1.16.1 ; python_full_version >= '3.11' \
     --hash=sha256:f7b8013c6c066609577d910d1a2a077021727af07b6fab0ee22c2f901f22352a \
     --hash=sha256:f8a5d6cd147acecc2603fbd382fed6c46f474cccfcf69ea32582e033fb54dcfe \
     --hash=sha256:f965bbf3235b01c776115ab18f092a95aa74c271a52577bcb0563e85738fd618
-    # via ado-base
+    # via ado-core
 send2trash==1.8.3 \
     --hash=sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9 \
     --hash=sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf
@@ -1567,7 +1567,7 @@ sqlalchemy==2.0.43 \
     --hash=sha256:e7a903b5b45b0d9fa03ac6a331e1c1d6b7e0ab41c63b6217b3d10357b83c8b00 \
     --hash=sha256:f42f23e152e4545157fa367b2435a1ace7571cab016ca26038867eb7df2c3631 \
     --hash=sha256:fe2b3b4927d0bc03d02ad883f402d5de201dbc8894ac87d2e981e7d87430e60d
-    # via ado-base
+    # via ado-core
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
@@ -1654,7 +1654,7 @@ traitlets==5.14.3 \
 typer==0.16.1 \
     --hash=sha256:90ee01cb02d9b8395ae21ee3368421faf21fa138cb2a541ed369c08cec5237c9 \
     --hash=sha256:d358c65a464a7a90f338e3bb7ff0c74ac081449e53884b12ba658cbd72990614
-    # via ado-base
+    # via ado-core
 types-python-dateutil==2.9.0.20250822 \
     --hash=sha256:849d52b737e10a6dc6621d2bd7940ec7c65fcb69e6aa2882acf4e56b2b508ddc \
     --hash=sha256:84c92c34bd8e68b117bff742bc00b692a1e8531262d4507b33afcc9f7716cd53

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and platform_python_implementation == 'PyPy'",
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "ado-base"
+name = "ado-core"
 source = { editable = "." }
 dependencies = [
     { name = "build" },

--- a/website/docs/examples/finetune-remotely.md
+++ b/website/docs/examples/finetune-remotely.md
@@ -218,7 +218,7 @@ In this section, we’ll focus on the second approach.
        PYTHONUNBUFFERED: "x"
     ```
     
-    If your RayCluster doesn't already have `ado` installed in its virtual environment then build the wheel for `ado-base` by repeating the above in the root directory of `ado`. Then add an entry under `pip` pointing to the the resulting `ado` wheel file.
+    If your RayCluster doesn't already have `ado` installed in its virtual environment then build the wheel for `ado-core` by repeating the above in the root directory of `ado`. Then add an entry under `pip` pointing to the the resulting `ado` wheel file.
 
     !!! info end
 

--- a/website/docs/examples/finetune-remotely.md
+++ b/website/docs/examples/finetune-remotely.md
@@ -371,7 +371,7 @@ You can find the complete list of the entity space properties in the documentati
 
      ```
      my-remote-measurements
-     ├── ado_base-1.1.0.dev133+f4b639c1.dirty-py3-none-any.whl
+     ├── ado_core-1.1.0.dev133+f4b639c1.dirty-py3-none-any.whl
      ├── context.yaml
      ├── operation.yaml
      ├── ray_runtime_env.yaml

--- a/website/docs/getting-started/remote_run.md
+++ b/website/docs/getting-started/remote_run.md
@@ -67,7 +67,7 @@ Then there are two steps:
     ```
     
     * First command removes any previous build artifacts and wheels. This prevents issues with old files being included in the new wheel
-    * Second command creates a `dist/` directory with the wheel. It will have a name like `ado_base-$VERSION-py3-none.whl`
+    * Second command creates a `dist/` directory with the wheel. It will have a name like `ado_core-$VERSION-py3-none.whl`
     * Last command copies the wheel to the directory you made
 
 === "Build the plugin wheels"
@@ -94,7 +94,7 @@ In our case it is the wheels we just created e.g.
 
 ```yaml
 pip: # One line for each wheel to install, in this example there is two. Be sure to check spelling.
- - ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/$ADO_BASE.whl
+ - ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/$ADO_CORE.whl
  - ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/$ADO_PLUGIN1.whl
 env_vars: # See below
   ...
@@ -162,7 +162,7 @@ The environment of the ray job is given in a YAML file. An example is:
 
 ```yaml
 pip: # One line for each wheel to install, in this example there is two. Be sure to check spelling.
- - ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/$ADO_BASE.whl
+ - ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/$ADO_CORE.whl
  - ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/$ADO_PLUGIN1.whl
 env_vars: # These envars are recommend. Some plugins may require others. Check plugin docs.
   PYTHONUNBUFFERED: "x" # Turns of buffering of the jobs logs. Useful if there is some error


### PR DESCRIPTION
# Changes

Resolves #5 

## 🔄 Renaming
- Replaced all references to `ado-base` with `ado-core` across the codebase and documentation.

## 🛠️ Code Updates
- Updated wheel filtering logic to exclude `ado_core` instead of `ado_base`.
- Modified environment setup scripts and YAML configurations to use `ADO_CORE.whl` instead of `ADO_BASE.whl`.

## 📦 Dependency Comments
- Changed inline comments in dependency files to reflect `ado-core` as the source instead of `ado-base`.

## 📚 Documentation
- Updated examples and instructions in markdown files:
  - Build instructions now refer to `ado-core` wheel.
  - RayCluster setup steps updated to use `ado-core`.
  - Plugin installation examples now include `ado-core`.

## ✅ Miscellaneous
- Ensured consistency in naming across all affected files including:
  - `requirements.txt`
  - `ray_runtime_env.yaml`
  - Plugin build and install scripts

---

Disclosure: changelog generated by Copilot