### PR TITLE
feat: allow specifying custom sampler class for use with `random_walk` operator

### DIFF
--- a/examples/ml-multi-cloud/randomwalk_ml_multicloud_operation.yaml
+++ b/examples/ml-multi-cloud/randomwalk_ml_multicloud_operation.yaml
@@ -12,6 +12,7 @@ operation:
   parameters:
     numberEntities: 48
     batchSize: 1
-    mode: 'random'
-    samplerType: 'generator'
     singleMeasurement: True
+    samplerConfig:
+      samplerType: generator
+      mode: random

--- a/examples/pfas-generative-models/operation_random_walk_test.yaml
+++ b/examples/pfas-generative-models/operation_random_walk_test.yaml
@@ -9,4 +9,5 @@ operation:
   parameters:
     numberEntities: 100
     batchSize: 10
-    mode: 'sequential'
+    samplerConfig:
+      mode: sequential

--- a/examples/pfas-generative-models/operation_transformer_benchmark.yaml
+++ b/examples/pfas-generative-models/operation_transformer_benchmark.yaml
@@ -10,4 +10,5 @@ operation:
   parameters:
     numberEntities: 43000
     batchSize: 1000
-    mode: 'sequential'
+  samplerConfig:
+    mode: sequential

--- a/orchestrator/core/discoveryspace/samplers.py
+++ b/orchestrator/core/discoveryspace/samplers.py
@@ -7,6 +7,7 @@ import logging
 import typing
 
 import numpy as np
