### PR TITLE
perf(core): add method to fetch multiple related resources from the DB at the same time

### DIFF
--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -137,6 +137,7 @@ class DiscoverySpace:
         project_context: ProjectContext,
         identifier: str | None = None,
         metadata_store: "SQLResourceStore | None" = None,
+        samplestore_resource: "orchestrator.core.SampleStoreResource | None" = None,
         load_experiment_catalog: bool = True,
     ) -> "DiscoverySpace":
         """Creates a discovery space from a config
@@ -151,6 +152,8 @@ class DiscoverySpace:
                 Otherwise, a new space not connected to the previous stored data may be created (depends on how the
                 discovery space generates the id versus how the id used to store was generated)
             metadata_store: Optional SQLResourceStore instance to reuse. If None, a new instance will be created.
+            samplestore_resource: Optional pre-fetched SampleStoreResource. When provided the metastore
+                round-trip to fetch the samplestore is skipped.
             load_experiment_catalog: When ``True`` (default) the samplestore's experiment catalog is
                 loaded and registered with the actuator registry.  Set to ``False`` for read-only
                 paths (e.g. CLI show commands) where replay experiment resolution is not needed.
@@ -168,12 +171,13 @@ class DiscoverySpace:
 
         entitySpace = None
 
-        resource = metadata_store.getResource(
-            identifier=conf.sampleStoreIdentifier,
-            kind=CoreResourceKinds.SAMPLESTORE,
-            raise_error_if_no_resource=True,
-        )
-        sample_store = load_sample_store_from_resource(resource)
+        if samplestore_resource is None:
+            samplestore_resource = metadata_store.getResource(
+                identifier=conf.sampleStoreIdentifier,
+                kind=CoreResourceKinds.SAMPLESTORE,
+                raise_error_if_no_resource=True,
+            )
+        sample_store = load_sample_store_from_resource(samplestore_resource)
 
         if conf.entitySpace is not None:
             entitySpace = EntitySpaceRepresentation.representationFromConfiguration(
@@ -231,23 +235,38 @@ class DiscoverySpace:
         project_context: ProjectContext,
         space_identifier: str,
         metadata_store: "SQLResourceStore | None" = None,
+        space_resource: "orchestrator.core.DiscoverySpaceResource | None" = None,
+        samplestore_resource: "orchestrator.core.SampleStoreResource | None" = None,
         load_experiment_catalog: bool = True,
     ) -> "DiscoverySpace":
+        """Creates a DiscoverySpace from a stored space identifier.
 
-        from orchestrator.metastore.sqlstore import SQLResourceStore
+        Args:
+            project_context: Project context used to connect to the metadata store.
+            space_identifier: Identifier of the stored DiscoverySpace resource.
+            metadata_store: Optional SQLResourceStore instance to reuse.
+            space_resource: Optional pre-fetched DiscoverySpaceResource. When provided
+                the metastore round-trip to fetch the space is skipped.
+            samplestore_resource: Optional pre-fetched SampleStoreResource. Forwarded
+                to :meth:`from_configuration` to skip the samplestore round-trip.
+            load_experiment_catalog: Forwarded to :meth:`from_configuration`.
+        """
+        from orchestrator.metastore.sqlstore import SQLStore
 
         moduleLogger.debug("Accessing discovery space metadata store")
         if metadata_store is None:
-            metadata_store = SQLResourceStore(project_context=project_context)
-        moduleLogger.debug(
-            f"Retrieving configuration for discovery space {space_identifier}"
-        )
-        resource = metadata_store.getResource(
-            identifier=space_identifier,
-            kind=CoreResourceKinds.DISCOVERYSPACE,
-            raise_error_if_no_resource=True,
-        )
-        conf = resource.config
+            metadata_store = SQLStore(project_context=project_context)
+
+        if space_resource is None:
+            moduleLogger.debug(
+                f"Retrieving configuration for discovery space {space_identifier}"
+            )
+            space_resource = metadata_store.getResource(
+                identifier=space_identifier,
+                kind=CoreResourceKinds.DISCOVERYSPACE,
+                raise_error_if_no_resource=True,
+            )
+        conf = space_resource.config
 
         moduleLogger.debug(f"Retrieved configuration is: {conf}")
 
@@ -265,6 +284,7 @@ class DiscoverySpace:
             project_context=project_context,
             identifier=space_identifier,
             metadata_store=metadata_store,
+            samplestore_resource=samplestore_resource,
             load_experiment_catalog=load_experiment_catalog,
         )
 
@@ -290,23 +310,33 @@ class DiscoverySpace:
             ResourceDoesNotExistError: If the specified operation or related space do not exist.
             NoRelatedResourcesError: If no sample store is associated with the specified operation or related space.
         """
