### PR TITLE
docs: add instructions on ensuring locked dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,22 +146,31 @@ namely:
 
 - [Black](https://ibm.github.io/ado/getting-started/developing#code-style)
 - [Ruff](https://ibm.github.io/ado/getting-started/developing#linting-code-with-ruff)
+- [uv](https://ibm.github.io/ado/getting-started/developing#verifying-lockfile-integrity)
 - [Copywrite](https://ibm.github.io/ado/getting-started/developing#copyright-and-license-headers)
 - [Markdownlint-cli2](https://ibm.github.io/ado/getting-started/developing#linting-markdown-with-markdownlint-cli2)
 - [Yamlfmt](https://github.com/google/yamlfmt)
 
-To verify that your code conforms to these rules you can run the following
-commands:
+Before submitting a pull request, you must ensure that all of the following
+checks pass. To verify that your code conforms to these rules you can run the
+following commands:
 
 ```commandline
 black --check . --extend-exclude website
 ruff check --exclude website
+uv lock --check
 copywrite headers --plan
 markdownlint-cli2 "**/*.md" "#.venv"
 detect-secrets scan --update .secrets.baseline
 detect-secrets audit .secrets.baseline --fail-on-unaudited --fail-on-live --fail-on-audited-real
 yamlfmt -lint .
 ```
+
+The `uv lock --check` command verifies that the `uv.lock` lockfile is up-to-date
+with the dependencies specified in `pyproject.toml`. If this check fails, run
+`uv lock` to regenerate the lockfile. See the
+[development guide](https://ibm.github.io/ado/getting-started/developing#verifying-lockfile-integrity)
+for more details.
 
 ## Website checks
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -363,3 +363,30 @@ With `uv` you can add dependencies to groups using `uv add --group NAME`:
 ```commandline
 uv add --group dev pytest
 ```
+
+## Verifying lockfile integrity
+
+After making changes to dependencies or before committing changes, you should
+verify that the `uv.lock` lockfile is synchronized with `pyproject.toml`. This
+ensures that the lockfile accurately reflects the current project dependencies.
+
+You can do this with:
+
+```commandline
+uv lock --check
+```
+
+If the check passes, no output is produced and the command exits with status
+code 0.
+
+### Fixing lockfile issues
+
+If `uv lock --check` fails, it means the lockfile is out of sync with
+`pyproject.toml`. To fix this, regenerate the lockfile by running:
+
+```commandline
+uv lock
+```
+
+After running this command, commit the updated `uv.lock` file along with your
+other changes.


### PR DESCRIPTION
# Summary

This pull request adds documentation and guidance for verifying lockfile integrity using `uv lock --check`. This ensures that the `uv.lock` lockfile stays synchronized with `pyproject.toml` dependencies.

## Changes

### Documentation Updates

- **CONTRIBUTING.md**: Added `uv lock --check` to the list of pre-commit checks that must pass before submitting a pull request
- **DEVELOPING.md**: Added new section "Verifying lockfile integrity" with detailed instructions on:
  - How to verify lockfile synchronization using `uv lock --check`
  - How to fix lockfile issues by regenerating with `uv lock`
  - When to run these checks (after dependency changes or before committing)

## Why These Changes

Keeping the lockfile synchronized with `pyproject.toml` is critical for:
- Ensuring reproducible builds across different environments
- Preventing dependency drift between what's declared and what's locked
- Catching dependency conflicts early in the development process
- Ensuring the CI can build container images successfully

## Testing

The changes are documentation-only and don't require functional testing.
