### PR TITLE
refactor: rewrite ProbabilityFunction.__eq__

### DIFF
--- a/orchestrator/schema/domain.py
+++ b/orchestrator/schema/domain.py
@@ -275,11 +275,8 @@ class ProbabilityFunction(pydantic.BaseModel):
             return not other.parameters
 
         # This instance has parameters. The other instance should
-        # have the same amount of parameters, and the parameters
-        # should be of the same value
-        if not other.parameters or len(self.parameters.keys()) != len(
-            other.parameters.keys()
-        ):
+        # have the same parameter keys and values
+        if not other.parameters or self.parameters.keys() != other.parameters.keys():
             logging.debug(
                 f"The other probability function has a different number of parameters: {self.parameters, other.parameters}"
             )


### PR DESCRIPTION
## Context

MyPy was reporting the following issues:

```
orchestrator/schema/domain.py:258: error: Argument 1 of "__eq__" is incompatible with supertype "builtins.object"; supertype defines the argument type as "object"  [override]
orchestrator/schema/domain.py:258: note: This violates the Liskov substitution principle
orchestrator/schema/domain.py:258: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
orchestrator/schema/domain.py:258: note: It is recommended for "__eq__" to work with arbitrary objects, for example:
orchestrator/schema/domain.py:258: note:     def __eq__(self, other: object) -> bool:
orchestrator/schema/domain.py:258: note:         if not isinstance(other, ProbabilityFunction):
orchestrator/schema/domain.py:258: note:             return NotImplemented
orchestrator/schema/domain.py:258: note:         return <logic to compare two ProbabilityFunction instances>
orchestrator/schema/domain.py:268: error: Item "None" of "dict[Any, Any] | None" has no attribute "keys"  [union-attr]
orchestrator/schema/domain.py:275: error: Value of type "dict[Any, Any] | None" is not indexable  [index]
orchestrator/schema/domain.py:276: error: Value of type "dict[Any, Any] | None" is not indexable  [index]
```

This was because:
1. The signature had `ProbabilityFunction` instead of `object`
2. The `parameters` field is of type `dict | None = pydantic.Field(default=None)` (should None even be allowed/the default?)
3. There was no check whether `other.parameters` was None

Additionally, the code made use of assertions, which are not executed in optimized mode.