### PR TITLE
build(hooks): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: detect-secrets # pragma: whitelist secret
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.6
     hooks:
       - id: ruff
         args:
@@ -16,7 +16,7 @@ repos:
           - website,plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
       - id: black-jupyter
   - repo: https://github.com/compilerla/conventional-pre-commit
@@ -28,13 +28,13 @@ repos:
           - --no-color
           - --verbose
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies: ['tomli']
         args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.8
+    rev: 0.10.11
     hooks:
       - id: uv-lock
       - id: uv-export
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.9.0
+    rev: v0.9.7
     hooks:
       - id: tombi-format
         args: ["--offline"]


### PR DESCRIPTION
## Updated pre-commit hooks

| Hook | From | To |
|---|---|---|
| [ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) | 0.15.4 | 0.15.6 |
| [black-pre-commit-mirror](https://github.com/psf/black-pre-commit-mirror) | 26.1.0 | 26.3.1 |
| [codespell](https://github.com/codespell-project/codespell) | 2.4.1 | 2.4.2 |
| [uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) | 0.10.8 | 0.10.11 |
| [tombi-pre-commit](https://github.com/tombi-toml/tombi-pre-commit) | 0.9.0 | 0.9.7 |
