### PR TITLE
build(containers): support building on multiple Python and CUDA versions

### DIFF
--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -1,5 +1,6 @@
-ARG base_image=mirror.gcr.io/rayproject/ray:latest-py310-cpu
-FROM $base_image
+ARG PYTHON_VERSION=310
+ARG BASE_IMAGE=mirror.gcr.io/rayproject/ray:latest-py${PYTHON_VERSION}-cpu
+FROM $BASE_IMAGE
 
 USER 0
 RUN chgrp -R 0 /home/ray && \

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,5 +1,7 @@
-ARG base_image=mirror.gcr.io/rayproject/ray:latest-py310-cu121
-FROM $base_image
+ARG PYTHON_VERSION=310
+ARG CUDA_VERSION=cu121
+ARG BASE_IMAGE=mirror.gcr.io/rayproject/ray:latest-py${PYTHON_VERSION}-${CUDA_VERSION}
+FROM $BASE_IMAGE
 
 # AP 19/05/2025:
 # CUDA_HOME is not set in the image and is required
@@ -23,6 +25,7 @@ RUN cd ado && \
     uv pip install --system -r requirements.txt && \
     uv pip install --system \
     '.'
+
 ## Install ray-tune operator
 RUN cd ado && \
     uv pip install --system \

--- a/Dockerfile-ofed
+++ b/Dockerfile-ofed
@@ -1,5 +1,7 @@
-ARG base_image=quay.io/ado/ado:latest-py310-cu121
-FROM $base_image
+ARG PYTHON_VERSION=310
+ARG CUDA_VERSION=cu121
+ARG BASE_IMAGE=quay.io/ado/ado:latest-py${PYTHON_VERSION}-${CUDA_VERSION}
+FROM $BASE_IMAGE
 
 # VV: Install MOFED from https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/
 USER 0


### PR DESCRIPTION
## Changes

This PR adds support for building container images on multiple Python versions (3.10, 3.11, 3.12 at the moment) and CUDA versions (121, 123, 124, 125, 127, 128, 129 at the moment).

> [!IMPORTANT]
> There will be changes to the tags that are produced as part of the CI builds for branches to better track when an image was built

By default, container images tags will now be:

```
${BRANCH_NAME}-${DATE}-${GIT_COMMIT}-${IMAGE_TYPE}-py${IMAGE_PYTHON_VERSION}-${IMAGE_CUDA_VERSION}-${IMAGE_OFED_VERSION}
```

Examples:

- `main_20251216_1b6deecb4216370850ce319564a088ff53b6887a_cpu_py312`
- `main_20251216_1b6deecb4216370850ce319564a088ff53b6887a_gpu_py312_cu121`
- `main_20251216_1b6deecb4216370850ce319564a088ff53b6887a_ofed_py312_cu121_ofed2410v1140`

The signed image will also be copied over with the following tags:

```
${BRANCH_NAME}-${IMAGE_TYPE}-py${IMAGE_PYTHON_VERSION}-${IMAGE_CUDA_VERSION}-${IMAGE_OFED_VERSION}
```

Examples:

- `main_cpu_py312`
- `main_gpu_py312_cu121`
- `main_ofed_py312_cu121_ofed2410v1140`

For tagged versions, the following tags will also be applied:

```
latest-${IMAGE_TYPE}-py${IMAGE_PYTHON_VERSION}-${IMAGE_CUDA_VERSION}-${IMAGE_OFED_VERSION}
```

(and just `latest` for cpu as well)

- `latest`
- `latest_cpu_py312`
- `latest_gpu_py312_cu121`
- `latest_ofed_py312_cu121_ofed2410v1140`

## Summing up

Considering:
- Python 312
- CUDA 121
- OFED ofed2410v1140

### Image tags for branch build

- `main_20251216_1b6deecb4216370850ce319564a088ff53b6887a_cpu_py312`
- `main_20251216_1b6deecb4216370850ce319564a088ff53b6887a_gpu_py312_cu121`
- `main_20251216_1b6deecb4216370850ce319564a088ff53b6887a_ofed_py312_cu121_ofed2410v1140`
- `main_cpu_py312`
- `main_gpu_py312_cu121`
- `main_ofed_py312_cu121_ofed2410v1140`

### Image tags for tag build

Example tag: 1.3.2

- `1.3.2_20251216_1b6deecb4216370850ce319564a088ff53b6887a_cpu_py312`
- `1.3.2_20251216_1b6deecb4216370850ce319564a088ff53b6887a_gpu_py312_cu121`
- `1.3.2_20251216_1b6deecb4216370850ce319564a088ff53b6887a_ofed_py312_cu121_ofed2410v1140`
- `1.3.2_cpu_py312`
- `1.3.2_gpu_py312_cu121`
- `1.3.2_ofed_py312_cu121_ofed2410v1140`
- `latest`
- `latest_cpu_py312`
- `latest_gpu_py312_cu121`
- `latest_ofed_py312_cu121_ofed2410v1140`
