### PR TITLE
fix(trim): return correct model default when registering operator

### DIFF
--- a/plugins/operators/trim/trim/operator.py
+++ b/plugins/operators/trim/trim/operator.py
@@ -23,7 +23,7 @@ logger_trim = logging.getLogger(__name__)
 @characterize_operation(
     name="trim",
     configuration_model=TrimParameters,
-    configuration_model_default=TrimParameters(targetOutput="TO_BE_SET"),
+    configuration_model_default=TrimParameters.defaultOperationParameters(),
     description="""
                 Trim is used to characterise a Discovery space.
                 In its first implementation it starts from a space,

--- a/plugins/operators/trim/trim/trim_pydantic.py
+++ b/plugins/operators/trim/trim/trim_pydantic.py
@@ -152,6 +152,10 @@ class TrimParameters(BaseModel):
     #     ),
     # ] = False
 
+    @classmethod
+    def defaultOperationParameters(cls) -> "TrimParameters":
+        return cls(targetOutput="TO_BE_SET")
+
     @model_validator(mode="after")
     def set_final_model_args(self) -> "TrimParameters":
         if self.finalModelAutoGluonArgs == AutoGluonArgs():


### PR DESCRIPTION
Fixes #644 