### PR TITLE
build(deps): require typer>=0.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "pyyaml>=6.0.2",
   "ray[serve]>=2.9",
   "sqlalchemy>2",
-  "typer>=0.16.1",
+  "typer>=0.22.0",
 ]
 # Deps/Build-related section
 dynamic = ["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ray", extras = ["serve"], specifier = ">=2.9" },
     { name = "sqlalchemy", specifier = ">2" },
-    { name = "typer", specifier = ">=0.16.1" },
+    { name = "typer", specifier = ">=0.22.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Prevents issue when running `uv sync --no-default-groups` on a pre-existing venv would break ado due to missing typer import

Resolves #550 