### PR TITLE
perf(core): fetch missing entities in a batch when parsing measurement requests from db

### DIFF
--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -1530,12 +1530,11 @@ class SQLSampleStore(ActiveSampleStore):
         self, db_cursor: sqlalchemy.CursorResult[typing.Any]
     ) -> list[MeasurementRequest]:
 
-        # PyMySQL buffers the full result set in memory, so fetchall() here adds
-        # no extra network round-trip.  We consume the cursor up-front so we can
-        # collect all entity IDs and pre-fetch any that are missing from the
-        # local cache in a single batched query.  The entityWithIdentifier
-        # fallback below is then only reached for entities added by a concurrent
-        # distributed process in the window between the batch fetch and now.
+        # We consume the whole result cursor early to extract the set of entities
+        # identifiers for which we have results and fetch missing ones in a batch
+        # to reduce network overhead. The fallback entityWithIdentifier call should
+        # only be reached for entities added by a concurrent distributed process
+        # in the window between the batch fetch and now.
         rows = db_cursor.fetchall()
 
         # row[9] is entity id


### PR DESCRIPTION

Previously, _measurement_requests_cursor_to_pydantic called entityWithIdentifier in a loop for each entity not already in the local cache, issuing one DB round-trip (~240ms) per unique entity. For an operation touching N distinct entities this was an N+1 query pattern. This is via a pattern of initializing the store an then calling measurement_requests_for_operation or related calls which happens with `ado show X operation`

It might be expected that self._entities is pre-populated before this method runs. There are two reasons it is not:

1. The bulk-load mechanism is bypassed. The public `entities` property triggers refresh(force_fetch_all_entities=True) when self._entities is empty, loading all entities in one query. But _measurement_requests_- cursor_to_pydantic accesses the private self._entities dict directly, never touching the property, so the lazy-load never fires.

2. Nothing in the construction path populates the cache. SQLSampleStore starts with self._entities = {}. By the time _measurement_requests_cursor_to_pydantic runs, the cache is still empty and every entity lookup falls through to entityWithIdentifier.

PyMySQL already buffers the full result set in memory before the Python loop begins, so consuming the cursor up-front with fetchall() adds no network round-trip. The fix uses this to collect all missing entity IDs before any entity is resolved, then issues a single _fetch_entities query for all of them at once regardless of N, ensuring the cache is populated with the required entities.

The entityWithIdentifier fallback is retained and still fires for entities added by a concurrent distributed process in the window between the batch fetch and the cursor scan — the intended use of that code path.

Measured on an operation with 4 distinct entities (197ms RTT to DB):
  _measurement_requests_cursor_to_pydantic: 3,378ms → 859ms (-2,519ms)

Saving scales linearly with the number of distinct entities touched by the operation: N round-trips collapsed to 1.