### PR TITLE
fix(core): copy dictionary to avoid race condition in DiscoverySpaceManager monitorUpdates

### DIFF
--- a/orchestrator/modules/operators/discovery_space_manager.py
+++ b/orchestrator/modules/operators/discovery_space_manager.py
@@ -302,7 +302,8 @@ class DiscoverySpaceManager:
             self.log.info(
                 "Measurement queue observation complete - notifying subscribers"
             )
-            for subscriber in self._subscribers.values():
+            subscriber_copy = self._subscribers.copy()
+            for subscriber in subscriber_copy.values():
                 try:
                     self.log.info("Notifying subscriber")
                     await subscriber.onCompleted.remote()


### PR DESCRIPTION
Copy self._subscribers before iterating to prevent dictionary size changes during iteration when unsubscribeFromUpdates is called concurrently.

This could happen on an interrupt in an explore operation - causing the operator to unsubscribe which could happen exactly when the discovery manager was notifing subscribers of a completed measurement