### PR TITLE
fix(ado-core): Enable decorated experiments with ray.remote

### DIFF
--- a/orchestrator/modules/actuators/custom_experiments.py
+++ b/orchestrator/modules/actuators/custom_experiments.py
@@ -335,6 +335,19 @@ def custom_experiment(
 
             return observed_property_values
 
+        # Set the wrapper's __signature__  so it is (entity,experiment)
+        # This is required for the wrapped function to be used with ray.remote
+        import inspect
+
+        wrapper.__signature__ = inspect.Signature(
+            [
+                inspect.Parameter("entity", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                inspect.Parameter(
+                    "experiment", inspect.Parameter.POSITIONAL_OR_KEYWORD
+                ),
+            ]
+        )
+
         # If we were not given information on required/optional properties
         # or parameterization try to infer it
         # This function will log a critical error message and raise exception


### PR DESCRIPTION
Need to change the signature of the wrapper.

By default functool.wraps assigns the signature of the wrapped function to the signature metadata of the wrapper, even if the wrapper has different parameters.

ray uses this metadata when it wraps a function (ray.remote) - to determine serialisation etc. Hence if the wrapper changed parameters of the function, it will not work with ray out-of-the-box. 