-        from orchestrator.metastore.sqlstore import SQLResourceStore
+        from orchestrator.metastore.sqlstore import SQLStore
 
         if metadata_store is None:
-            metadata_store = SQLResourceStore(project_context=project_context)
+            metadata_store = SQLStore(project_context=project_context)
 
+        # Fetch the operation, its space, and the space's samplestore in a
+        # single SQL JOIN rather than three sequential round-trips.
         # FIXME AP 12/06/2025:
         # We are using the first space - which may become a problem in the future
-        space_id = metadata_store.getResource(
-            identifier=operation_id,
-            kind=CoreResourceKinds.OPERATION,
-            raise_error_if_no_resource=True,
-        ).config.spaces[0]
+        _, space_resource, samplestore_resource = (
+            metadata_store.get_resource_and_producers(
+                identifier=operation_id,
+                kind=CoreResourceKinds.OPERATION,
+                chain=[
+                    ("$.config.spaces[0]", CoreResourceKinds.DISCOVERYSPACE),
+                    ("$.config.sampleStoreIdentifier", CoreResourceKinds.SAMPLESTORE),
+                ],
+                raise_error_if_no_resource=True,
+            )
+        )
 
         space = cls.from_stored_configuration(
             project_context=project_context,
-            space_identifier=space_id,
+            space_identifier=space_resource.identifier,
             metadata_store=metadata_store,
+            space_resource=space_resource,
+            samplestore_resource=samplestore_resource,
             load_experiment_catalog=False,
         )
         space._verified_operation_ids.add(operation_id)

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -160,6 +160,101 @@ class SQLResourceStore(ResourceStore):
     def engine(self) -> sqlalchemy.Engine:
         return self._engine
 
