### PR TITLE
fix(ray_tune): validate points_to_evaluate option of samplers

### DIFF
--- a/plugins/operators/ray_tune/ado_ray_tune/operator.py
+++ b/plugins/operators/ray_tune/ado_ray_tune/operator.py
@@ -661,6 +661,55 @@ def property_domain_to_ray_distribution(
     return retval
 
 
+def _validate_points_to_evaluate(
+    points_to_evaluate: list[dict] | None,
+    entity_space: EntitySpaceRepresentation,
+) -> None:
+    """Validate that each point in points_to_evaluate matches the entity space.
+
+    Each point must include all constitutive properties with values in their domains.
+    Extra properties are not allowed. Raises ValueError on first invalid point.
+
+    Args:
+        points_to_evaluate: List of point dicts from search_alg params, or None.
+        entity_space: The discovery space's entity space to validate against.
+
+    Raises:
+        ValueError: If any point is missing properties, has extra properties, or
+            has values outside the constitutive property domains.
+    """
+    if not points_to_evaluate:
+        return
+
+    space_property_ids = {cp.identifier for cp in entity_space.constitutiveProperties}
+
+    for i, point in enumerate(points_to_evaluate):
+        if not isinstance(point, dict):
+            raise ValueError(
+                f"points_to_evaluate[{i}] must be a dict of constitutive property "
+                f"id: value pairs, got {type(point).__name__}"
+            )
+        if not entity_space.isPointInSpace(point, allow_partial_matches=False):
+            point_ids = set(point.keys())
+            missing = space_property_ids - point_ids
+            extra = point_ids - space_property_ids
+            parts = []
+            if missing:
+                parts.append(f"missing properties: {sorted(missing)}")
+            if extra:
+                parts.append(f"extra properties not in space: {sorted(extra)}")
+            if not parts:
+                parts.append(
+                    "one or more values are not in the domain of their "
+                    "constitutive property"
+                )
+            raise ValueError(
+                f"points_to_evaluate[{i}] is invalid for this discovery space: {', '.join(parts)}. "
+                f"Space constitutive properties: {sorted(space_property_ids)}. "
+                f"Point keys: {sorted(point_ids)}."
+            )
+
+
 def search_space_from_explicit_entity_space(
     entitySpace: EntitySpaceRepresentation,
 ) -> dict:
@@ -816,6 +865,13 @@ class RayTune(Search):
                 search_space = search_space_from_explicit_entity_space(entity_space)
 
                 self.log.debug(search_space)
+
+                _validate_points_to_evaluate(
+                    points_to_evaluate=self.params.tuneConfig.search_alg.params.get(
+                        "points_to_evaluate"
+                    ),
+                    entity_space=entity_space,
+                )
 
                 # Create the tune instance
 


### PR DESCRIPTION
All ray tune samplers support points_to_evaluate which is a list of points to evaluate first. However it was never checked that the properties and values were valid. This PR adds a check to ensure the points are in the entity space before starting. 

For example if properties were misspelled or properties from another space were in file this would not necessarily be detected. 

This is because the point here are not correctly validated by ray against the space it holds (as ado would - as in ray tune the ado space is converted to a ray tune definition which ray tune works with). Strange things can happen if e.g. properties are missing from a points_to_evaluate entry, it was observed the entire domain of missing property (for categorical property) was merged with the points_to_evaluate - this would then be converted into an entity and then fail to be measured. 