### PR TITLE
fix(run_experiment): print request series with use_markup=False

### DIFF
--- a/orchestrator/utilities/run_experiment.py
+++ b/orchestrator/utilities/run_experiment.py
@@ -273,7 +273,8 @@ def run(
                 else:
                     console_print("Result:")
                     console_print(
-                        f"{request.series_representation(output_format='target')}\n"
+                        f"{request.series_representation(output_format='target')}\n",
+                        use_markup=False,
                     )
             else:
                 console_print(f"{ERROR}Entity is not valid")


### PR DESCRIPTION
console_print interprets [] as markup tags so if use_markup=True (the default) passing string representations of lists causes list content to be dropped (as rich tries to interpret what is within the [] as markup and find it invalid). 

Solution adopted here is to set use_markup=False when printing string representations of request series. Another option is to pass the python object to console_print. However the resulting print has a preceding tab inserted which looks strange. 