### PR TITLE
build(vllm_performance): require minimum datasets version

### DIFF
--- a/plugins/actuators/vllm_performance/pyproject.toml
+++ b/plugins/actuators/vllm_performance/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 ]
 dependencies = [
   "ado-core",
+  "datasets>=2.20.0",  # Required to avoid uv/pip to resolve to a version of datasets that is not compatible with vllm
   "kubernetes>=31.0.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Even though datasets is not a direct dependency, if it is not pinned to be at least 2.20.0, when it is installed dynamically during the installation of vLLM the installer might resolve it to a version that is not compatible with vLLM because of a pyarrow incompatibility.

This PR reinstated the datasets dependency and adds a comment in pyproject.