### PR TITLE
refactor(samplestores): disallow None parameters

### DIFF
--- a/orchestrator/core/samplestore/base.py
+++ b/orchestrator/core/samplestore/base.py
@@ -114,7 +114,7 @@ class SampleStore(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def validate_parameters(parameters=None) -> typing.Any:  # pragma: nocover
+    def validate_parameters(parameters: dict) -> typing.Any:  # pragma: nocover
         """
         Validates the parameters to be passed to the class
         according to the concrete class's logic.

--- a/orchestrator/core/samplestore/config.py
+++ b/orchestrator/core/samplestore/config.py
@@ -27,8 +27,8 @@ class SampleStoreSpecification(pydantic.BaseModel):
     module: SampleStoreModuleConf = pydantic.Field(
         description="The SampleStore module and class to use",
     )
-    parameters: typing.Any = pydantic.Field(
-        default={},
+    parameters: dict = pydantic.Field(
+        default_factory=dict,
         description="SampleStore specific parameters that configure its behaviour ",
     )
 

--- a/orchestrator/core/samplestore/csv.py
+++ b/orchestrator/core/samplestore/csv.py
@@ -78,11 +78,7 @@ class CSVSampleStore(PassiveSampleStore):
     """
 
     @staticmethod
-    def validate_parameters(parameters=None):
-        # AP: parameters are used to instantiate a CSVSampleStoreDescription
-        if parameters is None:
-            raise ValueError("parameters cannot be None for CSVSampleStore")
-
+    def validate_parameters(parameters: dict):
         return CSVSampleStoreDescription.model_validate(parameters)
 
     @staticmethod

--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -278,7 +278,7 @@ class SQLSampleStore(ActiveSampleStore):
         self,
         identifier: str | None,
         storageLocation: orchestrator.utilities.location.SQLStoreConfiguration,
-        parameters: dict | None,
+        parameters: dict,
     ) -> None:
 
         import uuid
@@ -692,7 +692,7 @@ class SQLSampleStore(ActiveSampleStore):
         ) + f"/{self._tablename}"
 
     @staticmethod
-    def validate_parameters(parameters=None):
+    def validate_parameters(parameters: dict):
 
         # No parameters to validate
         return parameters

--- a/orchestrator/plugins/samplestores/gt4sd.py
+++ b/orchestrator/plugins/samplestores/gt4sd.py
@@ -12,9 +12,8 @@ from orchestrator.core.samplestore.csv import (
 )
 
 
-def fill_gt4sd_transformer_csv_parameters(parameters: dict | None) -> dict:
+def fill_gt4sd_transformer_csv_parameters(parameters: dict) -> dict:
 
-    parameters = {} if parameters is None else parameters
     experimentDescription = ExperimentDescription(
         experimentIdentifier="transformer-toxicity-inference-experiment",
         propertyMap=GT4SDTransformer.propertyMap,
@@ -43,12 +42,8 @@ class GT4SDTransformer(CSVSampleStore):
 
     @staticmethod
     def validate_parameters(
-        parameters: dict | None = None,
+        parameters: dict,
     ) -> CSVSampleStoreDescription:
-        # AP: parameters are used to instantiate a CSVSampleStoreDescription
-        if parameters is None:
-            raise ValueError("parameters cannot be None for GT4SDTransformer")
-
         parameters = fill_gt4sd_transformer_csv_parameters(parameters)
         log = logging.getLogger("GT4SDTransformerSampleStore")
         log.debug(

--- a/orchestrator/plugins/samplestores/hopv.py
+++ b/orchestrator/plugins/samplestores/hopv.py
@@ -15,10 +15,9 @@ class HOPV(CSVSampleStore):
 
     @staticmethod
     def validate_parameters(
-        parameters: dict | None = None,
+        parameters: dict,
     ) -> CSVSampleStoreDescription:
 
-        parameters = {} if parameters is None else parameters
         properties = ["homo", "lumo", "pce", "voc", "jsc"]
 
         insilico = ExperimentDescription(


### PR DESCRIPTION
We required them to not be None everywhere and especially for SQL store we really need them to not be None