### PR TITLE
refactor: rewrite PropertyDescriptor.__eq__

### DIFF
--- a/orchestrator/schema/property.py
+++ b/orchestrator/schema/property.py
@@ -54,10 +54,10 @@ class PropertyDescriptor(pydantic.BaseModel):
 
         Metadata is not included"""
 
-        if not isinstance(other, (Property, PropertyDescriptor)):
-            return False
-
-        return hasattr(other, "identifier") and self.identifier == other.identifier
+        return (
+            isinstance(other, (Property, PropertyDescriptor))
+            and self.identifier == other.identifier
+        )
 
     def _repr_pretty_(self, p, cycle=False):
 


### PR DESCRIPTION
## Context

Fixes MyPy error:

> orchestrator/schema/property.py:50: error: Argument 1 of "__eq__" is incompatible with supertype "builtins.object"; supertype defines the argument type as "object"  [override]
> orchestrator/schema/property.py:50: note: This violates the Liskov substitution principle
> orchestrator/schema/property.py:50: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
> orchestrator/schema/property.py:50: note: It is recommended for "__eq__" to work with arbitrary objects, for example:
> orchestrator/schema/property.py:50: note:     def __eq__(self, other: object) -> bool:
> orchestrator/schema/property.py:50: note:         if not isinstance(other, PropertyDescriptor):
> orchestrator/schema/property.py:50: note:             return NotImplemented
> orchestrator/schema/property.py:50: note:         return <logic to compare two PropertyDescriptor instances>
