### PR TITLE
build: ensure container images use locked dependencies

### DIFF
--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -11,6 +11,7 @@ COPY --chown=1000:0 ./ ado
 
 ## Install ado
 RUN cd ado && \
+    uv pip install --system -r requirements.txt && \
     uv pip install --system \
     '.'
 

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -20,6 +20,7 @@ COPY --chown=1000:0 ./ ado
 
 ## Install ado
 RUN cd ado && \
+    uv pip install --system -r requirements.txt && \
     uv pip install --system \
     '.'
 ## Install ray-tune operator


### PR DESCRIPTION
## Context

Resolves #141 

## Changes

- Install locked dependencies in dockerfiles
