### PR TITLE
Remove script dependency from vLLM Performance acutator

### DIFF
--- a/plugins/actuators/vllm_performance/README.md
+++ b/plugins/actuators/vllm_performance/README.md
@@ -6,12 +6,24 @@ The actuator is called `vllm_performance` and features two experiments: `perform
 # Getting Started
 
 This guide has two parts:
-1. [Installing and configuring the actuator](#installing-and-configuring-the-vllm-actuator)
-    - [Installing the actuator](#installation)
+- [Getting Started](#getting-started)
+  - [Installing and configuring the vLLM actuator](#installing-and-configuring-the-vllm-actuator)
+    - [Installation](#installation)
     - [Configuring the actuator](#configuring-the-actuator)
-2. [A Simple Benchmarking Exercise](#a-simple-benchmarking-exercise)
+  - [A Simple Benchmarking Exercise](#a-simple-benchmarking-exercise)
     - [Creating a Discovery Space to describe the vLLM configurations to test](#creating-a-discovery-space-to-describe-the-vllm-configurations-to-test)
+      - [Checking the context](#checking-the-context)
+      - [Creating an sample store, if needed](#creating-an-sample-store-if-needed)
+      - [Defining a Discovery Space of vLLM configurations](#defining-a-discovery-space-of-vllm-configurations)
+      - [Querying the Discovery Space](#querying-the-discovery-space)
     - [Exploring the vLLM workload configuration space](#exploring-the-vllm-workload-configuration-space)
+- [Exploring Further](#exploring-further)
+  - [vLLM testing approach](#vllm-testing-approach)
+  - [The Actuator Package: Key Files](#the-actuator-package-key-files)
+    - [Customising Actuator Configurations](#customising-actuator-configurations)
+    - [Customising Experiment Protocol](#customising-experiment-protocol)
+    - [Notes on the Random walk operation](#notes-on-the-random-walk-operation)
+  - [A few ideas for further exploration](#a-few-ideas-for-further-exploration)
 
 
 After running the exercise, please feel free to [explore further](#exploring-further) and [try a larger experiment](#a-few-ideas-for-further-exploration).
@@ -24,6 +36,7 @@ After running the exercise, please feel free to [explore further](#exploring-fur
 
 ## Installing and configuring the vLLM actuator
 
+<!--
 ### Download the vLLM benchmark
 
 This actuator wraps the official `benchmark_serving` benchmark from vLLM, which you will download in this step from the vLLM repository on GitHub.
@@ -34,7 +47,7 @@ Run the following commands from within the `vllm_performance` directory:
 wget https://github.com/vllm-project/vllm/raw/refs/tags/v0.10.1.1/benchmarks/benchmark_serving.py -O ./ado_actuators/vllm_performance/vllm_performance_test/benchmark_serving.py
 wget https://github.com/vllm-project/vllm/raw/refs/tags/v0.10.1.1/benchmarks/backend_request_func.py -O ./ado_actuators/vllm_performance/vllm_performance_test/backend_request_func.py
 ```
-
+-->
 ### Installation
 Ensure the virtual environment you installed `ado` into is active. Then, in the top-level directory of this actuator (i.e. the directory with this README), run:
    ```commandline

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
@@ -26,6 +26,7 @@ from ado_actuators.vllm_performance.vllm_performance_test.execute_benchmark impo
     execute_benchmark,
 )
 from ray.actor import ActorHandle
+from ray.runtime_env import RuntimeEnv
 
 from orchestrator.modules.actuators.measurement_queue import MeasurementQueue
 from orchestrator.schema.experiment import Experiment, ParameterizedExperiment
@@ -186,7 +187,11 @@ def _create_environment(
     return env.k8_name, error, definition
 
 
-@ray.remote
+vllm_test_runtime_env = RuntimeEnv(
+        pip=["vllm"],
+)
+
+@ray.remote(runtime_env=vllm_test_runtime_env)
 def run_resource_and_workload_experiment(
     request: MeasurementRequest,
     experiment: Union[Experiment, ParameterizedExperiment],

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/execute_benchmark.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/execute_benchmark.py
@@ -57,7 +57,8 @@ def execute_benchmark(
         request = ""
     f_name = f"{uuid.uuid4().hex}.json"
     request += (
-        f"{interpreter} {code} --backend openai --base-url {base_url} --dataset-name {data_set} "
+        #f"{interpreter} {code} --backend openai --base-url {base_url} --dataset-name {data_set} "
+        f"vllm bench serve --backend openai --base-url {base_url} --dataset-name {data_set} "
         f"--model {model} --seed 12345 --num-prompts {num_prompts!s} --save-result --metric-percentiles "
         f'"25,75,99" --percentile-metrics "ttft,tpot,itl,e2el" --result-dir . --result-filename {f_name} '
     )

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/get_benchmark_results.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/get_benchmark_results.py
@@ -20,16 +20,19 @@ def get_results(f_name: str = "random.json") -> dict[str, Any]:
         print(f"Failed to read benchmark result {e}")
         raise Exception(f"Failed to read benchmark result {e}")
     del results["date"]
-    del results["backend"]
+    del results["endpoint_type"]
     del results["tokenizer_id"]
-    del results["best_of"]
-    del results["request_goodput:"]
-    del results["input_lens"]
-    del results["output_lens"]
-    del results["ttfts"]
-    del results["itls"]
-    del results["generated_texts"]
-    del results["errors"]
+    del results["label"]
+    #---- uncomment if directly invoking script
+    #del results["backend"] 
+    #del results["best_of"]
+    #del results["request_goodput:"]
+    #del results["input_lens"]
+    #del results["output_lens"]
+    #del results["ttfts"]
+    #del results["itls"]
+    #del results["generated_texts"]
+    #del results["errors"]
     return results
 
 


### PR DESCRIPTION
Fixes #22 

This change will remove the dependency of fetching `benchmark_serving.py` and `backend_request_func.py` from vLLM repo. 

Introduces a custom runtime environment initialised when executing the performance measurement task. However, this introduces the overhead of creating an environment and doing `pip install` etc. Informally, this will result in an overhead of of upto 5 minutes depending on network conditions, etc