+    def get_resource_and_producers(
+        self,
+        identifier: str,
+        kind: CoreResourceKinds,
+        chain: list[tuple[str, CoreResourceKinds]],
+        raise_error_if_no_resource: bool = False,
+    ) -> list[orchestrator.core.resources.ADOResource | None]:
+        """Fetch a resource and a chain of producer resources in a single SQL JOIN.
+
+        Each entry in ``chain`` defines how to reach the next resource: the
+        JSON path within the *previous* resource's ``data`` column that holds
+        the identifier of the next resource, and the ``CoreResourceKinds`` of
+        that next resource.  This traverses N hops in one round-trip rather
+        than N+1 sequential queries.
+
+        The ``->>`` operator is used for JSON path extraction; it is supported
+        by both MySQL and SQLite 3.38+.
+
+        Args:
+            identifier: Identifier of the starting resource.
+            kind: Kind of the starting resource.
+            chain: Ordered list of ``(json_path, kind)`` pairs.  Each pair
+                describes one hop: ``json_path`` (e.g.
+                ``'$.config.spaces[0]'``) is a JSON path expression in the
+                *previous* resource's ``data`` column whose unquoted value is
+                the identifier of the next resource.
+            raise_error_if_no_resource: When ``True``, raises
+                :class:`ResourceDoesNotExistError` if any resource in the
+                chain cannot be resolved.
+
+        Returns:
+            A list of ``len(chain) + 1`` deserialized
+            :class:`~orchestrator.core.resources.ADOResource` instances.  The
+            first element corresponds to the starting resource; subsequent
+            elements correspond to each hop in ``chain``.
+
+        Raises:
+            ResourceDoesNotExistError: When ``raise_error_if_no_resource`` is
+                ``True`` and any resource in the chain cannot be found.
+        """
+        n = len(chain)
+
+        # Build SELECT with explicit per-resource column aliases to avoid
+        # collisions when the same column name appears across table aliases.
+        selects = ", ".join(
+            f"r{i}.data AS r{i}_data, r{i}.kind AS r{i}_kind" for i in range(n + 1)
+        )
+
+        # Each JOIN hop resolves the next resource identifier from the JSON
+        # field of the previous resource.  Kind filtering is included in the
+        # ON clause so an incorrect kind never silently matches.
+        joins = "\n".join(
+            f"JOIN resources r{i + 1}"
+            f"  ON r{i + 1}.identifier = r{i}.data->>'{json_path}'"
+            f" AND r{i + 1}.kind = '{linked_kind.value}'"
+            for i, (json_path, linked_kind) in enumerate(chain)
+        )
+
+        # selects and joins are built from CoreResourceKinds enum values and
+        # literal JSON paths only; no user-supplied text is interpolated.
+        query = sqlalchemy.text(
+            f"SELECT {selects} FROM resources r0 {joins}"  # noqa: S608
+            " WHERE r0.identifier = :identifier AND r0.kind = :kind"
+        ).bindparams(identifier=identifier, kind=kind.value)
+
+        with self.engine.connect() as connectable:
+            row = connectable.execute(query).fetchone()
+
+        if row is None:
+            if raise_error_if_no_resource:
+                raise ResourceDoesNotExistError(resource_id=identifier, kind=kind)
+            return [None] * (n + 1)
+
+        mapping = row._mapping
+        all_kinds = [kind] + [k for _, k in chain]
+        resources = []
+        for i, _rk in enumerate(all_kinds):
+            data_raw = mapping[f"r{i}_data"]
+            kind_val = mapping[f"r{i}_kind"]
+            d = json.loads(data_raw) if isinstance(data_raw, str) else data_raw
+            custom_loader = kind_custom_model_load.get(kind_val)
+            if custom_loader:
+                resource = custom_loader(d, self.configuration)
+            else:
+                resource = orchestrator.core.kindmap[kind_val](**d)
+
+            if orchestrator.core.resources.VersionIsGreaterThan(
+                resource.version, d.get("version", "v0")
+            ):
+                self.updateResource(resource)
+
+            resources.append(resource)
+
+        return resources
+
     def getResourceRaw(self, identifier: str) -> dict | None:
         """Retrieve the raw JSON data for a resource.
 


### PR DESCRIPTION

`from_operation_id` previously made three sequential `getResource` calls to assemble a DiscoverySpace from an operation ID:

  1. getResource(operation_id, OPERATION)   → extract spaces[0]
  2. getResource(space_id, DISCOVERYSPACE)  → extract sampleStoreIdentifier
  3. getResource(samplestore_id, SAMPLESTORE)

Each call is a separate network round-trip (~240ms RTT each, plus SQLAlchemy query overhead). Because each call depends on the identifier returned by the previous one they cannot be parallelised; total cost was measured at ~2,520ms (1,194ms + 704ms + 622ms).

A new `SQLResourceStore` method, `get_resource_and_producers`, enables replacing the three calls with a single SQL statement that walks the parent-child identifier chain using JSON path extraction (data->>'$.path').

The method is generic: callers supply the root resource and an ordered chain of (json_path, kind) pairs, making it reusable for other parent-child resource hierarchies. Later we could hide the required paths in wrapper methods. 

`from_operation_id` passes the three fetched resources directly into `from_stored_configuration` and `from_configuration` via new optional parameters (space_resource, samplestore_resource), so neither method re-fetches what has already been retrieved.

Measured saving on ado show requests / show results: ~1.9s (three sequential round-trips collapsed to one query).