### PR TITLE
fix(cli): ensure run_experiment result is fully printed

### DIFF
--- a/orchestrator/utilities/run_experiment.py
+++ b/orchestrator/utilities/run_experiment.py
@@ -19,7 +19,6 @@ from orchestrator.cli.utils.output.prints import (
     ERROR,
     WARN,
     console_print,
-    set_pandas_display_options,
 )
 from orchestrator.modules.actuators.measurement_queue import MeasurementQueue
 from orchestrator.modules.actuators.registry import ActuatorRegistry
@@ -324,9 +323,8 @@ def run(
                     )
                 else:
                     console_print("Result:")
-                    set_pandas_display_options()
                     console_print(
-                        f"{request.series_representation(output_format='target')}\n",
+                        request.series_representation(output_format="target"),
                         has_pandas_content=True,
                         use_markup=False,
                     )


### PR DESCRIPTION
This was the case at some point but it had reverted in latest main