### PR TITLE
chore: disable tqdm progress bars from vllm benchmark output

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/execute_benchmark.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/execute_benchmark.py
@@ -71,7 +71,7 @@ def execute_benchmark(
         f"vllm bench serve --backend openai --base-url {base_url} --dataset-name {data_set} "
         f"--model {model} --seed 12345 --num-prompts {num_prompts!s} --save-result --metric-percentiles "
         f'"25,75,99" --percentile-metrics "ttft,tpot,itl,e2el" --result-dir . --result-filename {f_name} '
-        f"--burstiness {burstiness} "
+        f"--burstiness {burstiness} --disable-tqdm "
     )
 
     if data_set_path is not None:


### PR DESCRIPTION
The vllm benchmarks suite uses tqdm by default, and I feel it generates a lot of clutter in ADOs output that gets also mixed up with the measurements table output. See the below screenshot.

<img width="3460" height="2126" alt="image" src="https://github.com/user-attachments/assets/8c3ded60-45c8-4150-aec2-fa0d8b141094" />


This PR add the `--disable-tqdm` argument to the vllm benchmarks command.