### PR TITLE
fix(docs): fix typos 

### DIFF
--- a/website/docs/operators/random-walk.md
+++ b/website/docs/operators/random-walk.md
@@ -273,7 +273,7 @@ spaces:
 ### Custom Samplers
 
 It is also possible to specify that `random_walk` uses a custom sampler. This is
-a class that inherits from `orchestrator.core.discovery.samplers.BaseSampler`.
+a class that inherits from `orchestrator.core.discoveryspace.samplers.BaseSampler`.
 This is useful for implementing more complex sampling schemes. For example, for
 developers who want to use random_walk to drive an exploration but have custom
 logic to execute before choosing each sample/entity.

--- a/website/docs/resources/discovery-spaces.md
+++ b/website/docs/resources/discovery-spaces.md
@@ -217,7 +217,7 @@ propertyDomain: # The domain describes the values the property can take
 ```
 <!-- markdownlint-enable line-length -->
 
-As long as all constitutive properties are not "UNKNOWN_VARAIBLE_TYPE" there is
+As long as all constitutive properties are not "UNKNOWN_VARIABLE_TYPE" there is
 sufficient information to sample new entities from the `entityspace`
 description.
 


### PR DESCRIPTION
Used correct spelling of 'variable' and fixed the class reference for the Base Sampler