### PR TITLE
chore: website fixes

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,7 +19,7 @@ uv sync
 source .venv/bin/activate
 ```
 
-> [!INFO]
+> [!NOTE]
 > This installs `ado` in editable mode.
 
 > [!NOTE]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,7 @@ This is a living document that will be updated regularly as the project evolves.
 ### **Q3 2025**
 
 **Version 1.0.0 (Initial Release)**
+
    - Complete core feature set
    - Production actuator for fine-tuning performance measurement
    - Reference actuators for inference performance measurement and model evaluation

--- a/examples/optimization_test_functions/README.md
+++ b/examples/optimization_test_functions/README.md
@@ -266,20 +266,77 @@ The target property to optimize against is set by the `metric` field, under the 
             optimizer: "CMA"
 ```
 
-## See the operation results
+## See the optimization results
 
-Run 
+### Best configuration found
+
+The `ray_tune` operation will create a `datacontainer` resource containing information on the best configuration found. 
+
+To get the id of the `datacontainer` related to the `operation` use
+```commandline
+ado show related operation $OPERATION_ID
+```
+this will output something like,
+```commandline
+datacontainer
+  - datacontainer-d6a6501b
+discoveryspace
+  - space-047b6a-f60613
+```
+
+To see the best point found (and in general the contents of the datacontainer) use the `describe` CLI command:
+```commandline
+ado describe datacontainer $DATACONTAINER_ID
+```
+In this case the output will be something like:
+```commandline
+Identifier: datacontainer-d6a6501b
+Basic Data:
+  
+  Label: best_result
+  
+  {'config': {'x2': -1.1192905253425014,
+    'x1': 2.081208150586974,
+    'x0': 0.5621591414422049},
+   'metrics': {'function_value': 20.788056393697595,
+    'timestamp': 1756804287,
+    'checkpoint_dir_name': None,
+    'done': True,
+    'training_iteration': 1,
+    'trial_id': '7a7153ed',
+    'date': '2025-09-02_10-11-27',
+    'time_this_iter_s': 1.0576610565185547,
+    'time_total_s': 1.0576610565185547,
+    'pid': 52036,
+    'hostname': 'Michaels-MacBook-Pro-2.local',
+    'node_ip': '127.0.0.1',
+    'config': {'x2': -1.1192905253425014,
+     'x1': 2.081208150586974,
+     'x0': 0.5621591414422049},
+    'time_since_restore': 1.0576610565185547,
+    'iterations_since_restore': 1,
+    'experiment_tag': '40_x0=0.5622,x1=2.0812,x2=-1.1193'},
+   'error': None}
+```
+we can see the here the point found is `{'x2': -1.1192905253425014, 'x1': 2.081208150586974, 'x0': 0.5621591414422049}` where `function_value` was ~20.8.
+
+
+### Configurations visited
+
+To see the configurations visited during the optimization execute,
 ```
 ado show entities operation $OPERATION_IDENTIFIER
 ```
 where `$OPERATION_IDENTIFIER` is the identifier of the operation you just ran.
 This will output a dataframe containing the results of that operation.
 
-Also try
+### Operation resource YAML
+
+If at any point you want to see the details for an operation, for example the options used, execute:
 ```
 ado get operation $OPERATION_IDENTIFIER -o yaml
 ```
-will output the details of this operation in YAML format - this will be same YAML as shown in the previous section.
+This will output the details of this operation in YAML format - this will be same YAML as shown in the previous section.
 
 ## Parameterizable experiments
 

--- a/website/docs/core-concepts/actuators.md
+++ b/website/docs/core-concepts/actuators.md
@@ -8,14 +8,14 @@ To find the values of certain properties of Entities we need to perform measurem
 We use the term "experiment" to describe a particular type of measurement. 
 This could also be called an "experiment protocol".
 
-An experiment will define the set of constitutive and observed properties it requires entities to have.
+An experiment will define its inputs - the set of constitutive and observed properties it requires entities to have.
 It will also define the properties it measures.
 
 ## Actuators
 
 Experiments are provided by Actuators.
 An Actuator usually provides sets of experiments that work on the same types of entities i.e. have the same or similar input requirements.
