### PR TITLE
fix(core): show entities missing/unmeasured

### DIFF
--- a/orchestrator/cli/resources/discovery_space/show_entities.py
+++ b/orchestrator/cli/resources/discovery_space/show_entities.py
@@ -29,7 +29,6 @@ from orchestrator.core.discoveryspace.config import DiscoverySpaceConfiguration
 from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.core.resources import CoreResourceKinds
 from orchestrator.metastore.base import ResourceDoesNotExistError
-from orchestrator.schema.property import ConstitutiveProperty
 
 if typing.TYPE_CHECKING:
     from orchestrator.schema.entity import Entity
@@ -237,11 +236,7 @@ def entities_to_dataframe(
     if constitutive_properties_only:
         return pd.DataFrame(
             [
-                {
-                    p.property.identifier: p.value
-                    for p in e.propertyValues
-                    if isinstance(p.property, ConstitutiveProperty)
-                }
+                {p.property.identifier: p.value for p in e.constitutive_property_values}
                 for e in entities
             ]
         )


### PR DESCRIPTION
`ado show entities --include missing` and `ado show entities --include unmeasured` were both broken always returning that there were no entities missing or unmeasured.

Due to filtering on ConstitutiveProperty type when that type is not the type of the field since intro of ConstitutivePropertyDescriptor.

Use consitutive_property_values to avoid having to filter.