### PR TITLE
docs(cli): clarify --output flag behavior for json/raw/yaml formats

### DIFF
--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -120,7 +120,7 @@ def get_resource(
             "-o",
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
             show_default=False,
-            help="Output information in a different format. Not all formats may be supported by all resources.",
+            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. Not all formats may be supported by all resources.",
         ),
     ] = AdoGetSupportedOutputFormats.DEFAULT.value,
     exclude_default: Annotated[


### PR DESCRIPTION
Update help text for --output flag to explicitly state that json, raw, and yaml formats output the entire resource, improving clarity for users and agents relying on CLI help documentation.

CLOSE #700 