### PR TITLE
feat: add support for booleans and null values in sqlite field querying

### DIFF
--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -77,10 +77,10 @@ def check_field_in_sqlite_json_document(
     def _searchable_scalar_value_for_query_string(value: _ScalarType) -> str:
         if isinstance(value, str):
             return f"= '{value}'"
-        if isinstance(value, (int, float)):
-            return f"= {value}"
         if isinstance(value, bool):
             return f"= {json.dumps(value)}"
+        if isinstance(value, (int, float)):
+            return f"= {value}"
         if isinstance(value, NoneType):
             return "IS NULL"
         raise ValueError(f"Unexpected type {type(value)}")

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
+from types import NoneType
 from typing import Literal
 
 import sqlalchemy
@@ -71,6 +72,18 @@ def check_field_in_sqlite_json_document(
         list[str]: A list of SQL SELECT statements that can be combined via INTERSECT
         to filter rows whose JSON documents contain the specified structure or values.
     """
+    _ScalarType = str | int | float | bool | None
+
+    def _searchable_scalar_value_for_query_string(value: _ScalarType) -> str:
+        if isinstance(value, str):
+            return f"= '{value}'"
+        if isinstance(value, (int, float)):
+            return f"= {value}"
+        if isinstance(value, bool):
+            return f"= {json.dumps(value)}"
+        if isinstance(value, NoneType):
+            return "IS NULL"
+        raise ValueError(f"Unexpected type {type(value)}")
 
     fragments = []
     preamble = "SELECT identifier FROM F WHERE "
@@ -142,19 +155,14 @@ def check_field_in_sqlite_json_document(
     # we are in because it would require us to retrieve data from
     # the database, we must OR the three clauses.
     last_dot_index = path.rfind(".")
-    if isinstance(candidate, str):
+    if isinstance(candidate, _ScalarType):
         return [
             f"{preamble} "
-            f"(F.key LIKE '{path[2:]}%' AND F.value = '{candidate}') OR "
-            f"(F.path LIKE '{path}' AND F.value = '{candidate}') OR "
-            f"(F.path = '{path[:last_dot_index]}' AND F.key = '{path[last_dot_index+1:]}' AND F.value='{candidate}')"
-        ]
-    if isinstance(candidate, (int, float)):
-        return [
-            f"{preamble} "
-            f"(F.key LIKE '{path[2:]}%' AND F.value = {candidate}) OR "
-            f"(F.path LIKE '{path}' AND F.value = {candidate}) OR "
-            f"(F.path = '{path[:last_dot_index]}' AND F.key = '{path[last_dot_index+1:]}' AND F.value={candidate})"
+            f"(F.key LIKE '{path[2:]}%' AND F.value {_searchable_scalar_value_for_query_string(candidate)}) OR "
+            f"(F.path LIKE '{path}' AND F.value {_searchable_scalar_value_for_query_string(candidate)}) OR "
+            f"(F.path = '{path[:last_dot_index]}' AND "
+            f"F.key = '{path[last_dot_index+1:]}' AND "
+            f"F.value {_searchable_scalar_value_for_query_string(candidate)})"
         ]
 
     # We have handled an immediate scalar case, so we need to now handle:
@@ -200,13 +208,11 @@ def check_field_in_sqlite_json_document(
         # Here we need the % wildcard because we might be dealing
         # with an array field, for which the path would contain
         # the index.
-        if isinstance(candidate[field], (int, float)):
+        if isinstance(candidate[field], _ScalarType):
             fragments.append(
-                f"{preamble} F.path LIKE '{path}%' AND F.key = '{field}' AND F.value = {candidate[field]}"
-            )
-        else:
-            fragments.append(
-                f"{preamble} F.path LIKE '{path}%' AND F.key = '{field}' AND F.value = '{candidate[field]}'"
+                f"{preamble} F.path LIKE '{path}%' AND "
+                f"F.key = '{field}' AND "
+                f"F.value {_searchable_scalar_value_for_query_string(candidate[field])}"
             )
 
     return fragments

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -67,6 +67,8 @@ def test_field_querying(
     sql_store,
     valid_ado_project_context,
     create_active_ado_context,
+    empty_sample_store,
+    sample_store_resource,
 ):
 
     runner = CliRunner()
@@ -91,6 +93,8 @@ def test_field_querying(
         )
     )
     sql_store.addResource(operation_43dfdf)
+
+    sql_store.addResource(sample_store_resource)
 
     # ---------------------------------------------------------
     # Query scalar int field with int
@@ -142,6 +146,86 @@ def test_field_querying(
             "operations",
             "-q",
             'config.parameters.batchSize="1"',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_d5c036.identifier not in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query scalar null field with null
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "samplestores",
+            "-q",
+            "config.metadata.name=null",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert empty_sample_store.identifier in result.output
+        assert sample_store_resource.identifier not in result.output
+        assert operation_d5c036.identifier not in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query scalar null field with string
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "samplestores",
+            "-q",
+            'config.metadata.name="null"',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert empty_sample_store.identifier not in result.output
+        assert sample_store_resource.identifier not in result.output
+        assert operation_d5c036.identifier not in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query scalar boolean field with boolean
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            "config.operation.parameters.singleMeasurement=false",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert operation_d5c036.identifier in result.output
+        assert operation_43dfdf.identifier not in result.output
+
+    # ---------------------------------------------------------
+    # Query scalar boolean field with string
+    # ---------------------------------------------------------
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-q",
+            'config.parameters.singleMeasurement="false"',
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
## Context

Fixes #81

## Changes

###  🐍 Enhancements

**File:** `orchestrator/metastore/sql/statements.py`

- Introduced `_ScalarType` union type: `str | int | float | bool | None`
- Added helper function `_searchable_scalar_value_for_query_string(value: _ScalarType) -> str` to standardize SQL query formatting for scalar values.
- Refactored logic in `check_field_in_sqlite_json_document`:
  - Unified handling of scalar types (`str`, `int`, `float`, `bool`, `None`) using the new helper function.
  - Removed redundant type-specific SQL generation blocks.
  - Improved readability and maintainability of SQL query construction.

### ✅ Test Coverage Improvements

**File:** `tests/ado/get/test_ado_get.py`

- Extended `test_field_querying` with new test cases:
  - Querying scalar `null` field with `null`
  - Querying scalar `null` field with `"null"` (string)
  - Querying scalar `boolean` field with `false`
  - Querying scalar `boolean` field with `"false"` (string)
- Ensured correct resource filtering behavior across different scalar types.

---

Disclaimer: changelog generated via Copilot