### PR TITLE
perf(core): reuse engine for sql resource and sample stores

### DIFF
--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -341,6 +341,18 @@ class SQLSampleStore(ActiveSampleStore):
 
         self.log.debug(f"SQLSampleStore id {self.uri}")
 
+    # The SQLAlchemy Engine is not picklable, so anything using
+    # Ray would fail. To avoid this, we remove it before pickling
+    # and create a new instance when unpickling.
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        del state["_engine"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._engine = engine_for_sql_store(self._configuration)
+
     @property
     def engine(self) -> sqlalchemy.Engine:
         return self._engine

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -105,6 +105,18 @@ class SQLResourceStore(ResourceStore):
 
         super().__init__()
 
+    # The SQLAlchemy Engine is not picklable, so anything using
+    # Ray would fail. To avoid this, we remove it before pickling
+    # and create a new instance when unpickling.
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        del state["_engine"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._engine = engine_for_sql_store(self.configuration)
+
     @property
     def engine(self) -> sqlalchemy.Engine:
         return self._engine


### PR DESCRIPTION
## Context

I had Bob create the following benchmark script.

<details>
<summary>Benchmark script fetching all spaces, all operations, the latest operation, all datacontainers</summary>

```python
#!/usr/bin/env python3
# Copyright (c) IBM Corporation
# SPDX-License-Identifier: MIT

"""
Benchmark script for SQL Resource Store operations.

This script measures the execution time of various database operations
including fetching spaces, datastores, operations, and datacontainers.
"""

import sys
import timeit
from collections.abc import Callable
from pathlib import Path

from orchestrator.cli.core.config import AdoConfiguration

# Add the project root to the path if needed
project_root = Path(__file__).parent
if str(project_root) not in sys.path:
    sys.path.insert(0, str(project_root))

from orchestrator.core.resources import CoreResourceKinds
from orchestrator.metastore.project import ProjectContext
from orchestrator.metastore.sqlstore import SQLResourceStore, SQLStore


class BenchmarkResult:
    """Store benchmark results for a single operation."""

    def __init__(
        self,
        operation_name: str,
        execution_time_ms: float,
        success: bool = True,
        error: str = "",
    ):
        self.operation_name = operation_name
        self.execution_time_ms = execution_time_ms
        self.success = success
        self.error = error


class SQLStoreBenchmark:
    """Benchmark suite for SQL Resource Store operations."""

    def __init__(self, project_context: ProjectContext):
        """
        Initialize the benchmark suite.

        Args:
            project_context: ProjectContext for database connection
        """
        self.project_context = project_context
        self.store: SQLResourceStore | None = None
        self.results: list[BenchmarkResult] = []

    def setup(self):
        """Initialize the SQL store connection."""
        try:
            print("Setting up SQL Resource Store connection...")
            # SQLStore.__new__ returns SQLResourceStore, so this is safe despite type checker warning
            self.store = SQLStore(project_context=self.project_context)  # type: ignore
            print(
                f"✓ Connected to database: {self.project_context.metadataStore.database}"
            )
            print()
        except Exception as e:
            print(f"✗ Failed to connect to database: {e}")
            raise

    def teardown(self):
        """Clean up database connection."""
        try:
            if self.store and hasattr(self.store, "engine"):
                self.store.engine.dispose()
            print("\n✓ Database connection closed")
        except Exception as e:
            print(f"\n✗ Error during teardown: {e}")

    def benchmark_operation(
        self, operation_name: str, operation_func: Callable, number: int = 10
    ) -> BenchmarkResult:
        """
        Benchmark a single operation.

        Args:
            operation_name: Name of the operation being benchmarked
            operation_func: Function to benchmark
            number: Number of times to execute the operation

        Returns:
            BenchmarkResult object with timing information
        """
        try:
            # Measure execution time
            execution_time = timeit.timeit(operation_func, number=number)
            execution_time_ms = (execution_time / number) * 1000

            result = BenchmarkResult(
                operation_name=operation_name,
                execution_time_ms=execution_time_ms,
                success=True,
            )

        except Exception as e:
            import traceback

            error_details = f"{type(e).__name__}: {e!s}\n{traceback.format_exc()}"
            result = BenchmarkResult(
                operation_name=operation_name,
                execution_time_ms=0.0,
                success=False,
                error=error_details,
            )

        self.results.append(result)
        return result

    def fetch_all_spaces(self):
        """Fetch all discovery spaces from the database."""
        if self.store is None:
            raise RuntimeError("Store not initialized")
        return self.store.getResourcesOfKind(
            kind=CoreResourceKinds.DISCOVERYSPACE.value
        )

    def fetch_all_datastores(self):
        """Fetch all sample stores (datastores) from the database."""
        if self.store is None:
            raise RuntimeError("Store not initialized")
        return self.store.getResourcesOfKind(kind=CoreResourceKinds.SAMPLESTORE.value)

    def fetch_all_operations(self):
        """Fetch all operations from the database."""
        if self.store is None:
            raise RuntimeError("Store not initialized")
        return self.store.getResourcesOfKind(kind=CoreResourceKinds.OPERATION.value)

    def fetch_latest_operation(self):
        """Fetch the latest operation from the database."""
        if self.store is None:
            raise RuntimeError("Store not initialized")
        # Get all operations and return the most recent one
        operations = self.store.getResourceIdentifiersOfKind(
            kind=CoreResourceKinds.OPERATION.value
        )
        if not operations.empty:
            # Sort by AGE (most recent first) and get the first one
            # Column names are uppercase in the dataframe
            latest_id = operations.sort_values("AGE").iloc[0]["IDENTIFIER"]
            return self.store.getResource(
                identifier=latest_id, kind=CoreResourceKinds.OPERATION
            )
        return None

    def fetch_all_datacontainers(self):
        """Fetch all data containers from the database."""
        if self.store is None:
            raise RuntimeError("Store not initialized")
        return self.store.getResourcesOfKind(kind=CoreResourceKinds.DATACONTAINER.value)

    def run_benchmarks(self):
        """Run all benchmark operations."""
        print("=" * 80)
        print("SQL RESOURCE STORE BENCHMARK")
        print("=" * 80)
        print()

        # Define benchmarks to run
        benchmarks = [
            ("Fetch All Spaces", self.fetch_all_spaces),
            # ("Fetch All Datastores", self.fetch_all_datastores),
            ("Fetch All Operations", self.fetch_all_operations),
            ("Fetch Latest Operation", self.fetch_latest_operation),
            ("Fetch All Datacontainers", self.fetch_all_datacontainers),
        ]

        # Run each benchmark
        for operation_name, operation_func in benchmarks:
            print(f"Running: {operation_name}...", end=" ", flush=True)
            result = self.benchmark_operation(operation_name, operation_func)

            if result.success:
                print(f"✓ ({result.execution_time_ms:.2f} ms)")
            else:
                print(f"✗ Error: {result.error}")

        print()

    def print_results_table(self):
        """Print benchmark results in a formatted table."""
        print("=" * 80)
        print("BENCHMARK RESULTS")
        print("=" * 80)
        print()

        # Calculate column widths
        max_name_len = max(len(r.operation_name) for r in self.results)
        name_width = max(max_name_len, 25)

        # Print header
        header = f"{'Operation':<{name_width}} | {'Time (ms)':>12} | {'Status':>10}"
        print(header)
        print("-" * len(header))

        # Print results
        total_time = 0.0
        successful_ops = 0

        for result in self.results:
            if result.success:
                status = "✓ Success"
                time_str = f"{result.execution_time_ms:>12.3f}"
                total_time += result.execution_time_ms
                successful_ops += 1
            else:
                status = "✗ Failed"
                time_str = f"{'N/A':>12}"

            print(f"{result.operation_name:<{name_width}} | {time_str} | {status:>10}")

        # Print summary
        print("-" * len(header))
        print(f"{'TOTAL TIME':<{name_width}} | {total_time:>12.3f} | ")
        print(
            f"{'AVERAGE TIME':<{name_width}} | {total_time/successful_ops if successful_ops > 0 else 0:>12.3f} | "
        )
        print()
        print(f"Successful operations: {successful_ops}/{len(self.results)}")
        print()

        # Print any errors
        failed_ops = [r for r in self.results if not r.success]
        if failed_ops:
            print("=" * 80)
            print("ERRORS")
            print("=" * 80)
            for result in failed_ops:
                print(f"\n{result.operation_name}:")
                print(f"  {result.error}")
            print()


def main():
    """Main entry point for the benchmark script."""

    # Create a default ProjectContext
    # You can modify this to use a different database configuration
    try:
        ado_configuration = AdoConfiguration().load()
        project_context = ado_configuration.project_context
        print(f"Using project: {project_context.project}")
        print(f"Database: {project_context.metadataStore.database}")
        print()
    except Exception as e:
        print(f"Error creating ProjectContext: {e}")
        print("\nYou may need to configure the database connection.")
        print(
            "Example: Set environment variables or modify the ProjectContext initialization."
        )
        sys.exit(1)

    # Create and run benchmark
    benchmark = SQLStoreBenchmark(project_context)

    try:
        # Setup
        benchmark.setup()

        # Run benchmarks
        benchmark.run_benchmarks()

        # Print results
        benchmark.print_results_table()

    except KeyboardInterrupt:
        print("\n\nBenchmark interrupted by user.")
        sys.exit(1)
    except Exception as e:
        print(f"\n\nUnexpected error during benchmark: {e}")
        import traceback

        traceback.print_exc()
        sys.exit(1)
    finally:
        # Cleanup
        benchmark.teardown()


if __name__ == "__main__":
    main()

# Made with Bob
```

</details>

## Before

```terminaloutput
================================================================================
BENCHMARK RESULTS
================================================================================

Operation                 |    Time (ms) |     Status
-----------------------------------------------------
Fetch All Spaces          |    13341.545 |  ✓ Success
Fetch All Operations      |     5080.649 |  ✓ Success
Fetch Latest Operation    |     4093.291 |  ✓ Success
Fetch All Datacontainers  |     3598.352 |  ✓ Success
-----------------------------------------------------
TOTAL TIME                |    26113.838 | 
AVERAGE TIME              |     6528.459 | 

Successful operations: 4/4
```

## After

```terminaloutput
================================================================================
BENCHMARK RESULTS
================================================================================

Operation                 |    Time (ms) |     Status
-----------------------------------------------------
Fetch All Spaces          |    10151.791 |  ✓ Success
Fetch All Operations      |     1176.512 |  ✓ Success
Fetch Latest Operation    |      716.586 |  ✓ Success
Fetch All Datacontainers  |      574.162 |  ✓ Success
-----------------------------------------------------
TOTAL TIME                |    12619.051 | 
AVERAGE TIME              |     3154.763 | 

Successful operations: 4/4
```