### PR TITLE
fix(schema): handle none values in aggregation

### DIFF
--- a/orchestrator/schema/virtual_property.py
+++ b/orchestrator/schema/virtual_property.py
@@ -24,23 +24,108 @@ class PropertyAggregationMethodEnum(enum.Enum):
     max = "max"
 
 
+def _to_nan_array(values: list) -> np.ndarray:
+    """Flatten nested lists and replace None with np.nan, returning a float array.
+
+    Handles nested lists (e.g. a single measurement whose value is itself a
+    list of per-seed results) by ravelling before conversion.
+
+    Args:
+        values: Potentially nested list of numeric values or None.
+
+    Returns:
+        1-D float64 numpy array with None replaced by np.nan.
+    """
+    flat = np.asarray(values, dtype=object).ravel()
+    return np.array([np.nan if v is None else float(v) for v in flat])
+
+
+def _mean_no_none(values: list) -> tuple[Any, Any]:
+    """Mean and standard error, ignoring None values.
+
+    Args:
+        values: List of numeric values, possibly containing None.
+
+    Returns:
+        Tuple of (mean, standard_error), or (None, None) if all values are None.
+    """
+    arr = _to_nan_array(values)
+    if np.all(np.isnan(arr)):
+        return None, None
+    n = int(np.sum(~np.isnan(arr)))
+    return float(np.nanmean(arr)), float(np.nanstd(arr) / np.sqrt(n))
+
+
+def median(values: list) -> tuple[Any, Any]:
+    """Median and MAD, ignoring None values.
+
+    Args:
+        values: List of numeric values, possibly containing None.
+
+    Returns:
+        Tuple of (median, median_absolute_deviation), or (None, None) if all
+        values are None.
+    """
+    arr = _to_nan_array(values)
+    if np.all(np.isnan(arr)):
+        return None, None
+    med = float(np.nanmedian(arr))
+    non_nan = arr[~np.isnan(arr)]
+    return med, float(np.median(np.absolute(non_nan - med)))
+
+
+def _min_no_none(values: list) -> tuple[Any, Any]:
+    """Minimum, ignoring None values."""
+    arr = _to_nan_array(values)
+    if np.all(np.isnan(arr)):
+        return None, None
+    return float(np.nanmin(arr)), None
+
+
+def _max_no_none(values: list) -> tuple[Any, Any]:
+    """Maximum, ignoring None values."""
+    arr = _to_nan_array(values)
+    if np.all(np.isnan(arr)):
+        return None, None
+    return float(np.nanmax(arr)), None
+
+
+def _std_no_none(values: list) -> tuple[Any, Any]:
+    """Standard deviation, ignoring None values."""
+    arr = _to_nan_array(values)
+    if np.all(np.isnan(arr)):
+        return None, None
+    return float(np.nanstd(arr)), None
+
+
+def _var_no_none(values: list) -> tuple[Any, Any]:
+    """Variance, ignoring None values."""
+    arr = _to_nan_array(values)
+    if np.all(np.isnan(arr)):
+        return None, None
+    return float(np.nanvar(arr)), None
+
+
 class PropertyAggregationMethod(pydantic.BaseModel):
     identifier: Annotated[PropertyAggregationMethodEnum, pydantic.Field()] = (
         PropertyAggregationMethodEnum.mean
     )
 
     def function(self, values: list) -> float | tuple[Any, Any] | tuple[Any, None]:
-        """
-        Apply property aggregation methods to values.
+        """Apply property aggregation methods to values.
 
-        Parameters:
-        values (list): A list of values to apply aggregation methods to.
+        None entries in values are ignored (treated as missing data). If all
+        values are None the returned aggregate value is also None.
+
+        Args:
+            values: A list of values to aggregate. May contain None entries and
+                nested lists (e.g. per-seed result vectors).
 
         Returns:
-        The result of applying the aggregation method to the values.
+            The result of applying the aggregation method to the values.
 
         Raises:
