### PR TITLE
feat(cli): save latest operation id even on failure

### DIFF
--- a/orchestrator/cli/resources/operation/create.py
+++ b/orchestrator/cli/resources/operation/create.py
@@ -48,7 +48,6 @@ def _save_operation_identifier(
 def create_operation(parameters: AdoCreateCommandParameters) -> str | None:
 
     import orchestrator.modules.operators.orchestrate
-    from orchestrator.modules.actuators.base import MeasurementError
     from orchestrator.modules.operators.base import InterruptedOperationError
 
     try:
@@ -162,13 +161,6 @@ def create_operation(parameters: AdoCreateCommandParameters) -> str | None:
             project_context=parameters.ado_configuration.project_context,
             discovery_space_identifier=op_resource_configuration.spaces[0],
         )
-
-    except MeasurementError as e:
-        console_print(
-            f"{ERROR}A measurement error was encountered while running the operation:\n\t{e}",
-            stderr=True,
-        )
-        raise typer.Exit(1) from e
     except ValueError as e:
         console_print(f"{ERROR}Failed to create operation:\n\t{e}", stderr=True)
         raise typer.Exit(1) from e


### PR DESCRIPTION
# Summary

Refactors operation identifier saving logic to ensure the operation identifier is persisted even when exceptions occur during operation creation. This enables the `--use-latest` flag to reference failed operations.

Resolves #290

# Files Changed

📄 `orchestrator/cli/resources/operation/create.py`

Extracts operation identifier saving logic into a dedicated helper function `_save_operation_identifier()` and calls it in exception handlers for `InterruptedOperationError` and `OperationException`. This ensures that operation identifiers are saved to the configuration even when operations fail or are interrupted, allowing users to reference these operations later using the `--use-latest` flag.