### PR TITLE
fix(custom_experiments): detect if custom experiment returns unexpected properties

### DIFF
--- a/orchestrator/modules/actuators/custom_experiments.py
+++ b/orchestrator/modules/actuators/custom_experiments.py
@@ -328,6 +328,12 @@ def custom_experiment(
                 observed_property = experiment.observedPropertyForTargetIdentifier(
                     property_identifier
                 )
+                if not observed_property:
+                    raise ValueError(
+                        f"{experiment.identifier} returned a property called {property_identifier}, however "
+                        f"the experiment definition does not define an output property with this name"
+                    )
+
                 observed_property_value = ObservedPropertyValue(
                     property=observed_property, value=value
                 )


### PR DESCRIPTION
The custom_experiment decorator defines output names. These names must be keys in the dict returned by the function.

There was no check if when executing the function if the names matched - this would lead to a error which was handled but the error description did not describe the source of the issue.