### PR TITLE
fix: Potential access of unset var on Exception

### DIFF
--- a/orchestrator/modules/operators/discovery_space_manager.py
+++ b/orchestrator/modules/operators/discovery_space_manager.py
@@ -232,6 +232,7 @@ class DiscoverySpaceManager:
         monitoringError = False
         self.log.debug("Beginning observation of measurement queue")
         while self.isalive:
+            measurement_request: MeasurementRequest | None = None
             try:
                 self.log.debug("Waiting for new measurement")
                 measurement_request = await self._measurement_queue.get_async(


### PR DESCRIPTION
In DiscoverySpaceManager._monitor_updates_private the try:except block assumed any Exception came from  addMeasurement and tried to log the related measurement_request.

However, it possible an exception can come from measurement_queue.get_async(). In this case, measurement_request may not be set, leading to an Unexpected Exception when the log statement in the except block tries to print it.

This happens if the first measurement_request retrieval results in an exception. If it happened subsequently the log would print the previous request, hiding the error.