### PR TITLE
fix(core): set ray working_dir=None for local workers to support uv run

### DIFF
--- a/orchestrator/modules/operators/orchestrate.py
+++ b/orchestrator/modules/operators/orchestrate.py
@@ -104,7 +104,7 @@ def orchestrate(
             f"Setting runtime environment variables based on local environment - {ray_env_vars}"
         )
         ray.init(
-            runtime_env=RuntimeEnv(env_vars=ray_env_vars),
+            runtime_env=RuntimeEnv(env_vars=ray_env_vars, working_dir=None),
             ignore_reinit_error=True,
         )
 

--- a/orchestrator/utilities/run_experiment.py
+++ b/orchestrator/utilities/run_experiment.py
@@ -9,6 +9,7 @@ import typing
 from collections.abc import Callable
 from typing import Annotated
 
+import ray
 import ray.exceptions
 import requests
 import typer
@@ -273,6 +274,20 @@ def run(
 
     entity = point.to_entity()
     console_print(f"Point: {point.entity}")
+
+    # Initialize Ray before creating ActuatorRegistry to prevent auto-initialization
+    # ActuatorRegistry loads plugins that may use ray decorators, which would trigger
+    # ray auto-init with default settings
+    # This is overridden the below but leads to unslightly logs
+    if not remote:
+        # Assume run_experiment is being run directly
+        # We set working_dir = None to tell ray to use the CWD for all workers
+        # i.e. we are in local mode, code is local, no need to package
+        # This is required in particular because if "uv run" is used
+        # to execute a process that calls ray.init ray cannot work out that the workers
+        # can use the CWD of the main process.
+        ray.init(ignore_reinit_error=True, runtime_env={"working_dir": None})
+        initialize_ray_resource_cleaner()
 
     registry = ActuatorRegistry()
     execute = (


### PR DESCRIPTION
This PR fixes an issue where using "uv run" to execute code where ray is used (ado create operation, run_experiment) would cause errors. 

### Issue Description

For example on main

```
cd examples/optimization_test_functions
uv run run_experiment point.yaml
```

Unexpectedly fails with 
```
ERROR:  Your /Users/michaelj/git-working/discovery-orchestrator/ad-orchestrator/pyproject.toml is not in the working_dir /Users/michaelj/git-working/discovery-orchestrator/ad-orchestrator/examples/optimization_test_functions, so the workers will not have access to the file. Make sure the pyproject.toml file is in the working directory. You can do so by specifying --directory in 'uv run', by changing the current working directory before running 'uv run', or by using the 'working_dir' parameter of the runtime_environment.
Traceback (most recent call last):
  File "/Users/michaelj/git-working/discovery-orchestrator/ad-orchestrator/orchestrator/utilities/run_experiment.py", line 328, in main
    app()
```

Running it from root of repo unexpectedly fails with 
```
(ado-core) michaelj@Michaels-MacBook-Pro-2 ad-orchestrator % uv run run_experiment plugins/custom_experiments/cplex_solver/examples/test_point.yaml
Uninstalled 1 package in 20ms
Installed 1 package in 20ms
Point: {'model_file': 'simple_lp_model.lp', 'time_limit_seconds': 60, 'optimality_gap': 0.001, 'threads': 1, 'memory_limit_mb': 1024}
2026-02-05 15:22:01,323	INFO worker.py:1998 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8266 
2026-02-05 15:22:01,330	INFO packaging.py:392 -- Ignoring upload to cluster for these files: [PosixPath('/Users/michaelj/git-working/discovery-orchestrator/ad-orchestrator/.gitignore')]
2026-02-05 15:22:01,336	INFO packaging.py:392 -- Ignoring upload to cluster for these files: [PosixPath('/Users/michaelj/git-working/discovery-orchestrator/ad-orchestrator/toxenv/.gitignore')]
... (More lines about uploading files)
ray.exceptions.RuntimeEnvSetupError: Failed to set up runtime environment.
Failed to upload working_dir /Users/michaelj/git-working/discovery-orchestrator/ad-orchestrator to the Ray cluster: Package size (684.25MiB) exceeds the maximum size of 512.00MiB. You can exclude large files using the 'excludes' option to the runtime_env or provide a remote URI of a zip file using protocols such as 's3://', 'https://' and so on, refer to https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#api-reference.
```

In both cases executing run_experiment directly works. 

### Reason

The reason is that "uv run" changes how the script is executed in a way that means ray cannot work out that it is executing in local mode and that the workers will have access to the CWD of the main process. In this case ray abandons its normal behaviour (seen when not using uv run) of using the CWD for the workers and assumes it must package and send the CWD to each worker. 

### Change 

The change is that when ray program is executed in local mode (not ray job submit) we explicitly set working_dir to None which ensures ray to use the CWD of the main process for all workers. 