### PR TITLE
build(hooks): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: detect-secrets # pragma: whitelist secret
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.7
     hooks:
       - id: ruff
         args:
@@ -34,7 +34,7 @@ repos:
         additional_dependencies: ['tomli']
         args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.11
+    rev: 0.10.12
     hooks:
       - id: uv-lock
       - id: uv-export
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: add-headers
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.22.0
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/google/yamlfmt
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.9.7
+    rev: v0.9.9
     hooks:
       - id: tombi-format
         args: ["--offline"]


### PR DESCRIPTION
## Updated pre-commit hooks

| Hook | From | To |
|---|---|---|
| [ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) | 0.15.6 | 0.15.7 |
| [uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) | 0.10.11 | 0.10.12 |
| [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | 0.21.0 | 0.22.0 |
| [tombi-pre-commit](https://github.com/tombi-toml/tombi-pre-commit) | 0.9.7 | 0.9.9 |