### PR TITLE
feat(core): handle errors per custom_experiment

### DIFF
--- a/orchestrator/modules/actuators/custom_experiments.py
+++ b/orchestrator/modules/actuators/custom_experiments.py
@@ -498,28 +498,23 @@ def load_custom_experiments_from_entry_points():
     This function searches for entry points under 'ado.custom_experiments' and loads
     any decorated functions from those modules.
     """
-    try:
-        import importlib
-        import importlib.metadata
 
-        # Get all entry points for ado.custom_experiments
-        entry_points = importlib.metadata.entry_points()
-        custom_experiment_groups = entry_points.select(group="ado.custom_experiments")
-        for entry_point in custom_experiment_groups:
-            try:
-                entry_point.load()
-            except ImportError as error:
-                logging.getLogger("load_custom_experiments").warning(
-                    f"Unable to import custom experiments from {entry_point.value}: {error}"
-                )
-            except ValueError as error:
-                logging.getLogger("load_custom_experiments").warning(
-                    f"Error when creating custom experiments defined in {entry_point.value}: {error}"
-                )
-    except ImportError as error:
-        logging.getLogger("load_custom_experiments").warning(
-            f"Unexpected error getting custom experiments: {error}"
-        )
+    import importlib.metadata
+
+    # Get all entry points for ado.custom_experiments
+    entry_points = importlib.metadata.entry_points()
+    custom_experiment_groups = entry_points.select(group="ado.custom_experiments")
+    for entry_point in custom_experiment_groups:
+        try:
+            entry_point.load()
+        except ImportError as error:
+            logging.getLogger("load_custom_experiments").warning(
+                f"Unable to import custom experiments from {entry_point.value}: {error}"
+            )
+        except ValueError as error:
+            logging.getLogger("load_custom_experiments").warning(
+                f"Error when creating custom experiments defined in {entry_point.value}: {error}"
+            )
 
 
 def get_custom_experiments_catalog() -> (


### PR DESCRIPTION
Fixes: #280 and #279

If there is an error with loading a module with custom experiments a log will be output with the experiment, module and reason e.g. 

```
(ado-core) michaelj@Michaels-MacBook-Pro-2 yamls % ado get actuators custom_experiments --details        
WARN:   These functionalities are global, and not context-aware
WARN:   This a local command. It will not reflect the actuators on a remote cluster.
2025-12-15 13:12:23,791 WARNING   MainThread           load_custom_experiments: load_custom_experiments_from_entry_points: Error when creating custom experiments defined 
in optimization_test_functions.optimization_test_functions: Unable to generate custom experiment for nevergrad_opt_3d_test_func via decorator.
        nevergrad_opt_3d_test_func parameter names {'num_blocks', 'x', 'name', 'x2', 'x1'} must include all property identifiers {'num_blocks', 'x0', 'x2', 'x1', 'name'}.
Missing identifiers: {'x0'}
          ACTUATOR ID         CATALOG ID        EXPERIMENT ID  SUPPORTED
0  custom_experiments  CustomExperiments            acid_test       True
1  custom_experiments  CustomExperiments    calculate_density       True
2  custom_experiments  CustomExperiments  min_gpu_recommender       True
```