+import pydantic
 import ray
 
 from orchestrator.core.discoveryspace.space import (
@@ -40,6 +41,12 @@ class WalkModeEnum(enum.Enum):
 class SamplerTypeEnum(enum.Enum):
     SELECTOR = "selector"
     GENERATOR = "generator"
+
+
+class BaseParameters(pydantic.BaseModel):
+
+    mode: WalkModeEnum
+    model_config = pydantic.ConfigDict(extra="forbid")
 
 
 class BaseSampler(abc.ABC):
@@ -82,6 +89,12 @@ class BaseSampler(abc.ABC):
             batchsize: The iterator will return entities in batches of this size
 
         """
+
+    @classmethod
+    def parameters_model(cls) -> type[pydantic.BaseModel] | None:
+        """Returns a pydantic model for the init parameters of the class, if any"""
+
+        return None
 
 
 class GroupSampler(BaseSampler):
@@ -305,6 +318,11 @@ class ExplicitEntitySpaceGridSampleGenerator(BaseSampler):
 
         # noinspection PyUnresolvedReferences
         return cls.samplerCompatibleWithEntitySpace(discoverySpace.entitySpace)
+
+    @classmethod
+    def parameters_model(cls) -> type[pydantic.BaseModel] | None:
+
+        return BaseParameters
 
     def __init__(self, mode: WalkModeEnum):
 

--- a/orchestrator/modules/module.py
+++ b/orchestrator/modules/module.py
@@ -15,6 +15,7 @@ class ModuleTypeEnum(enum.Enum):
     ACTUATOR = "actuator"
     SAMPLE_STORE = "sample_store"
     GENERIC = "generic"
+    SAMPLER = "sampler"
 
 
 class ModuleConf(pydantic.BaseModel):

--- a/orchestrator/modules/operators/randomwalk.py
+++ b/orchestrator/modules/operators/randomwalk.py
@@ -301,7 +301,6 @@ class CustomSamplerConfiguration(pydantic.BaseModel):
     def sampler(self) -> BaseSampler | GroupSampler:
 
         cls = load_module_class_or_function(self.module)
-        print(cls)
         if self.parameters:
             sampler: BaseSampler | GroupSampler = cls(self.parameters)
         else:
@@ -367,10 +366,8 @@ class RandomWalkParameters(pydantic.BaseModel):
     @pydantic.model_validator(mode="before")
     def upgrade_model(cls, parameters: typing.Any):
 
-        print(f"IN BEFORE VALIDATOR: {parameters}")
         if isinstance(parameters, dict) and parameters.get("mode"):
 
-            print(f"UPGRADING PARAMETERS {parameters}")
             from orchestrator.modules.operators.base import (
                 warn_deprecated_operator_parameters_model_in_use,
             )
@@ -383,8 +380,6 @@ class RandomWalkParameters(pydantic.BaseModel):
             )
 
             defaultSamplerConfig = BaseSamplerConfiguration()
-            print(defaultSamplerConfig)
-            print(parameters)
             samplerConfig = BaseSamplerConfiguration(
                 mode=parameters.get("mode", defaultSamplerConfig.mode),
                 grouping=parameters.get("grouping", defaultSamplerConfig.grouping),
@@ -392,14 +387,12 @@ class RandomWalkParameters(pydantic.BaseModel):
                     "samplerType", defaultSamplerConfig.samplerType
                 ),
             )
-            print(samplerConfig)
             parameters = parameters.copy()
             parameters.pop("mode", None)
             parameters.pop("grouping", None)
             parameters.pop("samplerType", None)
             parameters["samplerConfig"] = samplerConfig
 
-        print(f"Returning {parameters}")
         return parameters
 
     @pydantic.field_validator("batchSize")

--- a/plugins/actuators/example_actuator/yamls/random_walk_operation.yaml
+++ b/plugins/actuators/example_actuator/yamls/random_walk_operation.yaml
@@ -10,5 +10,6 @@ operation:
   parameters:
     numberEntities: 10
     batchSize: 2
-    mode: 'sequential'
-    samplerType: 'generator'
+    samplerConfig:
+      mode: 'sequential'
+      samplerType: 'generator'

--- a/plugins/actuators/vllm_performance/yamls/random_walk_operation.yaml
+++ b/plugins/actuators/vllm_performance/yamls/random_walk_operation.yaml
@@ -11,5 +11,6 @@ operation:
   parameters:
     numberEntities: all
     batchSize: 2
-    mode: 'sequential'
-    samplerType: 'generator'
+    samplerConfig:
+      mode: 'sequential'
+      samplerType: 'generator'

--- a/plugins/actuators/vllm_performance/yamls/random_walk_operation_grouped.yaml
+++ b/plugins/actuators/vllm_performance/yamls/random_walk_operation_grouped.yaml
@@ -11,18 +11,19 @@ operation:
   parameters:
     numberEntities: all
     batchSize: 2
-    mode: sequentialgrouped
-    samplerType: generator
     singleMeasurement: false
-    grouping:
-      - model
-      - image
-      - n_gpus
-      - gpu_type
-      - n_cpus
-      - memory
-      - max_batch_tokens
-      - gpu_memory_utilization
-      - dtype
-      - cpu_offload
-      - max_num_seq
+    samplerConfig:
+      mode: 'sequentialgrouped'
+      samplerType: 'generator'
+      grouping:
+        - model
+        - image
+        - n_gpus
+        - gpu_type
+        - n_cpus
+        - memory
+        - max_batch_tokens
+        - gpu_memory_utilization
+        - dtype
+        - cpu_offload
+        - max_num_seq

--- a/website/docs/operators/random-walk.md
+++ b/website/docs/operators/random-walk.md
@@ -65,9 +65,10 @@ The parameters for a RandomWalk are (default values shown):
 ```yaml
 numberEntities: 1 # The maximum number of entities to sample. Can also be the string "all" - see "Sampling all Entities". 
 batchSize: 1  # The Number of entities in the initial batch. For more on this see "Batch Size and Concurrent Experiments" below
-mode: random # How to sample - can be random, sequential, sequentialgrouped or randomgrouped. sequential requires the sampling supports sequencing entities
-samplerType: selector # How to sample entities. Can be selector or generator. For more see Sampling Types and Modes below
-grouping: [] # If the mode sequentialgrouped or randomgrouped this is a list of constitutive properties identifiers to group the entities by
+samplerConfig:
+  mode: random # How to sample - can be random, sequential, sequentialgrouped or randomgrouped. sequential requires the sampling supports sequencing entities
+  samplerType: selector # How to sample entities. Can be selector or generator. For more see Sampling Types and Modes below
+  grouping: [] # If the mode sequentialgrouped or randomgrouped this is a list of constitutive properties identifiers to group the entities by
 singleMeasurement: true # If true memoization is used. If false already measured entities will be re-measured. For more see Multiple Measurement below
 maxRetries: 0 # The number of times to retry a failed measurement on an entity. See Retrying Failed Measurements below. 
 filter: 
@@ -86,9 +87,10 @@ operation:
     operatorType: explore
   parameters:
     batchSize: 1
-    mode: random
+    samplerConfig:
+      mode: random
+      samplerType: selector
     numberEntities: 1
-    samplerType: selector
     singleMeasurement: true
     filter:
         filterMode: unmeasured
@@ -117,7 +119,15 @@ The continuous batching will endeavour to keep this many concurrent experiment r
     Hence continuous batching can only maintain that there are N experiments requested at any time.  
 
 
-### Sampling Types and Modes
+### Base Sampling Types and Modes
+
+The `samplerConfig` field controls how Entities are sampled during the operation.
+The base `samplerConfig` is shown in the examples above and has following fields and defaults
+```yaml
+ mode: random 
+ samplerType: selector 
+ grouping: [] 
+```
 
 #### Sampling Types
 
@@ -197,17 +207,68 @@ operation:
     operatorType: explore
   parameters:
     batchSize: 1
-    grouping:
-      - $CONSTITUTIVE_PROPERTY_ONE
-      - $CONSTITUTIVE_PROPERTY_TWO
-    mode: sequentialgrouped
+    samplerConfig:
+      samplerType: generator
+      grouping:
+        - $CONSTITUTIVE_PROPERTY_ONE
+        - $CONSTITUTIVE_PROPERTY_TWO
+      mode: sequentialgrouped
     numberEntities: 1
-    samplerType: generator
+
     singleMeasurement: true
     filter:
         filterMode: unmeasured
 spaces:
 - your-spaces
+```
+
+### Custom Samplers
+
+It is also possible to specify that `randomw_walk` uses a custom sampler. 
+This is a class that inherits from `orchestrator.core.discovery.samplers.BaseSampler`.
+This is useful for implementing more complex sampling schemes.
+For example, for developers who want to use random_walk to drive an exploration but have custom logic to execute before choosing each sample/entity. 
+
+For custom samplers the `samplerConfig` field has the following structure:
+```yaml
+module:
+  moduleClass: #The name of the custom sampler class
+  moduleName: #The name of the python module containing the sampler
+parameters: # A dictionary of key value pairs with the values for the custom samplers input parameters 
+  ...
+```
+
+#### Implementing a Custom Sampler
+
+To implement a custom sampler create a sub-class of `orchestrator.core.discovery.samplers.BaseSampler` 
+and implement all required methods
+
+The `BaseSampler` class does not specify any `__init__` parameters.
+If your custom class requires initialization parameters then 
+
+- define a pydantic model for them
+- override the `parameters_model` class method to return this model
+- add a non key-word parameter to your custom classes `__init__` that is this type. 
+
+For example: 
+
+```python
+# Class for the custom samplers parameters
+class MySamplerParams(BaseModel): 
+   ...
+
+# Subclass of BaseSampler implementing the custom sampling logic
+class MySampler(BaseSampler):
+
+    @classmethod
+    def parameters_model(cls) -> Optional[Type[BaseModel]]:
+        
+        # Return the custom samplers parameters model
+        return MySamplerParams
+    
+    # Add an init arg to take the parameters model
+    def __init__(self, parameters: MySamplerParams):
+         ...
 ```
 
 ### Sampling all Entities


### PR DESCRIPTION
This PR changes the parameters of `random_walk` in two ways. 

First, it moves the fields `samplerType`, `mode` and `grouping` under a new field called `samplerConfig`.
A new model called `BaseSamplerConfiguration` has been created for this field and an upgrade path provided. 
Logic related to instantiating the sampler class has also been moved to this model.

Second, it adds an additional model `CustomSamplerConfiguration` that can also be given as the value of this field. 
A discriminator has been added to aid identifying the correct model to use. 
The `CustomSamplerConfiguration` can be used to specify a subclass of `BaseSampler` to use along with parameters to it

This PR also makes a small addition to `discoveryspace.samplers.BaseSampler`. 
It adds a new class method "parameters_model" which by default returns `None`.
This can be used by custom samplers to provide a model for their parameters, if required. 
`CustomSamplerConfiguration` then uses this to validate the provided parameters.

Docs have all be updated accordingly

### Example of changes for existing fields (mode, samplerType, grouping)

A parameters model that looked like

```yaml
parameters:
  batchSize: 1
  mode: random
  samplerType: generator
  numberEntities: 1
  singleMeasurement: true
  filter:
      filterMode: unmeasured
```

now is

```yaml
parameters:
  batchSize: 1
  samplerConfig:
    mode: random
    samplerType: generator
  numberEntities: 1
  singleMeasurement: true
  filter:
      filterMode: unmeasured
```

### Example of specifying a custom sampler

ExplicitGridSamplerSelector has been slightly modified to enable it to be used directly via this method.
The above YAML can now also be expressed using: 

```yaml
parameters:
  batchSize: 1
  samplerConfig:
    module: 
      moduleClass: ExplicitGridSampleSelector 
      moduleName: orchestrator.core.discoveryspace.samplers
    parameters:
       mode: random
  numberEntities: 1
  singleMeasurement: true
  filter:
      filterMode: unmeasured
```
