### PR TITLE
perf(core): allow skipping loading experiment catalogs from DB when initializing DiscoverySpace

### DIFF
--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -131,6 +131,7 @@ class DiscoverySpace:
         project_context: ProjectContext,
         identifier: str | None = None,
         metadata_store: "SQLResourceStore | None" = None,
+        load_experiment_catalog: bool = True,
     ) -> "DiscoverySpace":
         """Creates a discovery space from a config
 
@@ -144,6 +145,9 @@ class DiscoverySpace:
                 Otherwise, a new space not connected to the previous stored data may be created (depends on how the
                 discovery space generates the id versus how the id used to store was generated)
             metadata_store: Optional SQLResourceStore instance to reuse. If None, a new instance will be created.
+            load_experiment_catalog: When ``True`` (default) the samplestore's experiment catalog is
+                loaded and registered with the actuator registry.  Set to ``False`` for read-only
+                paths (e.g. CLI show commands) where replay experiment resolution is not needed.
 
         """
 
@@ -172,7 +176,7 @@ class DiscoverySpace:
 
         ## Add any external experiments to the replay actuators catalog
         externalCatalogs = []
-        if sample_store is not None:
+        if load_experiment_catalog and sample_store is not None:
             moduleLogger.debug(
                 f"Loading external experiments from sample store: {sample_store.identifier}"
             )
@@ -221,6 +225,7 @@ class DiscoverySpace:
         project_context: ProjectContext,
         space_identifier: str,
         metadata_store: "SQLResourceStore | None" = None,
+        load_experiment_catalog: bool = True,
     ) -> "DiscoverySpace":
 
         from orchestrator.metastore.sqlstore import SQLResourceStore
@@ -254,6 +259,7 @@ class DiscoverySpace:
             project_context=project_context,
             identifier=space_identifier,
             metadata_store=metadata_store,
+            load_experiment_catalog=load_experiment_catalog,
         )
 
     @classmethod
@@ -295,6 +301,7 @@ class DiscoverySpace:
             project_context=project_context,
             space_identifier=space_id,
             metadata_store=metadata_store,
+            load_experiment_catalog=False,
         )
 
     def __init__(


### PR DESCRIPTION


from_configuration unconditionally called experimentCatalog() on every construction of a DiscoverySpace. This method queries the samplestore for any externally registered experiment plugins and loads them into the actuator registry so they are available for replay during an active operation run.

For read-only CLI commands (show requests, show results, show entities) this work is entirely unnecessary: these commands inspect stored measurement data and never resolve or replay experiment references. The catalog load was measured at ~852ms — a full DB query round-trip plus plugin loading overhead — paid on every invocation with no benefit.

The commit adds a boolean load_experiment_catalog parameter to __init__ (default True), from_configuration and from_stored_configuration. from_operation_id, whose callers are exclusively read-only show commands, passes load_experiment_catalog=False, bypassing the experimentCatalog() call and the actuator registry update entirely.

The default remains True so all other construction paths (from_configuration called directly, space creation during an active run) retain the existing behaviour without requiring changes at call sites.

Measured saving on ado show requests / show results / show entities: ~852ms.