-As such Actuators usually are related to a particular domain e.g. computation chemistry, foundation model inference,
+As such Actuators usually are related to a particular domain e.g. computational chemistry, foundation model inference,
 robotic biology lab. 
 
 `ado get actuators --details` lists the available actuators and experiments. Here is a truncated example of the output:

--- a/website/docs/core-concepts/concepts.md
+++ b/website/docs/core-concepts/concepts.md
@@ -4,23 +4,23 @@ status: published #Status can be draft, reviewed or published.
 
 ## Discovery Space
 
-The core concept in `ado` is called a `Discovery Space`. 
+The core concept in `ado` is called a *Discovery Space*. 
 In `ado` you are often creating and performing operations on Discovery Spaces. 
 
-For users familiar with `pandas` and `dataframes`, a `Discovery Space` combines:
+For users familiar with `pandas` and `dataframes`, a Discovery Space combines:
 
 * the schema of a `dataframe` i.e. the columns and what they mean
 * instructions on how to fill the `dataframe` rows
 * the current data in the `dataframe` (and what's missing!)
 
-So a `Discovery Space` allows expressing the hidden metadata and contextual information necessary to understand and extend a dataframe.
+So a Discovery Space allows expressing the hidden metadata and contextual information necessary to understand and extend a dataframe.
 See [Discovery Space](discovery-spaces.md) for more details. 
 
-A `Discovery Space` is built from:
+A Discovery Space is built from:
 
 - [Entities and Entity Spaces](entity-spaces.md): The set of things in a Discovery Space
 - [Measurement Spaces](actuators.md#measurement-space):  The set of experiments in a Discovery Space
-- [Experiments and Actuators](actuators.md): The available experiments in `ado` and the tools that execute them
+- [Experiments and Actuators](actuators.md): The available experiments and the tools that execute them
 
 ## Sample Store
 

--- a/website/docs/core-concepts/data-sharing.md
+++ b/website/docs/core-concepts/data-sharing.md
@@ -2,15 +2,15 @@
 > We recommend to read about [Discovery Spaces](discovery-spaces.md) before reading this document. 
 
 
-In `ado` data from experiments are stored in a database a.k.a. "sample store".
-We call these databases Sample Stores and you can read more about them [here](../resources/sample-stores.md).
-They store Entities along with measurements made on them.
+In `ado` Entities and measurement results are stored in a database called a **Sample Store**. 
+This document describes how Sample Stores enabling sharing of data. 
+For more general information about these databases see [here](../resources/sample-stores.md).
 
 From the point-of-view of understanding data reuse in `ado`, the following points are key:
 
 * You can **share** a Sample Store between multiple Discovery Spaces
     * This allows a Discovery Space to (re)use relevant Entities and Measurements placed in the Sample Store by operations on other Discovery Spaces
-* **Entities are always shared**. There is only one entry in a Sample Store for an Entity. 
+* **Entities are always shared**. There is only one entry in a Sample Store for an Entity 
 
 > [!NOTE] 
 > To maximise the chance of data-reuse, similar Discovery Spaces should use the same Sample Store. 
@@ -28,7 +28,7 @@ There are two situations where data can be shared between Discovery Spaces in `a
 As a quick recap, a Discovery Space is composed of:
 
 * an [Entity Space](entity-spaces.md) which describes a set of Entities (points) to be measured
-* a [Measurement Space](actuators.md#measurement-space) which describes a set of Experiments to apply to the points. 
+* a [Measurement Space](actuators.md#measurement-space) which describes a set of Experiments to apply to the points 
 
 ### Entities
 

--- a/website/docs/core-concepts/discovery-spaces.md
+++ b/website/docs/core-concepts/discovery-spaces.md
@@ -6,7 +6,7 @@ status: published #Status can be draft, reviewed or published.
 A Discovery Space is made up of an [`Entity Space`](entity-spaces.md) and a [`Measurement Space`](actuators.md#measurement-space). 
 The `Entity Space` defines the things you want to measure and the `Measurement Space` how you want to measure them.
 
-A Discovery Space is also associated with some storage where the measured entities are placed.  
+A Discovery Space is also associated with a [Sample Store](data-sharing.md) where measurement results and entities are recorded.  
 
 ## Example: Fine-Tuning Deployment Configuration Discovery Space
 

--- a/website/docs/core-concepts/entity-spaces.md
+++ b/website/docs/core-concepts/entity-spaces.md
@@ -4,8 +4,8 @@ status: published #Status can be draft, reviewed or published.
 
 ## Entities
 
-Entities represent objects you can measure. 
-Examples are molecules or points in a parameter space.
+Entities represent things that can be measured. 
+Examples are molecules or points in a an application configuration space.
 
 Entities all have a set of constitutive properties which define them. 
 A molecule's constitutive properties might be a SMILES or INCHI string. 
@@ -62,7 +62,8 @@ For more about the meaning of `observed properties` see [target & observed prope
 
 ## Entity Spaces
     
-An entity space describes a set of entities. The set could be discrete or continuous, bounded or unbounded. 
+An Entity Space describes a set of entities. 
+The set could be discrete or continuous, bounded or unbounded. 
 In `ado` you normally define Entity Spaces and then sample Entities from them. 
 
 ### Example: Molecules
@@ -107,7 +108,7 @@ The domain is the range of values the property can take and also the probability
 In the `Fine-tuning Deployment Configuration` example we can see the domains for each property.
 The categorical properties have a set of values and the discrete properties a range and also a set of values.
 
-In the 'Molecules' example we see there is no domain, which means any value of `smiles` is allowed.
+In the `Molecules` example we see there is no domain, which means any value of `smiles` is allowed.
 When there is no domain it also means the Entity Space alone does not contain sufficient information by itself on how to sample the entities.
 
 By default, the probability is uniform, every value is equally likely, but it could also be more complex. 

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -6,9 +6,9 @@ status: published #Status can be draft, reviewed or published.
 
 **ado** can be installed in one of three ways:
 
-1. By **cloning the GitHub repository** locally 
-2. Via **GitHub** .
-
+1. From **pypi**
+2. From **GitHub**
+3. By **cloning the GitHub repository** locally 
 
 ???+ warning
 
@@ -29,12 +29,21 @@ status: published #Status can be draft, reviewed or published.
     source ado-venv/bin/activate
     ```
 
-=== "Cloning the repo"
+=== "From pypi"
 
-    This, method **requires having set up an SSH key** for the repository to be cloned. In case
-    you haven't already, you can do so [here](https://github.com/settings/keys)
-    by following GitHub's
-    [documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
+    This method installs the ado-core package from pypi
+
+    ```shell
+    pip install ado-core
+    ```
+
+=== "From GitHub"
+
+    ```shell
+    pip install git+https://github.com/IBM/ado.git
+    ```
+
+=== "Cloning the repo locally"
 
     ```shell
     git clone https://github.com/IBM/ado.git
@@ -42,27 +51,41 @@ status: published #Status can be draft, reviewed or published.
     pip install .
     ```
 
-=== "Via GitHub"
 
-    This, method **requires having set up an SSH key** for the repository to be cloned. In case
-    you haven't already, you can do so [here](https://github.com/settings/keys)
-    by following GitHub's
-    [documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
-
-    ```shell
-    pip install git+https://github.com/IBM/ado"
-    ```
 
 ## Installing plugins
 
 ado uses a plugin system to provide **additional actuators** and **operators**. 
 We maintain a set of actuators and operators in the ado main repo which you can see [here](https://github.com/ibm/ado/tree/main/plugins/).
+Some plugins may also have packages on pypi.
 You can install these actuators as follows:
 
 !!! info 
 
     Some plugins may have dependencies that may require credentials to access. 
     Check the plugins's docs if you encounter issues installing a specific actuator. 
+
+=== "From pypi"
+
+    The following plugin packages are available: `ado-sfttrainer`, `ado-vllm-performance` and `ado-ray-tune` 
+
+    ```shell
+    pip install $PLUGIN_NAME"
+    ```
+
+=== "From GitHub"
+
+    For actuators
+
+    ```shell
+    pip install "git+https://github.com/IBM/ado.git#subdirectory=plugins/actuators/$ACTUATOR_NAME"
+    ```
+
+    For operators
+
+    ```shell
+    pip install "git+https://github.com/IBM/ado.git#subdirectory=plugins/operators/$OPERATOR_NAME"
+    ```
 
 === "Cloning the repo"
 
@@ -80,14 +103,7 @@ You can install these actuators as follows:
     ```
 
 
-=== "Via GitHub"
 
-    We assume you have an SSH key configured on your GitHub account.
-    If you don't, look at the previous section for additional pointers.
-
-    ```shell
-    pip install "git+https://github.com/IBM/ado.git#subdirectory=plugins/actuators/$ACTUATOR_NAME"
-    ```
 
 
     

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -58,7 +58,7 @@ In addition `ado` plugins may have additional requirements for executing **_real
 
     ---
 
-    Assuming you have configured ssh access to IBM GitHub you can install **ado** by:
+    You can install **ado** by:
     
     ```shell
     pip install git+https://github.com/IBM/ado.git

--- a/website/docs/resources/actuatorconfig.md
+++ b/website/docs/resources/actuatorconfig.md
@@ -77,11 +77,11 @@ See [specifying actuator parameters](operation.md#passing-actuator-parameters) i
 ### Other ado commands that work with actuatorconfiguration
 
 - `ado get actuatorconfigurations`
-  - list stored `actuatorconfiguration`s or retrieve their representations
+    - list stored `actuatorconfiguration`s or retrieve their representations
 - `ado show related actuatorconfiguration ID`
-  - show operations using an `actuatorconfiguration`
+    - show operations using an `actuatorconfiguration`
 - `ado edit actuatorconfiguration ID`
-  - set the name, description, and labels for an `actuatorconfiguration`
+    - set the name, description, and labels for an `actuatorconfiguration`
 - `ado delete actuatorconfiguration ID` 
-  - delete an `actuatorconfiguration`
+    - delete an `actuatorconfiguration`
 

--- a/website/docs/resources/metastore.md
+++ b/website/docs/resources/metastore.md
@@ -55,7 +55,7 @@ metadataStore:
 
 ## Creating a context 
 
-To create a local or remote context in `ado` creates a file with the corresponding YAML definition (see above) and run:
+To create a local or remote context in `ado`, create a file with the corresponding YAML definition (see above) and run:
 
 ```commandline
 ado create context -f $YAML_FILE

--- a/website/docs/resources/operation.md
+++ b/website/docs/resources/operation.md
@@ -71,7 +71,7 @@ actuatorConfigurationIdentifiers:
   - actuatorconfiguration-st4sd-3cb3bb82
 ```
 
-## Specifying the `operator`
+### Specifying the `operator`
 
 The `operation.module` field sets the `operator` to use. For example above it was
 
@@ -134,37 +134,39 @@ Executing
 ado create operation -f OPERATION.YAML
 ```
 will create the `operation` resource in the active context and start performing whatever that operation does. 
-Currently, the operation happens synchronously with this command i.e. it will not return until the operation is complete.
+The operation executes synchronously with this command i.e. it will not return until the operation is complete.
 
 Before creating, and hence starting, the `operation`, the `parameters` will be validated with the `operator`. 
 If they are not valid e.g. a required argument is missing, the `create` operation will fail with a relevant error. 
 
 !!! info  end
 
-    Although the `create` command does not execute until the operation is finished distributed users querying the
+    Although the `create` command does not exit until the operation is finished distributed users querying the
     same context will be able to see the created operation, from the moment it is created.
 
 ### `operation` resource specific fields
 
-`operation` resources have some top-level fields in addition to common ones described [resources](resources.md#common-features-of-resources)
-
+`operation` resources has two additional top-level fields in addition to common ones described [resources](resources.md#common-features-of-resources)
 These are (with example values):
 
 ```yaml
 operationType: characterize # The type of the operation: characterize, modify etc.
 operatorIdentifier: profile-1.1 # The identifier of the operator including its version
-result: ... # The result of the operation if any
 ```
-
-For more on the result field see [getting operation output](#getting-operation-output).
-
-
 
 ## Getting `operation` output
 
 An operation can create any type of ado resource.
-To see the resources created by an operation use `ado show related operation`.
-Note output that is text, tables or locations will be contained in `datacontainer` resource.
+To see the resources created by an operation with identifier $OPERATION_ID use
+```commandline
+ado show related operation $OPERATION_ID`
+```
+Output that is text, tables or locations will be contained in  a `datacontainer` resource. 
+It can be output with,
+```commandline
+ado describe datacontainer $DATACONTAINER_IDENTIFIER
+```
+See [datacontainers](datacontainer.md) for more details. 
 
 ## `operation` status update events
 
@@ -186,18 +188,25 @@ operationType: search
 operatorIdentifier: raytune-0.7.5.dev10+g731d1e21.d20241218
 status:
 - event: created
-  recorded_at: '2024-12-19T10:53:58.411745Z'
+  recorded_at: '2025-09-02T09:09:02.187149Z'
 - event: added
-  recorded_at: '2024-12-19T10:54:45.841908Z'
+  recorded_at: '2025-09-02T09:09:15.187747Z'
 - event: started
-  recorded_at: '2024-12-19T10:54:55.995781Z'
+  recorded_at: '2025-09-02T09:09:15.190337Z'
+- event: updated
+  recorded_at: '2025-09-02T09:09:15.190383Z'
 - event: finished
   exit_state: success
-  recorded_at: '2024-12-19T10:55:21.429855Z'
+  message: Ray Tune operation completed successfully
+  recorded_at: '2025-09-02T09:11:28.047676Z'
 - event: updated
-  recorded_at: '2024-12-19T10:55:21.431450Z'
+  recorded_at: '2025-09-02T09:11:29.096685Z'
 version: v1
 ```
+
+> [!NOTE]
+> The first updated status reflects an update to the stored operation resource which added the `started` event.
+> The second updated status reflects an update to the storedx operation resource which added the `finished` event.
 
 ## Deleting operations
 

--- a/website/docs/resources/resources.md
+++ b/website/docs/resources/resources.md
@@ -6,10 +6,9 @@ status: published #Status can be draft, reviewed or published.
 
     We recommend to first familiarise yourself with the [core-concepts](../core-concepts/concepts.md) before reading about resources. 
 
-`ado` manages resources related to discovery. 
+`ado` manages resources related to discovery, for example descriptions of spaces to explore, exploration and analysis operations, and actuator configurations.
 It allows you to create resources, which it stores in a database (the [metastore](metastore.md)) along with their relationships to other resources. 
 You can then describe, list or delete those resources.
-Note, some resources take other resources as input, for example `operations` take `discoveryspaces` as input. 
 
 The resources are (use side panel to fine out more about each type):
 
@@ -19,9 +18,12 @@ The resources are (use side panel to fine out more about each type):
 * **datacontainer**: A collection of string, tabular or location data. Used to store arbitrary output from `operation`'s.
 * **actuatorconfigurations**: A configuration for an actuator. 
 
+> [!NOTE] 
+> Some resources take other resources as input, for example `operations` take `discoveryspaces` as input. 
+
 ## Naming Conventions: Concepts versus Resources
 
-`ado` resources are directly related to core `ado` [concepts](../core-concepts/concepts.md) and usually have the same name. 
+`ado` resources are directly related to `ado` [concepts](../core-concepts/concepts.md) and usually have the same name. 
 To differentiate a concept and the associated resource in the documentation we adopt the following conventions. 
 
 When we refer to concepts, upper case nouns like "Sample Store", "Actuator" are used.
@@ -41,7 +43,7 @@ However, they are not true resources and are not stored in the metastore.
 
 ## Common CLI commands for interacting with resources
 
-Here is a list of common `ado` CLI commands for interacting with resources. See [ado CLI guide](../getting-started/ado.md) for more details
+Here is a list of common `ado` CLI commands for interacting with resources. See the [ado CLI guide](../getting-started/ado.md) for more details
 
 * `ado get [resource type]` 
     * Lists all resource of the requested type

--- a/website/docs/resources/sample-stores.md
+++ b/website/docs/resources/sample-stores.md
@@ -2,13 +2,12 @@
 status: published #Status can be draft, reviewed or published. 
 ---
 
-A `samplestore` resource is a key:value store for [`entities`](../core-concepts/entity-spaces.md#entities), where the key is an entity's identifier and the value is the entity description along with the result of experiments that 
-have been applied to it.
+A `samplestore` resource is a database containing [`entities`](../core-concepts/entity-spaces.md#entities) along with result of experiments that have been applied to it.
 
 ## `samplestore`s and `discoveryspace`s
 
 When you create a [discovery space](discovery-spaces.md) you associate a `samplestore` with it.
-This is where the `discoveryspace` will read and write its data i.e. entities and the results of experiments on them.
+This is where the `discoveryspace` will read and write data i.e. entities and the results of experiments on them.
 You primarily access the entities in a `samplestore` via a `discoveryspace` that is attached to it.  
 
 You can think of a `discoveryspace` as a view or filter on a sample store - when you access data in a `samplestore` through a discovery space
@@ -21,7 +20,7 @@ you only see data that matches the `discoveryspace`.
 ## `samplestore`s and data-sharing
 
 When multiple `discoveryspace`s use the same `samplestore` this enables transparent data-sharing between the different `discoveryspace`s.
-When and how data is shared is covered in detail in [Shared sample stores](../core-concepts/data-sharing.md)
+When and how data is shared is covered in detail in [shared sample stores](../core-concepts/data-sharing.md).
 
 To see the `discoveryspaces` using a given `samplestore` run 
 
@@ -38,7 +37,8 @@ ado show related samplestore $SAMPLE_STORE_IDENTIFIER
  
 ## active and passive Sample Stores
 
-`ado` distinguishes two types of Sample Store: **active** Sample Stores which allow read and write; and **passive** Sample Stores that only have read capabilities.
+`ado` distinguishes two types of Sample Store: **active** Sample Stores which allow read and write; and **passive** Sample Stores that only have read capabilities 
+(for example a CSV file containing measurement data).
 
 All `samplestore` resources created with `ado` will be `**active**. However, they can copy data in from **passive** Sample Stores.
 
@@ -72,7 +72,7 @@ copyFrom: # An array of Sample Stores data will be copied from
 ```
 
 The [Sample Store types](#sample-store-types) section details how to fill the above fields for the different available Sample Store.
-For illustration purposes, this is an example of copying data from a CSV file using `CSVSampleStore`
+Here is an example of copying data from a CSV file using `CSVSampleStore`:
 
 ```yaml
 specification:
@@ -103,12 +103,12 @@ For an existing `discoveryspace` to retrieve all entities that match it run
 ado show entities space $SPACEID --include matching
 ```
 
-You can also define a `discoveryspace` in a YAML and run 
+You can also define a `discoveryspace` in a YAML and run:
 
 ```commandline
 ado show entities space --file $FILE 
 ```
-this allows you to see what entities match a space without having to create it
+This allows you to see what entities match a space without having to create it.
 
 
 ## Sample Store types
@@ -116,9 +116,9 @@ this allows you to see what entities match a space without having to create it
 ### SQLSampleStore
 
 This is an active Sample Store that stores entity data in SQL tables. 
-In `ado` a SQLSampleStore is always associated with a particular project
+In `ado` a SQLSampleStore is always associated with a particular project.
 
-When you want to copy from another SQLSampleStore you need to identifier and the metastore URL to the the project it is in
+When you want to copy from another SQLSampleStore you need the identifier and the metastore URL to the the project it is in
 
 ```yaml
 copyFrom:


### PR DESCRIPTION
Various improvements and updates to the website inc:
- Remove redundant text from install
- Fix example in ray_tune docs
- Add missing section in ray_tune docs on getting output
- Extend getting output section in ray_tune/optimization example
- Only describe "function" type operator specification (using name and type of operator)