### PR TITLE
perf(core): cache operation IDs belonging to space to avoid preflight DB lookup

### DIFF
--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -297,11 +297,13 @@ class DiscoverySpace:
             raise_error_if_no_resource=True,
         ).config.spaces[0]
 
-        return cls.from_stored_configuration(
+        space = cls.from_stored_configuration(
             project_context=project_context,
             space_identifier=space_id,
             metadata_store=metadata_store,
         )
+        space._verified_operation_ids.add(operation_id)
+        return space
 
     def __init__(
         self,


### PR DESCRIPTION

_perform_preflight_checks_for_sample_store_methods decorates every
sample store method (measurement_requests_for_operation,
complete_measurement_request_with_results_timeseries, etc.) and
verifies that the supplied operation_id belongs to the space before
allowing the call through. It did this by calling getResource(operation)
on every decorated call — a full DB round-trip each time.

For the common path for `ado show X operation` which goes through from_operation_id, this check is redundant as
the operation was already fetched to locate the space, so ownership is
proven by construction.

The fix adds _verified_operation_ids: set[str] to DiscoverySpace.__init__
and guards the getResource call in the preflight decorator behind a set
membership test. from_operation_id pre-populates the set with the
operation_id immediately after the space is built, so any subsequent
decorated call on that space skips the DB round-trip entirely.

The full ownership check (getResource + uri comparison) is still
executed for operation IDs not in the set, preserving correctness for
spaces constructed via other paths (e.g. from_stored_configuration
called directly) where ownership has not yet been established.

Measured saving per decorated method call: ~653ms (this is saving in ado show X operation call)