-        ValueError: If values is empty or none.
+            ValueError: If values is empty.
         """
         if not values:
             raise ValueError(
@@ -49,21 +134,13 @@ class PropertyAggregationMethod(pydantic.BaseModel):
         return functionMap[self.identifier](values)
 
 
-def median(values: list) -> float:
-    x = np.asarray(values)
-    return np.median(values), np.median(np.absolute(x - np.median(x)))
-
-
 functionMap = {
-    PropertyAggregationMethodEnum.mean: lambda x: (
-        np.asarray(x).mean(),
-        np.asarray(x).std() / np.sqrt(len(x)),
-    ),
+    PropertyAggregationMethodEnum.mean: _mean_no_none,
     PropertyAggregationMethodEnum.median: median,
-    PropertyAggregationMethodEnum.min: lambda x: (min(x), None),
-    PropertyAggregationMethodEnum.max: lambda x: (max(x), None),
-    PropertyAggregationMethodEnum.std: lambda x: (np.asarray(x).std(), None),
-    PropertyAggregationMethodEnum.variance: lambda x: (np.asarray(x).var(), None),
+    PropertyAggregationMethodEnum.min: _min_no_none,
+    PropertyAggregationMethodEnum.max: _max_no_none,
+    PropertyAggregationMethodEnum.std: _std_no_none,
+    PropertyAggregationMethodEnum.variance: _var_no_none,
 }
 
 

--- a/tests/schema/test_virtual_properties.py
+++ b/tests/schema/test_virtual_properties.py
@@ -119,6 +119,109 @@ def test_virtual_property_identifiers(
     assert str(virtual_property) == f"vp-{virtual_property.identifier}"
 
 
+class TestAggregationWithNoneValues:
+    """Aggregation functions must ignore None entries (treated as missing data)."""
+
+    def test_mean_ignores_none(self) -> None:
+        """Mean of [1.0, None, 3.0] must equal mean of [1.0, 3.0]."""
+        import numpy as np
+
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.mean
+        )
+        value, uncertainty = method.function([1.0, None, 3.0])
+        assert value == pytest.approx(np.mean([1.0, 3.0]))
+        assert uncertainty == pytest.approx(np.std([1.0, 3.0]) / np.sqrt(2))
+
+    def test_mean_nested_list_with_none(self) -> None:
+        """Mean handles a single nested list whose elements may be None."""
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.mean
+        )
+        value, _ = method.function([[0.1, None, 0.3]])
+        assert value == pytest.approx(0.2)
+
+    def test_mean_all_none_returns_none(self) -> None:
+        """Mean of all-None input must return (None, None)."""
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.mean
+        )
+        assert method.function([None, None, None]) == (None, None)
+
+    def test_median_ignores_none(self) -> None:
+        """Median of [1.0, None, 3.0] must equal median of [1.0, 3.0]."""
+        import numpy as np
+
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.median
+        )
+        value, _ = method.function([1.0, None, 3.0])
+        assert value == pytest.approx(np.median([1.0, 3.0]))
+
+    def test_median_all_none_returns_none(self) -> None:
+        """Median of all-None input must return (None, None)."""
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.median
+        )
+        assert method.function([None, None]) == (None, None)
+
+    def test_min_ignores_none(self) -> None:
+        """Min of [2.0, None, 5.0] must be 2.0."""
+        method = PropertyAggregationMethod(identifier=PropertyAggregationMethodEnum.min)
+        value, uncertainty = method.function([2.0, None, 5.0])
+        assert value == pytest.approx(2.0)
+        assert uncertainty is None
+
+    def test_min_all_none_returns_none(self) -> None:
+        """Min of all-None input must return (None, None)."""
+        method = PropertyAggregationMethod(identifier=PropertyAggregationMethodEnum.min)
+        assert method.function([None]) == (None, None)
+
+    def test_max_ignores_none(self) -> None:
+        """Max of [2.0, None, 5.0] must be 5.0."""
+        method = PropertyAggregationMethod(identifier=PropertyAggregationMethodEnum.max)
+        value, uncertainty = method.function([2.0, None, 5.0])
+        assert value == pytest.approx(5.0)
+        assert uncertainty is None
+
+    def test_max_all_none_returns_none(self) -> None:
+        """Max of all-None input must return (None, None)."""
+        method = PropertyAggregationMethod(identifier=PropertyAggregationMethodEnum.max)
+        assert method.function([None]) == (None, None)
+
+    def test_std_ignores_none(self) -> None:
+        """Std of [1.0, None, 3.0] must equal std of [1.0, 3.0]."""
+        import numpy as np
+
+        method = PropertyAggregationMethod(identifier=PropertyAggregationMethodEnum.std)
+        value, uncertainty = method.function([1.0, None, 3.0])
+        assert value == pytest.approx(np.std([1.0, 3.0]))
+        assert uncertainty is None
+
+    def test_std_all_none_returns_none(self) -> None:
+        """Std of all-None input must return (None, None)."""
+        method = PropertyAggregationMethod(identifier=PropertyAggregationMethodEnum.std)
+        assert method.function([None, None]) == (None, None)
+
+    def test_variance_ignores_none(self) -> None:
+        """Variance of [1.0, None, 3.0] must equal variance of [1.0, 3.0]."""
+        import numpy as np
+
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.variance
+        )
+        value, uncertainty = method.function([1.0, None, 3.0])
+        assert value == pytest.approx(np.var([1.0, 3.0]))
+        assert uncertainty is None
+
+    def test_variance_all_none_returns_none(self) -> None:
+        """Variance of all-None input must return (None, None)."""
+        method = PropertyAggregationMethod(
+            identifier=PropertyAggregationMethodEnum.variance
+        )
+        assert method.function([None]) == (None, None)
+
+
 def test_is_virtual_property_identifier() -> None:
     for e in PropertyAggregationMethodEnum:
         e = e.value


### PR DESCRIPTION
numpy can't aggregate "None" in an array.

However, None is natural used as a placeholder if an experiment could not return a value for some reason. In this case those values should be dropped from the aggregation rather than raising a numpy error.