### PR TITLE
fix: ensure simulated JSON_CONTAINS works on SQLite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: detect-secrets # pragma: whitelist secret
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.13.2
     hooks:
       - id: ruff
         args:
@@ -16,7 +16,7 @@ repos:
           - website,plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black-jupyter
   - repo: https://github.com/compilerla/conventional-pre-commit
@@ -34,7 +34,7 @@ repos:
       additional_dependencies: ['tomli']
       args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.20
+    rev: 0.8.22
     hooks:
       - id: uv-lock
       - id: uv-export

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -78,16 +78,16 @@ def check_field_in_sqlite_json_document(
     # The user has provided a scalar candidate.
     # There are two options:
     #   1. The path points to an object field (a field in a dictionary)
-    #   2. The path points to an array value (an field in a list)
+    #   2. The path points to an array value (a field in a list)
     #
     ######################################################
     #
     # An example of the path pointing to an object field is:
-    #   ado get operations -q config.operation.module.moduleClass=RayTune
+    #   ado get operations -q config.operation.parameters.batchSize=1
     #
     # Which translates to
-    #   - candidate = RayTune
-    #   - path = $.config.operation.module.moduleClass
+    #   - candidate = batchSize
+    #   - path = $.config.operation.parameter
     #
     # When creating the json_tree we will see that:
     #   - The path points to the root of the json_tree
@@ -95,11 +95,24 @@ def check_field_in_sqlite_json_document(
     #   - The value is the candidate
     #
     # | identifier | key | value | path |
-    # | ------------------------------------------------- | ----------------------------------- | ------- | - |
-    # | raytune-0.9.2.dev11+gff71d082.d20250520-ax-9684fb | config.operation.module.moduleClass | RayTune | $ |
+    # | ------------------------------------------- | ------------------------------------- | - | - |
+    # | randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf | config.operation.parameters.batchSize | 2 | $ |
     #
     # Handling this case requires us to:
     #   - Strip the $. from the path and use it as a key
+    #   - Searching for the value
+    #
+    # AP: 29/09/2025
+    # In some case it looks like this is not necessarily the case
+    # with outputs like:
+    #
+    # | identifier | key | value | path |
+    # | ------------------------------------------- | --------- | - | ----------------------------- |
+    # | randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf | batchSize | 2 | $.config.operation.parameters |
+    #
+    # Handling this case requires us to:
+    #   - Remove the field selector from the path
+    #   - Use the field selector as key
     #   - Searching for the value
     #
     ######################################################
@@ -125,20 +138,23 @@ def check_field_in_sqlite_json_document(
     #
     ######################################################
     #
-    # Given that we cannot know for sure which of the two cases
+    # Given that we cannot know for sure which of the three cases
     # we are in because it would require us to retrieve data from
-    # the database, we must OR the two clauses.
+    # the database, we must OR the three clauses.
+    last_dot_index = path.rfind(".")
     if isinstance(candidate, str):
         return [
             f"{preamble} "
             f"(F.key LIKE '{path[2:]}%' AND F.value = '{candidate}') OR "
-            f"(F.path LIKE '{path}' AND F.value = '{candidate}')"
+            f"(F.path LIKE '{path}' AND F.value = '{candidate}') OR "
+            f"(F.path = '{path[:last_dot_index]}' AND F.key = '{path[last_dot_index+1:]}' AND F.value='{candidate}')"
         ]
     if isinstance(candidate, (int, float)):
         return [
             f"{preamble} "
             f"(F.key LIKE '{path[2:]}%' AND F.value = {candidate}) OR "
-            f"(F.path LIKE '{path}' AND F.value = {candidate})"
+            f"(F.path LIKE '{path}' AND F.value = {candidate}) OR "
+            f"(F.path = '{path[:last_dot_index]}' AND F.key = '{path[last_dot_index+1:]}' AND F.value={candidate})"
         ]
 
     # We have handled an immediate scalar case, so we need to now handle:

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -50,7 +50,7 @@ def simulate_json_contains_on_sqlite(path: str, candidate: str) -> str:
     )
 
 
-def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
+def check_field_in_sqlite_json_document(candidate: dict, path: str) -> list[str]:
     """
     Check if a field exists in a SQLite JSON document.
     This method builds subqueries that, given a "database" F which contains
@@ -59,10 +59,10 @@ def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
         - key
         - value
         - path
-    Check whether the entries are contained in the document.
+    Check whether the candidate are contained in the document.
 
     Parameters:
-    entries (dict): A dictionary representing the JSON document.
+    candidate (dict): A dictionary representing the JSON document.
     path (str): The path to the field to check.
 
     Returns:
@@ -75,7 +75,7 @@ def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
     # The user has provided a scalar candidate.
     # There are two options:
     #   1. The path points to an object field (a field in a dictionary)
-    #   2. The path points to an array value (an entry in a list)
+    #   2. The path points to an array value (an field in a list)
     #
     ######################################################
     #
@@ -83,7 +83,7 @@ def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
     #   ado get operations -q config.operation.module.moduleClass=RayTune
     #
     # Which translates to
-    #   - entries = RayTune
+    #   - candidate = RayTune
     #   - path = $.config.operation.module.moduleClass
     #
     # When creating the json_tree we will see that:
@@ -105,7 +105,7 @@ def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
     #   ado get operation -q 'config.spaces=space-dfdc98-43534b'
     #
     # Which translates to
-    #   - entries = space-dfdc98-43534b
+    #   - candidate = space-dfdc98-43534b
     #   - path = $.config.spaces
     #
     # When creating the json_tree we will see that:
@@ -125,67 +125,69 @@ def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
     # Given that we cannot know for sure which of the two cases
     # we are in because it would require us to retrieve data from
     # the database, we must OR the two clauses.
-    if isinstance(entries, str):
+    if isinstance(candidate, str):
         return [
             f"{preamble} "
-            f"(F.key LIKE '{path[2:]}%' AND F.value = '{entries}') OR "
-            f"(F.path LIKE '{path}' AND F.value = '{entries}')"
+            f"(F.key LIKE '{path[2:]}%' AND F.value = '{candidate}') OR "
+            f"(F.path LIKE '{path}' AND F.value = '{candidate}')"
         ]
-    if isinstance(entries, (int, float)):
+    if isinstance(candidate, (int, float)):
         return [
             f"{preamble} "
-            f"(F.key LIKE '{path[2:]}%' AND F.value = {entries}) OR "
-            f"(F.path LIKE '{path}' AND F.value = {entries})"
+            f"(F.key LIKE '{path[2:]}%' AND F.value = {candidate}) OR "
+            f"(F.path LIKE '{path}' AND F.value = {candidate})"
         ]
 
     # We have handled an immediate scalar case, so we need to now handle:
     #   - Arrays (lists)
     #   - Objects (dictionaries)
     # Both can be iterated, returning either list elements or keys
-    for entry in entries:
+    for field in candidate:
 
         # If the list element or the dictionary key is not a scalar, we need recursion.
         # Example:
         #   - ado get operation -q 'status=[{"event": "finished", "exit_state": "success"}]'
-        if isinstance(entry, (list, dict)):
-            fragments.extend(check_field_in_sqlite_json_document(entry, path))
+        if isinstance(field, (list, dict)):
+            fragments.extend(check_field_in_sqlite_json_document(field, path))
             continue
 
         # When dealing with lists we use recursion to ensure we process
         # their contents.
-        if isinstance(entries, list):
-            fragments.extend(check_field_in_sqlite_json_document(entry, path))
+        if isinstance(candidate, list):
+            fragments.extend(check_field_in_sqlite_json_document(field, path))
             continue
 
         # We now know that:
-        #   - entries is a dictionary
-        #   - entry is a scalar that we can use to index the dictionary
+        #   - candidate is a dictionary
+        #   - field is a scalar that we can use to index the dictionary
         #
-        # We need to check the type of entries[entry]:
+        # We need to check the type of candidate[field]:
         #   - If it's an array or an object, we need to use recursion. We will
         #     also update the path to keep track of the fact that we explored
         #     one field of the object.
         #   - If it's a scalar, we can create a query with all the information
         #     we have available.
-        if isinstance(entries[entry], (list, dict)):
+        if isinstance(candidate[field], (list, dict)):
             # The use of % in the path is because json_tree will add list items in the path.
             # (e.g., $.config.entitySpace[2].propertyDomain). As we can't know for sure
             # whether a field is a list or not, we use the LIKE operator and a wildcard (%)
             fragments.extend(
-                check_field_in_sqlite_json_document(entries[entry], f"{path}%.{entry}")
+                check_field_in_sqlite_json_document(
+                    candidate[field], f"{path}%.{field}"
+                )
             )
             continue
 
         # Here we need the % wildcard because we might be dealing
         # with an array field, for which the path would contain
         # the index.
-        if isinstance(entries[entry], (int, float)):
+        if isinstance(candidate[field], (int, float)):
             fragments.append(
-                f"{preamble} F.path LIKE '{path}%' AND F.key = '{entry}' AND F.value = {entries[entry]}"
+                f"{preamble} F.path LIKE '{path}%' AND F.key = '{field}' AND F.value = {candidate[field]}"
             )
         else:
             fragments.append(
-                f"{preamble} F.path LIKE '{path}%' AND F.key = '{entry}' AND F.value = '{entries[entry]}'"
+                f"{preamble} F.path LIKE '{path}%' AND F.key = '{field}' AND F.value = '{candidate[field]}'"
             )
 
     return fragments

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -103,8 +103,8 @@ def check_field_in_sqlite_json_document(
     #   - Searching for the value
     #
     # AP: 29/09/2025
-    # In some case it looks like this is not necessarily the case
-    # with outputs like:
+    # In some cases it looks like this is not necessarily true.
+    # It can also be:
     #
     # | identifier | key | value | path |
     # | ------------------------------------------- | --------- | - | ----------------------------- |

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -28,12 +28,9 @@ def simulate_json_contains_on_sqlite(path: str, candidate: str) -> str:
     """
 
     # The subqueries produced by check_field_in_sqlite_json_document need to be
-    # part of a JOIN to ensure they are all "AND"-ed (an actual AND is not sufficient
-    # as json_tree returns separate rows).
-    # We also add a progressive D<number> identifier to each subquery to avoid
-    # possible complaints about ambiguous column names.
+    # INTERSECT-ed to make sure we only retrieve the identifiers that match all
+    # the subqueries.
     subqueries = check_field_in_sqlite_json_document(json.loads(candidate), path)
-    subqueries = [f"{s} D{idx}" for idx, s in enumerate(subqueries)]
 
     return (  # noqa: S608 - we don't care about local sql injection
         """
@@ -44,14 +41,12 @@ def simulate_json_contains_on_sqlite(path: str, candidate: str) -> str:
                     resources r,
                     json_tree(r.data, '{path}') jt
             )
-            SELECT
-                D0.identifier
-            FROM {subqueries}
+            {subqueries}
         )
         """
     ).format(
         path=path,
-        subqueries=" JOIN ".join(subqueries),
+        subqueries="\n            INTERSECT ".join(subqueries),
     )
 
 
@@ -75,30 +70,124 @@ def check_field_in_sqlite_json_document(entries: dict, path: str) -> list[str]:
     """
 
     fragments = []
-    preamble = "(SELECT identifier FROM F WHERE "
+    preamble = "SELECT identifier FROM F WHERE "
 
-    # We iterate over all the keys in the dictionary representing our JSON document:
-    #   - If the value for the key is itself a dictionary, we use recursion to go deeper.
-    #   - If the value for the key is a list, we create a subquery for every list item.
-    #   - If the value for the key is a single value, we create a subquery for it.
+    # The user has provided a scalar candidate.
+    # There are two options:
+    #   1. The path points to an object field (a field in a dictionary)
+    #   2. The path points to an array value (an entry in a list)
     #
-    # The use of % in the path is because json_tree will add list items in the path.
-    # (e.g., $.config.entitySpace[2].propertyDomain). As we can't know for sure
-    # whether a field is a list or not, we use the LIKE operator and a wildcard (%)
-    for key in entries:
-        if isinstance(entries[key], dict):
+    ######################################################
+    #
+    # An example of the path pointing to an object field is:
+    #   ado get operations -q config.operation.module.moduleClass=RayTune
+    #
+    # Which translates to
+    #   - entries = RayTune
+    #   - path = $.config.operation.module.moduleClass
+    #
+    # When creating the json_tree we will see that:
+    #   - The path points to the root of the json_tree
+    #   - The key is the path provided
+    #   - The value is the candidate
+    #
+    # | identifier | key | value | path |
+    # | ------------------------------------------------- | ----------------------------------- | ------- | - |
+    # | raytune-0.9.2.dev11+gff71d082.d20250520-ax-9684fb | config.operation.module.moduleClass | RayTune | $ |
+    #
+    # Handling this case requires us to:
+    #   - Strip the $. from the path and use it as a key
+    #   - Searching for the value
+    #
+    ######################################################
+    #
+    # An example of the path pointing to an array value is:
+    #   ado get operation -q 'config.spaces=space-dfdc98-43534b'
+    #
+    # Which translates to
+    #   - entries = space-dfdc98-43534b
+    #   - path = $.config.spaces
+    #
+    # When creating the json_tree we will see that:
+    #   - The path is the one provided by the user
+    #   - The key is the index of the array
+    #   - The value is the candidate
+    #
+    # | identifier | key | value | path |
+    # | ------------------------------------------------- | - | ------------------- | --------------- |
+    # | randomwalk-0.8.3.dev46+g054e2ff6.d20250425-beaef5 | 0 | space-dfdc98-43534b | $.config.spaces |
+    #
+    # Handling this case requires us to not make any assumption
+    # about the key
+    #
+    ######################################################
+    #
+    # Given that we cannot know for sure which of the two cases
+    # we are in because it would require us to retrieve data from
+    # the database, we must OR the two clauses.
+    if isinstance(entries, str):
+        return [
+            f"{preamble} "
+            f"(F.key LIKE '{path[2:]}%' AND F.value = '{entries}') OR "
+            f"(F.path LIKE '{path}' AND F.value = '{entries}')"
+        ]
+    if isinstance(entries, (int, float)):
+        return [
+            f"{preamble} "
+            f"(F.key LIKE '{path[2:]}%' AND F.value = {entries}) OR "
+            f"(F.path LIKE '{path}' AND F.value = {entries})"
+        ]
+
+    # We have handled an immediate scalar case, so we need to now handle:
+    #   - Arrays (lists)
+    #   - Objects (dictionaries)
+    # Both can be iterated, returning either list elements or keys
+    for entry in entries:
+
+        # If the list element or the dictionary key is not a scalar, we need recursion.
+        # Example:
+        #   - ado get operation -q 'status=[{"event": "finished", "exit_state": "success"}]'
+        if isinstance(entry, (list, dict)):
+            fragments.extend(check_field_in_sqlite_json_document(entry, path))
+            continue
+
+        # When dealing with lists we use recursion to ensure we process
+        # their contents.
+        if isinstance(entries, list):
+            fragments.extend(check_field_in_sqlite_json_document(entry, path))
+            continue
+
+        # We now know that:
+        #   - entries is a dictionary
+        #   - entry is a scalar that we can use to index the dictionary
+        #
+        # We need to check the type of entries[entry]:
+        #   - If it's an array or an object, we need to use recursion. We will
+        #     also update the path to keep track of the fact that we explored
+        #     one field of the object.
+        #   - If it's a scalar, we can create a query with all the information
+        #     we have available.
+        if isinstance(entries[entry], (list, dict)):
+            # The use of % in the path is because json_tree will add list items in the path.
+            # (e.g., $.config.entitySpace[2].propertyDomain). As we can't know for sure
+            # whether a field is a list or not, we use the LIKE operator and a wildcard (%)
             fragments.extend(
-                check_field_in_sqlite_json_document(entries[key], f"{path}%.{key}")
+                check_field_in_sqlite_json_document(entries[entry], f"{path}%.{entry}")
             )
-        elif isinstance(entries[key], list):
-            for item in entries[key]:
-                fragments.append(
-                    f"{preamble} F.path LIKE '{path}.{key}' AND F.value = '{item}')"
-                )
+            continue
+
+        # Here we need the % wildcard because we might be dealing
+        # with an array field, for which the path would contain
+        # the index.
+        if isinstance(entries[entry], (int, float)):
+            fragments.append(
+                f"{preamble} F.path LIKE '{path}%' AND F.key = '{entry}' AND F.value = {entries[entry]}"
+            )
         else:
             fragments.append(
-                f"{preamble} F.path LIKE '{path}%' AND F.value = '{entries[key]}')"
+                f"{preamble} F.path LIKE '{path}%' AND F.key = '{entry}' AND F.value = '{entries[entry]}'"
             )
+
     return fragments
 
 

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -50,23 +50,26 @@ def simulate_json_contains_on_sqlite(path: str, candidate: str) -> str:
     )
 
 
-def check_field_in_sqlite_json_document(candidate: dict, path: str) -> list[str]:
+def check_field_in_sqlite_json_document(
+    candidate: dict | list | str | float, path: str
+) -> list[str]:
     """
-    Check if a field exists in a SQLite JSON document.
-    This method builds subqueries that, given a "database" F which contains
-    at least the following keys:
-        - identifier
-        - key
-        - value
-        - path
-    Check whether the candidate are contained in the document.
+    Generate SQLite-compatible SQL fragments to check for the presence of specific fields or values
+    within a JSON document using the json_tree virtual table.
 
-    Parameters:
-    candidate (dict): A dictionary representing the JSON document.
-    path (str): The path to the field to check.
+    This function recursively traverses the input JSON-like structure (dictionary, list, or scalar)
+    and constructs SQL subqueries that can be used to filter rows produced by SQLite's json_tree
+    function based on whether the specified fields and values exist at the given JSON path.
+
+    Args:
+        candidate (dict | list | str | int | float): The JSON structure or scalar value to match against.
+            - If a scalar (str, int, float), generates a simple query checking for value presence.
+            - If a dict or list, recursively builds queries for nested fields and values.
+        path (str): The JSON path (e.g., '$.config.spaces') used to locate the field within the document.
 
     Returns:
-    list[str]: A list of SQL statements to check if the field exists in the document.
+        list[str]: A list of SQL SELECT statements that can be combined via INTERSECT
+        to filter rows whose JSON documents contain the specified structure or values.
     """
 
     fragments = []

--- a/ruff.toml
+++ b/ruff.toml
@@ -84,7 +84,7 @@ select = [
 
 # E501 - line too long (https://docs.astral.sh/ruff/rules/line-too-long/)
 # RUF100 - unused-noqa (https://docs.astral.sh/ruff/rules/unused-noqa/)
-ignore = ["E501", "RUF100", "UP038"]
+ignore = ["E501", "RUF100"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -84,7 +84,7 @@ select = [
 
 # E501 - line too long (https://docs.astral.sh/ruff/rules/line-too-long/)
 # RUF100 - unused-noqa (https://docs.astral.sh/ruff/rules/unused-noqa/)
-ignore = ["E501", "RUF100"]
+ignore = ["E501", "RUF100", "UP038"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -6,9 +6,11 @@ import pathlib
 import sqlite3
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from orchestrator.cli.core.cli import app as ado
+from orchestrator.core import OperationResource
 
 sqlite3_version = sqlite3.sqlite_version_info
 
@@ -52,3 +54,173 @@ def test_get_robotic_lab_actuator():
     if os.environ.get("CI", "false") != "true":
         assert "robotic_lab" in result.output
         assert "peptide_mineralization" in result.output
+
+
+# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
+# ref: https://sqlite.org/json1.html#jptr
+@pytest.mark.skipif(
+    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
+)
+def test_field_querying(
+    tmp_path: pathlib.Path,
+    mysql_test_instance,
+    sql_store,
+    valid_ado_project_context,
+    create_active_ado_context,
+):
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    operation_d5c036 = OperationResource.model_validate(
+        yaml.safe_load(
+            pathlib.Path(
+                "tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml"
+            ).read_text()
+        )
+    )
+    sql_store.addResource(operation_d5c036)
+
+    operation_43dfdf = OperationResource.model_validate(
+        yaml.safe_load(
+            pathlib.Path(
+                "tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml"
+            ).read_text()
+        )
+    )
+    sql_store.addResource(operation_43dfdf)
+
+    # ---------------------------------------------------------
+    # Query scalar int field with int
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            "config.operation.parameters.batchSize=1",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_d5c036.identifier in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query scalar int field with float
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            "config.operation.parameters.batchSize=1.0",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_d5c036.identifier in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query scalar int field with string
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            'config.parameters.batchSize="1"',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_d5c036.identifier not in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query array field with array
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            'status=[{"event": "finished", "exit_state": "success"}]',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_43dfdf.identifier in result.output
+        assert operation_d5c036.identifier in result.output
+
+    # ---------------------------------------------------------
+    # Query array field with scalar
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            "config.spaces=space-7dab39-c0c30f",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_43dfdf.identifier in result.output
+        assert operation_d5c036.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query object field with object with nested array
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            'config={"spaces": ["space-7dab39-c0c30f"]}',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_43dfdf.identifier in result.output
+        assert operation_d5c036.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query object field with nested objects
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            'config.operation.parameters={"batchSize": 2, "samplerConfig": {"mode": "sequential"}}',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_43dfdf.identifier in result.output
+        assert operation_d5c036.identifier not in result.output

--- a/tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml
+++ b/tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) IBM Corporation
+# SPDX-License-Identifier: MIT
+
 config:
   metadata:
     description: Perform a random walk on all points in a space

--- a/tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml
+++ b/tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml
@@ -1,0 +1,36 @@
+config:
+  metadata:
+    description: Perform a random walk on all points in a space
+    name: randomwalk-all
+  operation:
+    parameters:
+      samplerConfig:
+        samplerType: generator
+        mode: random
+      batchSize: 1
+      numberEntities: all
+      singleMeasurement: false
+  spaces:
+  - space-610c82-927db8
+created: '2025-09-08T15:28:03.622683Z'
+identifier: randomwalk-1.0.2.dev17+5e50632.dirty-d5c036
+metadata:
+  entities_submitted: 12
+  experiments_requested: 12
+operationType: search
+operatorIdentifier: randomwalk-1.0.2.dev17+5e50632.dirty
+status:
+- event: created
+  recorded_at: '2025-09-08T15:27:52.405818Z'
+- event: added
+  recorded_at: '2025-09-08T15:28:03.631678Z'
+- event: started
+  recorded_at: '2025-09-08T15:28:03.643462Z'
+- event: updated
+  recorded_at: '2025-09-08T15:28:03.643474Z'
+- event: finished
+  exit_state: success
+  recorded_at: '2025-09-08T15:39:30.202935Z'
+- event: updated
+  recorded_at: '2025-09-08T15:39:30.217895Z'
+

--- a/tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml
+++ b/tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml
@@ -1,0 +1,32 @@
+config:
+  operation:
+    parameters:
+      batchSize: 2
+      numberEntities: 10
+      samplerConfig:
+        mode: sequential
+        samplerType: generator
+  spaces:
+  - space-7dab39-c0c30f
+created: '2025-09-10T15:29:15.223757Z'
+identifier: randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf
+metadata:
+  entities_submitted: 10
+  experiments_requested: 10
+operationType: search
+operatorIdentifier: randomwalk-1.0.2.dev39+7f0c421.dirty
+status:
+- event: created
+  recorded_at: '2025-09-10T15:29:01.854202Z'
+- event: added
+  recorded_at: '2025-09-10T15:29:15.236808Z'
+- event: started
+  recorded_at: '2025-09-10T15:29:15.249270Z'
+- event: updated
+  recorded_at: '2025-09-10T15:29:15.249280Z'
+- event: finished
+  exit_state: success
+  recorded_at: '2025-09-10T15:29:17.699139Z'
+- event: updated
+  recorded_at: '2025-09-10T15:29:17.709570Z'
+

--- a/tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml
+++ b/tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) IBM Corporation
+# SPDX-License-Identifier: MIT
+
 config:
   operation:
     parameters:


### PR DESCRIPTION
## Context

Resolves #64 

## Changes

## 🐛 Bug Fixes
- Replaced incorrect use of `JOIN` with `INTERSECT` in `simulate_json_contains_on_sqlite` to ensure correct filtering of identifiers matching all subqueries.
- Improved SQL fragment generation logic in `check_field_in_sqlite_json_document` to handle scalar values, arrays, and nested objects more robustly.

## ✨ Enhancements
- Refactored `check_field_in_sqlite_json_document` to support recursive traversal of JSON structures and generate SQLite-compatible queries using `json_tree`.
- Added detailed inline documentation explaining the logic for handling object fields, array values, and scalar comparisons in SQLite JSON queries.

## 🧪 Tests
- Added `test_field_querying` to validate querying behavior across various JSON structures:
  - Scalar int field with int, float, and string.
  - Array field with array and scalar.
  - Object field with nested array and nested objects.
- Introduced two new test resource YAML files:
  - `randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml`
  - `randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml`

---

Disclaimer: changelog generated with copilot