### PR TITLE
fix(vllm_performance): k8s resource not marked for cleaning on exception

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
@@ -323,6 +323,8 @@ def run_resource_and_workload_experiment(
     # For every entity
     for entity in request.entities:
 
+        port_forward = None
+        definition = None
         try:
             values = experiment.propertyValuesFromEntity(entity=entity)
 
@@ -368,9 +370,7 @@ def run_resource_and_workload_experiment(
             )
 
             logger.debug(f"benchmark executed in {time.time() - start} sec")
-            if port_forward is not None:
-                port_forward.kill()
-            env_manager.done_using.remote(definition=definition)
+
         except (
             K8EnvironmentCreationError,
             K8ConnectionError,
@@ -407,6 +407,11 @@ def run_resource_and_workload_experiment(
                     reference=request.experimentReference,
                 )
             )
+        finally:
+            if port_forward is not None:
+                port_forward.kill()
+            if definition is not None:
+                env_manager.done_using.remote(definition=definition)
 
     # For multi entity experiments if ONE entity had ValidResults the status must be SUCCESS
     if len(measurements) > 0:


### PR DESCRIPTION
If there was an exception in port_foward creation or benchmark:
- the port-forward was not cleaned up
- done_using is not called on the environment

This is because the clean-up code required a successful benchmark to execute and was not in a `finally:` block.

The impact of this would be the inability of the actuator to run an experiment (continued attempts to run same entity that cannot succeed) if
* max_environments environments had been created
* there was at least one exception among the entities processed by each environment
* an entity needed an new environment.

Neither of the existing environments would be "reaped" as the entities with the exceptions never decremented the in use counter (so it could never reach zero).

The entity requiring the new environment would find all "max_environment" environments always in_use, looping forever waiting for them to be free - the corresponding ado operation would appear to hang. 