### PR TITLE
docs(test): Add --reinstall flag to uv sync command

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,11 +6,12 @@ i.e. the top directory of the `ado` repo.
 We recommend using `uv sync` to install all test requirements:
 
 ```commandline
-uv sync --group test
+uv sync --group test --reinstall
 ```
 
 Note: This will also remove all packages not required for testing and sync
 all package versions to the lockfile.
+Local packages will be rebuilt.
 
 To execute all tests run:
 


### PR DESCRIPTION
Without `--reinstall`, `uv sync` will use existing wheels it finds for workspace members. This behaviour is not what you want for testing e.g.
- Use "uv sync --group test" to create a brand new environment
- Switch branches
- Use "uv sync --group test" to update the venv to new branch and test -> does not work as expected. Packages from previous branch will be used.

The only solution is `--reinstall` which forces a rebuild of the local workspace members.