### PR TITLE
fix(modules): use correct type annotations for closures

### DIFF
--- a/orchestrator/modules/operators/_explore_orchestration.py
+++ b/orchestrator/modules/operators/_explore_orchestration.py
@@ -156,7 +156,8 @@ def run_explore_operation_core_closure(
             operation_future=future,
         )
 
-        return ray.get(future)  # type: OperationOutput
+        operation_output: OperationOutput = ray.get(future)
+        return operation_output
 
     return _run_explore_operation_core
 

--- a/orchestrator/modules/operators/_general_orchestration.py
+++ b/orchestrator/modules/operators/_general_orchestration.py
@@ -39,10 +39,10 @@ def run_general_operation_core_closure(
     operation_parameters: dict,
 ) -> typing.Callable[[], OperationOutput | None]:
 
-    def _run_general_operation_core() -> OperationOutput:
+    def _run_general_operation_core() -> OperationOutput | None:
         return operation_function(
             discovery_space, operationInfo, **operation_parameters
-        )  # type: OperationOutput | None
+        )
 
     return _run_general_operation_core
 


### PR DESCRIPTION
## Changes

- Moves comment-based type annotations as they were preventing mypy from running
- Fix one wrong type annotation