### PR TITLE
fix(ray_tune): prevent deadlock by polling for critical errors

### DIFF
--- a/plugins/operators/ray_tune/ado_ray_tune/operator.py
+++ b/plugins/operators/ray_tune/ado_ray_tune/operator.py
@@ -366,6 +366,12 @@ def tune_trainable(config: dict, parameters: dict) -> dict[str, Any]:
     counter = 0
     while waitingOnExperiments:
         time.sleep(1)
+        # Check for critical error (e.g. DiscoverySpaceManager crash) to avoid
+        # spinning forever waiting for measurements that will never arrive
+        if ray.get(driver.isCriticalError.remote()):
+            raise SystemError(
+                "Exiting trainable as notification of critical error received by operator"
+            )
         newDependentRequests = []
         newCompletedRequests = []
 


### PR DESCRIPTION
The trainable only checked for critical errors at the very start of execution. Hence, if an effect of a critical error was to stop the measurement a trainable was waiting on to be delivered, it would never exit.