### PR TITLE
fix(vllm_performance): Replace binary type with discrete type for properties in geospatial experiments

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
@@ -193,14 +193,14 @@ performance_testing-geospatial-full:
       metadata:
         description: "(deployment) skip tokenizer initialization"
       propertyDomain:
-        variableType: BINARY_VARIABLE_TYPE
-        values: [True, False]
+        variableType: DISCRETE_VARIABLE_TYPE
+        values: [1]
     - identifier: 'enforce_eager'
       metadata:
         description: "(deployment) enforce pytorch eager mode"
       propertyDomain:
-        variableType: BINARY_VARIABLE_TYPE
-        values: [True, False]
+        variableType: DISCRETE_VARIABLE_TYPE
+        values: [1]
     - identifier: 'io_processor_plugin'
       metadata:
         description: 'IO Processor plugin to load for the model'
@@ -249,10 +249,10 @@ performance_testing-geospatial-full:
       value: 'NVIDIA-A100-80GB-PCIe'
     - property:
         identifier: 'skip_tokenizer_init'
-      value: True
+      value: 1
     - property:
         identifier: 'enforce_eager'
-      value: True
+      value: 1
     - property:
         identifier: 'io_processor_plugin'
       value: "terratorch_segmentation"
@@ -386,14 +386,14 @@ performance_testing-geospatial-full-custom-dataset:
       metadata:
         description: "(deployment) skip tokenizer initialization"
       propertyDomain:
-        variableType: BINARY_VARIABLE_TYPE
-        values: [True, False]
+        variableType: DISCRETE_VARIABLE_TYPE
+        values: [1]
     - identifier: 'enforce_eager'
       metadata:
         description: "(deployment) enforce PyTorch eager mode"
       propertyDomain:
-        variableType: BINARY_VARIABLE_TYPE
-        values: [True, False]
+        variableType: DISCRETE_VARIABLE_TYPE
+        values: [1]
     - identifier: 'io_processor_plugin'
       metadata:
         description: 'IO Processor plugin to load for the model'
@@ -442,10 +442,10 @@ performance_testing-geospatial-full-custom-dataset:
       value: 'NVIDIA-A100-80GB-PCIe'
     - property:
         identifier: 'skip_tokenizer_init'
-      value: True
+      value: 1
     - property:
         identifier: 'enforce_eager'
-      value: True
+      value: 1
     - property:
         identifier: 'io_processor_plugin'
       value: "terratorch_segmentation"


### PR DESCRIPTION
This PR replaces the `BINARY_VARIABLE_TYPE` with `DISCRETE_VARIABLE_TYPE` for the `skip_tokenizer_init` and `enforce_eager` properties of the `performance_testing-geospatial-full` and `performance_testing-geospatial-full-custom-dataset` experiments in the vllm-performance  actuator. 

This change is needed because those properties are to be forcibly set to 1 (True) for loading the Geospatial models with vLLM. Using a binary type would instead lead to an entity space where both values in the domain (True, False) are tested, causing the failure of the vLLM engine for all the entities with one (or both) of the above properties set to False.