### PR TITLE
fix(vllm_performance): cap deployment name length and update cli flag

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/k8/yaml_support/build_components.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/k8/yaml_support/build_components.py
@@ -41,7 +41,11 @@ class ComponentsYaml:
         :return: k8 unique name for a given LLM model
         """
         m_parts = model.split("/")
-        return f"vllm-{m_parts[-1].lower()}-{uuid.uuid4().hex}".replace(".", "-")
+
+        # Making sure the resulting name is not longer than 63 characters as it is
+        # the maximum allowed for a name in kubernetes.
+        name_prefix = m_parts[-1][: min(len(m_parts[-1]), 25)].rstrip("-")
+        return f"vllm-{name_prefix.lower()}-{uuid.uuid4().hex}".replace(".", "-")
 
     @staticmethod
     def _adjust_file_name(f: str) -> str:

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/execute_benchmark.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test/execute_benchmark.py
@@ -79,7 +79,7 @@ def execute_benchmark(
     if request_rate is not None:
         request += f"--request-rate {request_rate!s} "
     if max_concurrency is not None:
-        request += f"--max-concurrency {max_concurrency!s}"
+        request += f"--max-concurrency {max_concurrency!s} "
     if custom_args is not None:
         for key, value in custom_args.items():
             request += f"{key} {value!s} "


### PR DESCRIPTION
This PR adds:
- Guarantee the length of the vllm deployment name does not exceed 63 characters.
- Added a missing space in the vllm benchmark cli