### PR TITLE
refactor(test): support locked and unlocked runners

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,26 @@
 [tox]
-# Test matrix: Python versions 3.10-3.13
-envlist: py3{10-13}
+# Test matrix: Python versions 3.10-3.13 with locked/nonlocked dependencies on darwin/linux
+# Default: locked dependencies on Linux
+envlist = py3{10,11,12,13}-locked-linux
 
-# We use the macos modifier to ensure we can exclude tests
-# that require wheels that are not available on macOS
-# (e.g., CUDA)
-[testenv:py3{10-13}-macos]
-description = "Tests to run on macOS machines"
-platform = darwin
+# Unified test environment configuration with factor-based conditional logic
+[testenv:py3{10,11,12,13}-{locked,nonlocked}-{macos,linux}]
+# Dynamic runner selection based on locked/nonlocked factor
+runner = 
+    locked: uv-venv-lock-runner
+    nonlocked: uv-venv-runner
 
-# Default test environment configuration
-[testenv]
-# Use uv for faster dependency resolution and installation
-runner = uv-venv-lock-runner
-description = "Tests to run on Linux machines"
+# Platform-specific configuration
+platform = 
+    macos: darwin
+    linux: linux
 
-# Tests consider linux by default
-platform = linux
+# Dynamic description based on factors
+description = 
+    macos-locked: Tests with locked dependencies on macOS machines
+    macos-nonlocked: Tests with unlocked dependencies on macOS machines
+    linux-locked: Tests with locked dependencies on Linux machines
+    linux-nonlocked: Tests with unlocked dependencies on Linux machines
 
 # Pass through CI environment variable for CI/CD detection
 passenv=
@@ -28,10 +32,29 @@ setenv=
     LOGLEVEL=DEBUG
     RAY_TASK_MAX_RETRIES=0
 
-# PEP 735 dependency groups from pyproject.toml
+# uv sync reads and respects the sources section, which
+# does not happen with uv pip.
+#
+# When using the unlocked runners, do not install the
+# test dependencies, and install them via their path
+# in the deps section.
 dependency_groups =
     dev
-    test
+    locked: test
+
+deps =
+    nonlocked:
+        .
+        plugins/custom_experiments/autoconf
+        plugins/operators/ray_tune
+        plugins/actuators/sfttrainer; python_version < '3.13'
+        plugins/actuators/vllm_performance; sys_platform != 'darwin'
+        plugins/operators/anomalous_series
+        examples/density_example
+        examples/optimization_test_functions/custom_experiments
+        examples/pfas-generative-models/custom_actuator_function
+        plugins/operators/profile_space
+        plugins/actuators/example_actuator
 
 # External commands allowed to be executed
 allowlist_externals=


### PR DESCRIPTION
**DO NOT QUEUE TO MERGE AFTER APPROVAL - REQUIRES CI UPDATE**

Currently, we only support running tests using our locked dependencies, meaning we won't know if a new dependency has come out which might cause failures.

This PR adds support for using a different tox runner which uses `uv pip install` instead of `uv sync` (i.e., a runner that doesn't use the lockfile). 

**NOTE**: These runners will only be used in the CI pipeline: having these checks in a PR pipeline might cause us to not be able to merge anything due to a breaking dep upgrade. In the CI pipeline they will mark it as failed, signalling something's wrong, but won't affect anything other than that