### PR TITLE
docs(agents): add instructions on using uv workspace packages when developing plugins

### DIFF
--- a/.cursor/rules/plugin-development.mdc
+++ b/.cursor/rules/plugin-development.mdc
@@ -76,7 +76,7 @@ By default, plugins added in-tree are not workspace members and should
 not be added to `[tool.uv.workspace]` members in the root `pyproject.toml`.
 
 This means the plugins pyproject.toml should not include a `[tool.uv.sources]`
-section resolving `ado-core` via`{ workspace = true }`.
+section resolving `ado-core` via `{ workspace = true }`.
 
 Only add a plugin to the workspace when explicitly
 asked, for example when the plugin must be included in `uv sync` for CI or


### PR DESCRIPTION
Without this clarification when creating plugins agents will copy the pattern of the standard plugins and add new plugins also to the workspace defined in the root pyproject.toml which is not usually what is desired when developing.