### PR TITLE
docs(website): fix typo in "Target v observed property formats"

### DIFF
--- a/website/docs/resources/discovery-spaces.md
+++ b/website/docs/resources/discovery-spaces.md
@@ -176,7 +176,7 @@ table = space.measuredEntitiesTable()
 table = space.matchingEntitiesTable()
 ```
 
-## Target v observed property formats
+## Target vs observed property formats
 
 There are two formats the entities can be output controlled by the
 `--property-format` option to `show entities`


### PR DESCRIPTION
"Target v observed property formats" to "Target vs observed property formats"