### PR TITLE
fix(cli): ensure we find space ids in delete operation

### DIFF
--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1246,7 +1246,8 @@ class SQLResourceStore(ResourceStore):
                             "WHERE identifier = ("
                             "   SELECT subject_identifier"
                             "   FROM resource_relationships"
-                            "   WHERE object_identifier=:operation_identifier)"
+                            "   WHERE object_identifier=:operation_identifier"
+                            "   AND subject_identifier LIKE 'space-%')"
                         ).bindparams(operation_identifier=identifier)
                     ).first()[0]
 


### PR DESCRIPTION
When targeting operations that used actuator configurations, we might find their identifiers first.

Fixes #810