### PR TITLE
refactor(cli): update --use-latest to use db instead of local information

### DIFF
--- a/.cursor/skills/examining-discovery-spaces/SKILL.md
+++ b/.cursor/skills/examining-discovery-spaces/SKILL.md
@@ -93,8 +93,6 @@ The output produced by '-o/--output' can be very large e.g. from "show entities"
 Use the `--output-file` flag with the name of the file where to save the output
 and, when inspecting these files:
 
-When inspecting these files:
-
 - Use wc to count the file size first before using head/tail/cat etc. on it.
 - Use head -n1 to get column headers, this will not be large
 - Avoid head -n > 1 unless you have a specific need e.g. checking if file is

--- a/.cursor/skills/resource-yaml-creation/SKILL.md
+++ b/.cursor/skills/resource-yaml-creation/SKILL.md
@@ -43,9 +43,7 @@ placeholders and resolve them at creation time — do not hard-code IDs.
 ### --use-latest
 
 Queries the current context's metastore to find the most recently created
-resource of the given type. It is context-aware: switching to a different
-context and using --use-latest will find the most recent resource in that
-context's database, not the previously active one.
+resource of the given type.
 
 ```bash
 # Create space, then operation that references it — no manual ID copy

--- a/.cursor/skills/resource-yaml-creation/SKILL.md
+++ b/.cursor/skills/resource-yaml-creation/SKILL.md
@@ -42,19 +42,16 @@ placeholders and resolve them at creation time — do not hard-code IDs.
 
 ### --use-latest
 
-Fills in the most recently created resource ID of the given type.
+Queries the current context's metastore to find the most recently created
+resource of the given type. It is context-aware: switching to a different
+context and using --use-latest will find the most recent resource in that
+context's database, not the previously active one.
 
 ```bash
 # Create space, then operation that references it — no manual ID copy
 uv run ado create space -f space.yaml
 uv run ado create operation -f operation.yaml --use-latest space
 ```
-
-> **Context scoping**: `--use-latest` resolves relative to the _execution
-> context_, not the project. On a laptop, it finds the last resource created
-> locally. When launched with `--remote`, it finds the last resource created on
-> the remote cluster. Keep this in mind when reusing resources across
-> environments.
 
 ### --with
 
@@ -123,8 +120,8 @@ uv run ado template actuatorconfiguration --actuator-identifier my_actuator
 
 ### DiscoverySpace
 
-See [formulate-discovery-problem](../formulate-discovery-problem/SKILL.md)
-for further details on creating discovery spaces.
+See [formulate-discovery-problem](../formulate-discovery-problem/SKILL.md) for
+further details on creating discovery spaces.
 
 **Before creating** (ado create space), check if a matching space already
 exists:

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -33,14 +33,14 @@ uv run ado [COMMAND] [SUBCOMMAND1] [SUBCOMMAND2] --help
 
 These plausible-sounding commands do not exist in ado. Do not write them:
 
-| ❌ Does not exist | ✅ Correct equivalent |
-| --------- | -------------------- |
-| `ado run` | `ado create operation -f op.yaml` |
-| `ado start` | `ado create operation -f op.yaml` |
-| `ado execute` | `ado create operation -f op.yaml` |
-| `ado launch` | `ado create operation -f op.yaml` |
-| `ado list` | `ado get spaces` / `ado get operations` |
-| `ado status` | `ado show details space SPACE_ID` |
+| ❌ Does not exist | ✅ Correct equivalent                   |
+| ----------------- | --------------------------------------- |
+| `ado run`         | `ado create operation -f op.yaml`       |
+| `ado start`       | `ado create operation -f op.yaml`       |
+| `ado execute`     | `ado create operation -f op.yaml`       |
+| `ado launch`      | `ado create operation -f op.yaml`       |
+| `ado list`        | `ado get spaces` / `ado get operations` |
+| `ado status`      | `ado show details space SPACE_ID`       |
 
 **Key principle**: `ado create operation` both _defines_ and _starts_ the
 operation in a single command. There is no separate "run" step.
@@ -175,7 +175,10 @@ uv run ado show results operation op-123
 
 ### --use-latest
 
-Uses the ID of the most recently created resource of the relevant type.
+Queries the current context's metastore to find the most recently created
+resource of the given type. It is context-aware: switching to a different
+context and using --use-latest will find the most recent resource in that
+context's database, not the previously active one.
 
 **Without --use-latest**:
 
@@ -199,8 +202,7 @@ uv run ado create space -f space.yaml
 uv run ado create operation -f operation.yaml --use-latest
 ```
 
-The `--use-latest` flag automatically fills in the space ID from the previous
-`ado create space` command.
+The `--use-latest` flag automatically fills in the latest space ID.
 
 ### --set
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -176,9 +176,7 @@ uv run ado show results operation op-123
 ### --use-latest
 
 Queries the current context's metastore to find the most recently created
-resource of the given type. It is context-aware: switching to a different
-context and using --use-latest will find the most recent resource in that
-context's database, not the previously active one.
+resource of the given type.
 
 **Without --use-latest**:
 

--- a/examples/ml-multi-cloud/EXAMPLE_SIMPLE.md
+++ b/examples/ml-multi-cloud/EXAMPLE_SIMPLE.md
@@ -537,8 +537,8 @@ will give you a summary of what has been measured.
 
 > [!NOTE]
 >
-> If you want to run these commands with the latest space created use the
-> `--use-latest` flag as above
+> If you want to run these commands against the most recent space in the current
+> context, use the `--use-latest` flag as above.
 
 ### Resource provenance
 

--- a/examples/optimization_test_functions/README.md
+++ b/examples/optimization_test_functions/README.md
@@ -182,8 +182,8 @@ ado create space -f space.yaml --use-default-sample-store
 This will output a `discoveryspace` id you can use to run an optimization
 operation.
 
-Assuming you did not modify `space.yaml`, running
-`ado describe space --use-latest` will output (identifiers will
+Assuming the space you just created is the most recent space in the current
+context, running `ado describe space --use-latest` will output (identifiers will
 be different):
 
 ```terminaloutput

--- a/orchestrator/cli/commands/create.py
+++ b/orchestrator/cli/commands/create.py
@@ -264,8 +264,6 @@ def create_resource(
     except UnknownExperimentError as e:
         handle_unknown_experiment_error(error=e)
 
-    ado_configuration.store()
-
 
 def register_create_command(app: typer.Typer) -> None:
     app.command(

--- a/orchestrator/cli/commands/describe.py
+++ b/orchestrator/cli/commands/describe.py
@@ -136,7 +136,7 @@ def describe_resource(
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,
             resource_type=resource_type.value,
-            ado_configuration=ado_configuration,
+            project_context=ado_configuration.project_context,
         )
 
     if not (resource_id or resource_configuration) or (

--- a/orchestrator/cli/commands/show_details.py
+++ b/orchestrator/cli/commands/show_details.py
@@ -107,7 +107,7 @@ def show_details_for_resources(
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,
             resource_type=resource_type.value,
-            ado_configuration=ado_configuration,
+            project_context=ado_configuration.project_context,
         )
 
     parameters = AdoShowDetailsCommandParameters(

--- a/orchestrator/cli/commands/show_entities.py
+++ b/orchestrator/cli/commands/show_entities.py
@@ -191,7 +191,7 @@ def show_entities_for_resources(
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,
             resource_type=resource_type.value,
-            ado_configuration=ado_configuration,
+            project_context=ado_configuration.project_context,
         )
 
     if not (resource_id or resource_configuration) or (

--- a/orchestrator/cli/commands/show_related.py
+++ b/orchestrator/cli/commands/show_related.py
@@ -102,7 +102,7 @@ def show_related_for_resources(
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,
             resource_type=resource_type.value,
-            ado_configuration=ado_configuration,
+            project_context=ado_configuration.project_context,
         )
 
     parameters = AdoShowRelatedCommandParameters(

--- a/orchestrator/cli/commands/show_requests.py
+++ b/orchestrator/cli/commands/show_requests.py
@@ -142,7 +142,7 @@ def show_requests_for_resources(
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,
             resource_type=resource_type.value,
-            ado_configuration=ado_configuration,
+            project_context=ado_configuration.project_context,
         )
 
     parameters = AdoShowRequestsCommandParameters(

--- a/orchestrator/cli/commands/show_results.py
+++ b/orchestrator/cli/commands/show_results.py
@@ -137,7 +137,7 @@ def show_results_for_resources(
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,
             resource_type=resource_type.value,
-            ado_configuration=ado_configuration,
+            project_context=ado_configuration.project_context,
         )
 
     parameters = AdoShowResultsCommandParameters(

--- a/orchestrator/cli/commands/show_summary.py
+++ b/orchestrator/cli/commands/show_summary.py
@@ -6,6 +6,7 @@ import typing
 from typing import Annotated
 
 import typer
+from rich.status import Status
 
 from orchestrator.cli.models.choice import HiddenPluralChoice
 from orchestrator.cli.models.parameters import AdoShowSummaryCommandParameters
@@ -16,10 +17,12 @@ from orchestrator.cli.models.types import (
 from orchestrator.cli.resources.discovery_space.show_summary import (
     show_discovery_space_summary,
 )
+from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.input.parsers import (
     parse_key_value_pairs,
 )
 from orchestrator.cli.utils.output.prints import (
+    ADO_SPINNER_QUERYING_DB,
     ERROR,
     console_print,
     latest_identifier_for_resource_not_found,
@@ -201,7 +204,15 @@ def show_summary_for_resources(
         raise typer.Exit(1)
 
     resource_kind = CoreResourceKinds(resource_type.value)
-    resource_id = ado_configuration.latest_resource_ids.get(resource_kind)
+
+    # Fetch the latest resource ID from the database
+    sql_store = get_sql_store(ado_configuration.project_context)
+    with Status(ADO_SPINNER_QUERYING_DB):
+        latest_ids = sql_store.get_latest_resource_identifiers_of_kinds(
+            kinds=[resource_kind]
+        )
+
+    resource_id = latest_ids.get(resource_kind)
     if not resource_id:
         console_print(
             latest_identifier_for_resource_not_found(

--- a/orchestrator/cli/core/config.py
+++ b/orchestrator/cli/core/config.py
@@ -19,7 +19,6 @@ from orchestrator.cli.utils.output.prints import (
     green,
     magenta,
 )
-from orchestrator.core import CoreResourceKinds
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.utilities.location import SQLiteStoreConfiguration
 
@@ -35,7 +34,21 @@ class AdoConfiguration(pydantic.BaseModel):
     _app_dir: Path = Path(typer.get_app_dir(ADO_APP_NAME))
     _project_context: ProjectContext | None = None
     active_context: str | None = None
-    latest_resource_ids: dict[CoreResourceKinds, str] = {}
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def remove_latest_resource_ids(cls, data: dict) -> dict:
+        """Before validator to handle backwards compatibility with old config files.
+
+        This validator strips the deprecated 'latest_resource_ids' field if present
+        before validation occurs. This ensures old config files can be loaded without
+        errors.
+        """
+        # Strip deprecated field before validation
+        if isinstance(data, dict) and "latest_resource_ids" in data:
+            data.pop("latest_resource_ids")
+
+        return data
 
     @classmethod
     def load(
@@ -103,6 +116,7 @@ class AdoConfiguration(pydantic.BaseModel):
 
             ado_config._project_context = project_context
             ado_config.active_context = project_context.project
+            ado_config.store()
             return ado_config
 
         # At this point we don't have a context_path to load from.

--- a/orchestrator/cli/resources/actuator_configuration/create.py
+++ b/orchestrator/cli/resources/actuator_configuration/create.py
@@ -17,7 +17,6 @@ from orchestrator.cli.utils.output.prints import (
     magenta,
 )
 from orchestrator.cli.utils.pydantic.updaters import override_values_in_pydantic_model
-from orchestrator.core import CoreResourceKinds
 from orchestrator.core.actuatorconfiguration.config import ActuatorConfiguration
 from orchestrator.core.actuatorconfiguration.resource import (
     ActuatorConfigurationResource,
@@ -54,12 +53,6 @@ def create_actuator_configuration(parameters: AdoCreateCommandParameters) -> str
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
     with Status(ADO_SPINNER_SAVING_TO_DB):
         sql.addResource(resource_to_be_created)
-
-    # Save the identifier of the resource we created
-    # for reuse
-    parameters.ado_configuration.latest_resource_ids[
-        CoreResourceKinds.ACTUATORCONFIGURATION
-    ] = resource_to_be_created.identifier
 
     console_print(
         f"{SUCCESS}Created actuator configuration with identifier "

--- a/orchestrator/cli/resources/discovery_space/create.py
+++ b/orchestrator/cli/resources/discovery_space/create.py
@@ -98,13 +98,15 @@ def create_discovery_space(parameters: AdoCreateCommandParameters) -> str | None
     elif (
         parameters.use_latest and CoreResourceKinds.SAMPLESTORE in parameters.use_latest
     ):
+        sql_store = get_sql_store(parameters.ado_configuration.project_context)
 
-        latest_recorded_sample_store = (
-            parameters.ado_configuration.latest_resource_ids.get(
-                CoreResourceKinds.SAMPLESTORE
-            )
+        # Query for single kind (only SAMPLESTORE needed here)
+        latest_ids = sql_store.get_latest_resource_identifiers_of_kinds(
+            kinds=[CoreResourceKinds.SAMPLESTORE]
         )
-        if not latest_recorded_sample_store:
+        latest_sample_store = latest_ids.get(CoreResourceKinds.SAMPLESTORE)
+
+        if not latest_sample_store:
             console_print(
                 latest_identifier_for_resource_not_found(CoreResourceKinds.SAMPLESTORE),
                 stderr=True,
@@ -115,11 +117,11 @@ def create_discovery_space(parameters: AdoCreateCommandParameters) -> str | None
             value_in_configuration_replaced_with_latest_identifier_for_resource(
                 reused_resource_kind=CoreResourceKinds.SAMPLESTORE,
                 target_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
-                replacement_identifier=latest_recorded_sample_store,
+                replacement_identifier=latest_sample_store,
             ),
             stderr=True,
         )
-        space_configuration.sampleStoreIdentifier = latest_recorded_sample_store
+        space_configuration.sampleStoreIdentifier = latest_sample_store
 
     elif parameters.new_sample_store:
 
@@ -172,9 +174,6 @@ def create_discovery_space(parameters: AdoCreateCommandParameters) -> str | None
             )
 
         space_configuration.sampleStoreIdentifier = sample_store_resource.identifier
-        parameters.ado_configuration.latest_resource_ids[
-            CoreResourceKinds.SAMPLESTORE
-        ] = sample_store_resource.identifier
 
     elif parameters.use_default_sample_store:
         space_configuration.sampleStoreIdentifier = "default"
@@ -255,12 +254,6 @@ def create_discovery_space(parameters: AdoCreateCommandParameters) -> str | None
 
         status.update(ADO_SPINNER_SAVING_TO_DB)
         space.saveSpace()
-
-    # Save the identifier of the resource we created
-    # for reuse
-    parameters.ado_configuration.latest_resource_ids[
-        CoreResourceKinds.DISCOVERYSPACE
-    ] = space.uri
 
     console_print(
         f"{SUCCESS}Created space with identifier: {magenta(space.uri)}", stderr=True

--- a/orchestrator/cli/resources/operation/create.py
+++ b/orchestrator/cli/resources/operation/create.py
@@ -35,16 +35,6 @@ from orchestrator.core.operation.resource import (
 )
 
 
-def _save_operation_identifier(
-    parameters: AdoCreateCommandParameters, operation_identifier: str
-) -> None:
-    """Save operation identifier to configuration for reuse with --use-latest."""
-    parameters.ado_configuration.latest_resource_ids[CoreResourceKinds.OPERATION] = (
-        operation_identifier
-    )
-    parameters.ado_configuration.store()
-
-
 def create_operation(parameters: AdoCreateCommandParameters) -> str | None:
 
     import orchestrator.modules.operators.orchestrate
@@ -165,7 +155,6 @@ def create_operation(parameters: AdoCreateCommandParameters) -> str | None:
         console_print(f"{ERROR}Failed to create operation:\n\t{e}", stderr=True)
         raise typer.Exit(1) from e
     except InterruptedOperationError as e:
-        _save_operation_identifier(parameters, e.operation_identifier)
         console_print(
             f"{ERROR}Created operation with identifier {magenta(e.operation_identifier)} "
             "but it was interrupted.",
@@ -179,7 +168,6 @@ def create_operation(parameters: AdoCreateCommandParameters) -> str | None:
         )
         raise typer.Exit(3) from e
     except OperationException as e:
-        _save_operation_identifier(parameters, e.operation.identifier)
         console_print(
             f"{ERROR}An unexpected error occurred. "
             f"Operation {magenta(e.operation.identifier)} did not run successfully:\n\n"
@@ -194,9 +182,6 @@ def create_operation(parameters: AdoCreateCommandParameters) -> str | None:
         )
         raise
 
-    # Save the identifier of the resource we created for reuse
-    _save_operation_identifier(parameters, operation_output.operation.identifier)
-
     return output_operation_result(result=operation_output)
 
 
@@ -204,55 +189,44 @@ def reuse_requested_latest_identifiers(
     resource_configuration: DiscoveryOperationResourceConfiguration,
     parameters: AdoCreateCommandParameters,
 ) -> None:
+    """Fetch latest resource identifiers from database in a single batch query."""
+    from orchestrator.cli.utils.generic.wrappers import get_sql_store
 
-    if CoreResourceKinds.ACTUATORCONFIGURATION in parameters.use_latest:
-        latest_recorded_actuator_configuration = (
-            parameters.ado_configuration.latest_resource_ids.get(
-                CoreResourceKinds.ACTUATORCONFIGURATION
-            )
-        )
+    sql_store = get_sql_store(parameters.ado_configuration.project_context)
 
-        if not latest_recorded_actuator_configuration:
+    # Batch query for all requested kinds at once
+    latest_ids = sql_store.get_latest_resource_identifiers_of_kinds(
+        kinds=parameters.use_latest
+    )
+
+    # Map resource kinds to their configuration fields
+    resource_field_mapping = {
+        CoreResourceKinds.ACTUATORCONFIGURATION: "actuatorConfigurationIdentifiers",
+        CoreResourceKinds.DISCOVERYSPACE: "spaces",
+    }
+
+    # Handle each requested resource kind
+    for resource_kind in parameters.use_latest:
+        if resource_kind not in resource_field_mapping:
+            continue
+
+        latest_id = latest_ids.get(resource_kind)
+        if not latest_id:
             console_print(
-                latest_identifier_for_resource_not_found(
-                    CoreResourceKinds.ACTUATORCONFIGURATION
-                ),
+                latest_identifier_for_resource_not_found(resource_kind),
                 stderr=True,
             )
             raise typer.Exit(1)
 
-        resource_configuration.actuatorConfigurationIdentifiers = [
-            latest_recorded_actuator_configuration
-        ]
+        # Set the appropriate field on the configuration
+        field_name = resource_field_mapping[resource_kind]
+        setattr(resource_configuration, field_name, [latest_id])
 
         console_print(
             value_in_configuration_replaced_with_latest_identifier_for_resource(
-                reused_resource_kind=CoreResourceKinds.ACTUATORCONFIGURATION,
+                reused_resource_kind=resource_kind,
                 target_resource_kind=CoreResourceKinds.OPERATION,
-                replacement_identifier=latest_recorded_actuator_configuration,
-            ),
-            stderr=True,
-        )
-
-    if CoreResourceKinds.DISCOVERYSPACE in parameters.use_latest:
-        latest_recorded_space = parameters.ado_configuration.latest_resource_ids.get(
-            CoreResourceKinds.DISCOVERYSPACE
-        )
-        if not latest_recorded_space:
-            console_print(
-                latest_identifier_for_resource_not_found(
-                    CoreResourceKinds.DISCOVERYSPACE
-                ),
-                stderr=True,
-            )
-            raise typer.Exit(1)
-
-        resource_configuration.spaces = [latest_recorded_space]
-        console_print(
-            value_in_configuration_replaced_with_latest_identifier_for_resource(
-                reused_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
-                target_resource_kind=CoreResourceKinds.OPERATION,
-                replacement_identifier=latest_recorded_space,
+                replacement_identifier=latest_id,
             ),
             stderr=True,
         )

--- a/orchestrator/cli/resources/sample_store/create.py
+++ b/orchestrator/cli/resources/sample_store/create.py
@@ -19,7 +19,6 @@ from orchestrator.cli.utils.output.prints import (
     magenta,
 )
 from orchestrator.cli.utils.pydantic.updaters import override_values_in_pydantic_model
-from orchestrator.core import CoreResourceKinds
 from orchestrator.core.samplestore.config import (
     SampleStoreConfiguration,
     SampleStoreModuleConf,
@@ -83,12 +82,6 @@ def create_sample_store(parameters: AdoCreateCommandParameters) -> str:
             sample_store_configuration,
             sql,
         )
-
-    # Save the identifier of the resource we created
-    # for reuse
-    parameters.ado_configuration.latest_resource_ids[CoreResourceKinds.SAMPLESTORE] = (
-        sample_store.identifier
-    )
 
     console_print(
         f"{SUCCESS}Created sample store with identifier {magenta(sample_store.identifier)}",

--- a/orchestrator/cli/utils/generic/common.py
+++ b/orchestrator/cli/utils/generic/common.py
@@ -3,8 +3,8 @@
 
 import typer
 
-from orchestrator.cli.core.config import AdoConfiguration
 from orchestrator.cli.utils.output.prints import (
+    ADO_SPINNER_QUERYING_DB,
     WARN,
     console_print,
     latest_identifier_for_resource_not_found,
@@ -12,22 +12,25 @@ from orchestrator.cli.utils.output.prints import (
     using_latest_identifier_for_resource,
 )
 from orchestrator.core import CoreResourceKinds
+from orchestrator.metastore.project import ProjectContext
 
 
 def get_effective_resource_id(
-    explicit_resource_id: str, resource_type: str, ado_configuration: AdoConfiguration
+    explicit_resource_id: str | None,
+    resource_type: str,
+    project_context: ProjectContext,
 ) -> str:
     """
     Determines the effective resource ID to use, prioritizing an explicitly provided ID.
 
-    If an explicit resource ID is provided, it takes precedence over any configuration or flags.
-    Otherwise, the method attempts to retrieve the latest resource ID from the ADO configuration
-    based on the resource type. If no ID is found, the program exits with an error.
+    If an explicit resource ID is provided, it takes precedence over the latest resource IDs.
+    Otherwise, the method queries the database to retrieve the latest resource ID for the
+    given resource type. If no ID is found, the program exits with an error.
 
     Args:
-        explicit_resource_id (str): The resource ID explicitly provided by the user.
+        explicit_resource_id (str | None): The resource ID explicitly provided by the user.
         resource_type (str): The type of resource (i.e., a cli resource type).
-        ado_configuration (AdoConfiguration): Configuration object containing latest resource IDs.
+        project_context (ProjectContext): The project context for database access.
 
     Returns:
         str: The effective resource ID to use.
@@ -35,16 +38,27 @@ def get_effective_resource_id(
     Raises:
         typer.Exit: If no latest resource ID is found for the given resource type.
     """
+    from rich.status import Status
+
+    from orchestrator.cli.utils.generic.wrappers import get_sql_store
 
     if explicit_resource_id:
         console_print(
-            f"{WARN}explicitly specified resource ids take precedence over the --use-latest flag\n\t"
-            f"The command will show details for {resource_type} {magenta(explicit_resource_id)}"
+            f"{WARN}explicitly specified resource ids take precedence over the --use-latest flag\n"
+            f"\tThis command will use {resource_type} identifier {magenta(explicit_resource_id)}"
         )
         return explicit_resource_id
 
     resource_kind = CoreResourceKinds(resource_type)
-    resource_id = ado_configuration.latest_resource_ids.get(resource_kind)
+
+    # Query database for latest resource ID
+    sql_store = get_sql_store(project_context)
+    with Status(ADO_SPINNER_QUERYING_DB):
+        latest_ids = sql_store.get_latest_resource_identifiers_of_kinds(
+            kinds=[resource_kind]
+        )
+
+    resource_id = latest_ids.get(resource_kind)
     if not resource_id:
         console_print(
             latest_identifier_for_resource_not_found(

--- a/orchestrator/cli/utils/generic/wrappers.py
+++ b/orchestrator/cli/utils/generic/wrappers.py
@@ -13,17 +13,18 @@ from orchestrator.cli.utils.output.prints import (
 from orchestrator.metastore.project import ProjectContext
 
 if typing.TYPE_CHECKING:
-    from orchestrator.metastore.sqlstore import SQLStore
+    from orchestrator.metastore.sqlstore import SQLResourceStore
 
 
-def get_sql_store(project_context: ProjectContext) -> "SQLStore":
+def get_sql_store(project_context: ProjectContext) -> "SQLResourceStore":
     from sqlalchemy.exc import OperationalError
 
     from orchestrator.metastore.sqlstore import SQLStore
 
     with Status(ADO_SPINNER_CONNECTING_TO_DB) as status:
         try:
-            return SQLStore(project_context=project_context)
+            # SQLStore.__new__ returns SQLResourceStore
+            return SQLStore(project_context=project_context)  # type: ignore[abstract]
         except OperationalError as e:
             status.stop()
             console_print(

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -430,3 +430,49 @@ def upsert_entities(
             """)  # noqa: S608 - sample_store_name is not untrusted
 
     return query
+
+
+def resource_select_latest_by_kinds(
+    kinds: list[str],
+    dialect: Literal["mysql", "sqlite"] = "mysql",
+) -> sqlalchemy.TextClause:
+    """Generate SQL to fetch the most recently created resource for each specified kind.
+
+    Uses a window function (ROW_NUMBER) to rank resources by creation time within
+    each kind, then filters to only the most recent (rank=1) for each kind.
+
+    Args:
+        kinds: List of resource kind values to query
+        dialect: SQL dialect ("mysql" or "sqlite") - unused, kept for API consistency
+
+    Returns:
+        Bound SQLAlchemy TextClause with kinds parameter
+
+    Example result:
+        identifier                          | kind              | created
+        ------------------------------------|-------------------|-------------------------
+        space-f3660b-default                | discoveryspace    | 2026-04-13T08:00:00.000Z
+        randomwalk-1.7.0-c47119             | operation         | 2026-04-13T09:00:00.000Z
+    """
+    if not kinds:
+        raise ValueError("kinds list cannot be empty")
+
+    # Both MySQL and SQLite support this syntax
+    # Use parameter binding with expanding=True for the IN clause
+    return sqlalchemy.text("""
+        WITH ranked_resources AS (
+            SELECT
+                identifier,
+                kind,
+                data->>'$.created' as created,
+                ROW_NUMBER() OVER (
+                    PARTITION BY kind
+                    ORDER BY data->>'$.created' DESC
+                ) as rn
+            FROM resources
+            WHERE kind IN :kinds
+        )
+        SELECT identifier, kind, created
+        FROM ranked_resources
+        WHERE rn = 1
+    """).bindparams(sqlalchemy.bindparam("kinds", value=kinds, expanding=True))

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -643,6 +643,71 @@ class SQLResourceStore(ResourceStore):
 
         return output_df[columns]
 
+    def get_latest_resource_identifiers_of_kinds(
+        self,
+        kinds: list[CoreResourceKinds],
+    ) -> dict[CoreResourceKinds, str]:
+        """Retrieve the identifiers of the most recently created resources for multiple kinds.
+
+        This method executes a single database query to fetch the latest resource
+        identifier for each specified kind, minimizing database round-trips.
+
+        Args:
+            kinds: List of resource kinds to query
+
+        Returns:
+            Dictionary mapping each kind to its most recent resource identifier.
+            Kinds with no resources are omitted from the result.
+
+        Raises:
+            ValueError: If any supplied kind is not a known CoreResourceKinds value
+
+        Example:
+            >>> store.get_latest_resource_identifiers_of_kinds([
+            ...     CoreResourceKinds.DISCOVERYSPACE,
+            ...     CoreResourceKinds.ACTUATORCONFIGURATION
+            ... ])
+            {
+                CoreResourceKinds.DISCOVERYSPACE: "space-abc123",
+                CoreResourceKinds.ACTUATORCONFIGURATION: "actconf-def456"
+            }
+        """
+        if not kinds:
+            return {}
+
+        # Validate all kinds are CoreResourceKinds instances
+        invalid_kinds = [
+            kind for kind in kinds if not isinstance(kind, CoreResourceKinds)
+        ]
+
+        if invalid_kinds:
+            raise ValueError(
+                f"All kinds must be CoreResourceKinds instances. Invalid: {invalid_kinds}"
+            )
+
+        # Convert CoreResourceKinds to string values for SQL query
+        kind_values = [kind.value for kind in kinds]
+
+        # Generate and execute the SQL query (returns bound TextClause)
+        query = orchestrator.metastore.sql.statements.resource_select_latest_by_kinds(
+            kinds=kind_values,
+            dialect=self.engine.dialect.name,
+        )
+
+        with self.engine.connect() as connectable:
+            result = connectable.execute(query)
+            rows = result.fetchall()
+
+        # Build dictionary mapping kind to identifier
+        latest_ids: dict[CoreResourceKinds, str] = {}
+        for row in rows:
+            identifier, kind_str, _created = row
+            # Convert string kind back to CoreResourceKinds enum
+            kind_enum = CoreResourceKinds(kind_str)
+            latest_ids[kind_enum] = identifier
+
+        return latest_ids
+
     def resourceTable(self) -> "pd.DataFrame":
         import pandas as pd
 

--- a/tests/ado/create/test_ado_create_discovery_space.py
+++ b/tests/ado/create/test_ado_create_discovery_space.py
@@ -12,6 +12,7 @@ from orchestrator.core.discoveryspace.config import DiscoverySpaceConfiguration
 from orchestrator.core.samplestore.sql import SQLSampleStore
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.utilities.output import pydantic_model_as_yaml
+from tests.conftest import requires_sqlite_3_38
 
 
 def test_create_discovery_space_dry_run_success(tmp_path: pathlib.Path) -> None:
@@ -206,6 +207,7 @@ def test_create_discovery_space_success_new_sample_store(
     assert result.output.startswith(expected_output)
 
 
+@requires_sqlite_3_38
 def test_create_discovery_space_success_with_latest_samplestore(
     tmp_path: pathlib.Path,
     valid_ado_project_context: ProjectContext,

--- a/tests/ado/create/test_ado_create_operation.py
+++ b/tests/ado/create/test_ado_create_operation.py
@@ -13,6 +13,7 @@ from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.core.operation.config import DiscoveryOperationResourceConfiguration
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.utilities.output import pydantic_model_as_yaml
+from tests.conftest import requires_sqlite_3_38
 
 
 @pytest.fixture(
@@ -208,6 +209,7 @@ def test_create_operation_success_with_discovery_space(
     assert result.exit_code == 0, result.output
 
 
+@requires_sqlite_3_38
 def test_create_ml_multi_cloud_operation_success_lhc_sampler(
     tmp_path: pathlib.Path,
     ml_multi_cloud_sample_store_configuration_file: pathlib.Path,

--- a/tests/ado/delete/test_ado_delete_operation.py
+++ b/tests/ado/delete/test_ado_delete_operation.py
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 import pathlib
-import sqlite3
 from collections.abc import Callable
 
-import pytest
 from typer.testing import CliRunner
 
 from orchestrator.cli.core.cli import app as ado
@@ -18,15 +16,10 @@ from orchestrator.schema.request import (
     MeasurementRequestStateEnum,
     ReplayedMeasurement,
 )
+from tests.conftest import requires_sqlite_3_38
 
-sqlite3_version = sqlite3.sqlite_version_info
 
-
-# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-# ref: https://sqlite.org/json1.html#jptr
-@pytest.mark.skipif(
-    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
-)
+@requires_sqlite_3_38
 def test_delete_ml_multi_cloud_operation(
     tmp_path: pathlib.Path,
     valid_ado_project_context: ProjectContext,

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -3,11 +3,9 @@
 import importlib.metadata
 import os
 import pathlib
-import sqlite3
 from collections.abc import Callable
 
 import pandas as pd
-import pytest
 import rich.box
 import yaml
 from testcontainers.mysql import MySqlContainer
@@ -19,18 +17,13 @@ from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.metastore.sqlstore import SQLStore
 from orchestrator.utilities.rich import dataframe_to_rich_table, render_to_string
+from tests.conftest import requires_sqlite_3_38
 from tests.utilities.cli_rendering import (
     render_ado_resources_to_cli_output,
 )
 
-sqlite3_version = sqlite3.sqlite_version_info
 
-
-# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-# ref: https://sqlite.org/json1.html#jptr
-@pytest.mark.skipif(
-    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
-)
+@requires_sqlite_3_38
 def test_space_exists(
     tmp_path: pathlib.Path,
     mysql_test_instance: MySqlContainer,
@@ -82,11 +75,7 @@ def test_get_robotic_lab_actuator() -> None:
         assert rendered_output in result.output
 
 
-# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-# ref: https://sqlite.org/json1.html#jptr
-@pytest.mark.skipif(
-    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
-)
+@requires_sqlite_3_38
 def test_field_querying(
     tmp_path: pathlib.Path,
     mysql_test_instance: MySqlContainer,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
+import sqlite3
 import uuid
 from collections.abc import Callable, Generator
 
@@ -33,6 +34,13 @@ from .fixtures.schema.results import *
 # This import is required to be run after the others,
 # or we will get create_sample_store fixture not found.
 from .fixtures.samplestore.crud_from_configurations import *
+
+# SQLite version check for tests requiring JSON operators (-> and ->>)
+# ref: https://sqlite.org/json1.html#jptr
+sqlite3_version = sqlite3.sqlite_version_info
+requires_sqlite_3_38 = pytest.mark.skipif(
+    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/test_legacy_migrators.py
+++ b/tests/core/test_legacy_migrators.py
@@ -3,7 +3,6 @@
 
 """Integration tests for legacy migrators with pydantic models and upgrade process"""
 
-import sqlite3
 from collections.abc import Callable
 from pathlib import Path
 
@@ -13,8 +12,7 @@ import pytest
 from orchestrator.core.legacy.registry import LegacyMigratorRegistry, legacy_migrator
 from orchestrator.core.resources import CoreResourceKinds
 from orchestrator.metastore.project import ProjectContext
-
-sqlite3_version = sqlite3.sqlite_version_info
+from tests.conftest import requires_sqlite_3_38
 
 
 class TestLegacyMigratorWithPydantic:
@@ -352,12 +350,7 @@ class TestUpgradeHandlerIntegration:
             "unknown" in result.output.lower() or "not found" in result.output.lower()
         )
 
-    # AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-    # ref: https://sqlite.org/json1.html#jptr
-    @pytest.mark.skipif(
-        sqlite3_version < (3, 38, 0),
-        reason="SQLite version 3.38.0 or higher is required",
-    )
+    @requires_sqlite_3_38
     def test_upgrade_auto_resolves_migrator_dependencies(
         self,
         legacy_migrators_loaded: None,

--- a/tests/fixtures/core/space.py
+++ b/tests/fixtures/core/space.py
@@ -25,6 +25,8 @@ def random_space_resource_from_file(
     def _random_space_resource_from_file(
         sample_store_id: str | None = None,
     ) -> DiscoverySpaceResource:
+        import datetime
+
         file = pathlib.Path("tests/resources/space/discoveryspace_resource.json")
         random_resource_id = random_identifier()
         if not sample_store_id:
@@ -36,6 +38,7 @@ def random_space_resource_from_file(
         # Final touch-ups
         space.identifier = random_resource_id
         space.config.sampleStoreIdentifier = sample_store_id
+        space.created = datetime.datetime.now(datetime.timezone.utc)
         return space
 
     return _random_space_resource_from_file

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -1,7 +1,6 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 import re
-import sqlite3
 import uuid
 from collections.abc import Callable
 
@@ -30,6 +29,7 @@ from orchestrator.core.resources import (
 )
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.metastore.sqlstore import SQLStore
+from tests.conftest import requires_sqlite_3_38
 
 # Methods to test:
 # READ
@@ -41,14 +41,6 @@ from orchestrator.metastore.sqlstore import SQLStore
 
 
 # Test for new resource store
-
-sqlite3_version = sqlite3.sqlite_version_info
-
-# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-# ref: https://sqlite.org/json1.html#jptr
-requires_sqlite_3_38 = pytest.mark.skipif(
-    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
-)
 
 
 @requires_sqlite_3_38

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -44,16 +44,18 @@ from orchestrator.metastore.sqlstore import SQLStore
 
 sqlite3_version = sqlite3.sqlite_version_info
 
+# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
+# ref: https://sqlite.org/json1.html#jptr
+requires_sqlite_3_38 = pytest.mark.skipif(
+    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
+)
 
+
+@requires_sqlite_3_38
 def test_get_resources_of_kind(
     resource_store: SQLStore, resource_type: CoreResourceKinds
 ) -> None:
     """Test can we get resource of the given kind from the resource_store"""
-
-    # AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-    # ref: https://sqlite.org/json1.html#jptr
-    if resource_store.engine.dialect.name == "sqlite" and sqlite3_version < (3, 38, 0):
-        pytest.xfail("SQLite version 3.38.0 or higher is required")
 
     resources = resource_store.getResourcesOfKind(resource_type.value)
     for resource in resources.values():
@@ -65,19 +67,12 @@ def test_get_resources_of_kind(
     assert len(expected_ids.IDENTIFIER) == len(resources.keys())
 
 
+@requires_sqlite_3_38
 def test_get_resources_and_get_resource_identifiers_of_kind(
     sql_store_with_resources_preloaded: SQLStore, resource_type: CoreResourceKinds
 ) -> None:
     """
     Test can we get resource of the given kind from the resource_store of type new"""
-
-    # AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-    # ref: https://sqlite.org/json1.html#jptr
-    if (
-        sql_store_with_resources_preloaded.engine.dialect.name == "sqlite"
-        and sqlite3_version < (3, 38, 0)
-    ):
-        pytest.xfail("SQLite version 3.38.0 or higher is required")
 
     x = sql_store_with_resources_preloaded.getResourceIdentifiersOfKind(
         resource_type.value
@@ -102,6 +97,7 @@ def test_get_resources_and_get_resource_identifiers_of_kind(
         assert len(objects) > 0
 
 
+@requires_sqlite_3_38
 def test_get_related_resource_identifiers(
     sql_store_with_resources_preloaded: SQLStore, resource_type: CoreResourceKinds
 ) -> None:
@@ -109,14 +105,6 @@ def test_get_related_resource_identifiers(
     Tests getting the identifiers of related resources
 
     """
-
-    # AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-    # ref: https://sqlite.org/json1.html#jptr
-    if (
-        sql_store_with_resources_preloaded.engine.dialect.name == "sqlite"
-        and sqlite3_version < (3, 38, 0)
-    ):
-        pytest.xfail("SQLite version 3.38.0 or higher is required")
 
     identifiers = sql_store_with_resources_preloaded.getResourceIdentifiersOfKind(
         resource_type.value
@@ -220,6 +208,7 @@ def test_add_and_delete_discovery_space(
     )
 
 
+@requires_sqlite_3_38
 def test_add_update_and_delete_operation_related_to_discovery_space(
     random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
     sql_store: SQLStore,
@@ -228,15 +217,6 @@ def test_add_update_and_delete_operation_related_to_discovery_space(
     """
     Tests adding an operation and its relation to a discovery space and then deleting it
     """
-
-    # AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-    # ref: https://sqlite.org/json1.html#jptr
-    if sql_store.engine.dialect.name == "sqlite" and sqlite3_version < (
-        3,
-        38,
-        0,
-    ):
-        pytest.xfail("SQLite version 3.38.0 or higher is required")
 
     space_resource = random_space_resource_from_db()
     space_identifier = space_resource.identifier
@@ -325,21 +305,13 @@ def test_add_update_and_delete_operation_related_to_discovery_space(
     )
 
 
+@requires_sqlite_3_38
 def test_add_operation_and_output(
     random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
     sql_store: SQLStore,
     random_walk_multicloud_operation_configuration: DiscoveryOperationResourceConfiguration,
     data_container_resource: orchestrator.core.datacontainer.resource.DataContainerResource,
 ) -> None:
-
-    # AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-    # ref: https://sqlite.org/json1.html#jptr
-    if sql_store.engine.dialect.name == "sqlite" and sqlite3_version < (
-        3,
-        38,
-        0,
-    ):
-        pytest.xfail("SQLite version 3.38.0 or higher is required")
 
     import orchestrator.core.resources
     import orchestrator.modules.operators.base
@@ -496,3 +468,151 @@ def test_custom_sample_store_loading(
         model.config.specification.storageLocation
         == ado_test_file_project_context.metadataStore
     )
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_empty_database(
+    resource_store: SQLStore,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds with empty database returns empty dict."""
+
+    result = resource_store.get_latest_resource_identifiers_of_kinds(
+        kinds=[CoreResourceKinds.DISCOVERYSPACE, CoreResourceKinds.OPERATION]
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 0
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_single_kind(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    resource_store: SQLStore,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds with single kind returns correct identifier."""
+
+    # Create a space resource
+    space = random_space_resource_from_db(None)
+
+    # Query for latest discoveryspace
+    result = resource_store.get_latest_resource_identifiers_of_kinds(
+        kinds=[CoreResourceKinds.DISCOVERYSPACE]
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert result[CoreResourceKinds.DISCOVERYSPACE] == space.identifier
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_multiple_kinds(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    resource_store: SQLStore,
+    operation_resource: OperationResource,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds with multiple kinds in single query."""
+
+    # Create a space resource
+    space = random_space_resource_from_db(None)
+
+    # Add an operation resource
+    resource_store.addResource(operation_resource)
+
+    # Query for both kinds in single batch query
+    result = resource_store.get_latest_resource_identifiers_of_kinds(
+        kinds=[CoreResourceKinds.DISCOVERYSPACE, CoreResourceKinds.OPERATION]
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 2
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert CoreResourceKinds.OPERATION in result
+    assert result[CoreResourceKinds.DISCOVERYSPACE] == space.identifier
+    assert result[CoreResourceKinds.OPERATION] == operation_resource.identifier
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_multiple_resources_same_kind(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    resource_store: SQLStore,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds returns most recent when multiple resources of same kind exist."""
+
+    import time
+
+    # Create first space
+    _space1 = random_space_resource_from_db(None)
+
+    # Small delay to ensure different timestamps
+    time.sleep(0.1)
+
+    # Create second space (should be more recent)
+    space2 = random_space_resource_from_db(None)
+
+    # Query for latest discoveryspace
+    result = resource_store.get_latest_resource_identifiers_of_kinds(
+        kinds=[CoreResourceKinds.DISCOVERYSPACE]
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    # Should return the most recently created space
+    assert (
+        result[CoreResourceKinds.DISCOVERYSPACE] == space2.identifier
+    ), f"Previous one was {_space1.identifier}"
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_some_kinds_missing(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    resource_store: SQLStore,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds omits kinds with no resources."""
+
+    # Create only a space resource
+    space = random_space_resource_from_db(None)
+
+    # Query for both space and operation, but only space exists
+    result = resource_store.get_latest_resource_identifiers_of_kinds(
+        kinds=[CoreResourceKinds.DISCOVERYSPACE, CoreResourceKinds.OPERATION]
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert CoreResourceKinds.OPERATION not in result
+    assert result[CoreResourceKinds.DISCOVERYSPACE] == space.identifier
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_invalid_kind(
+    resource_store: SQLStore,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds raises ValueError for invalid kind."""
+
+    # This should raise ValueError because we're passing an invalid kind
+    # Note: This test assumes the method validates kinds before querying
+    invalid_kind = "invalid_kind"  # type: ignore[arg-type]
+    with pytest.raises(
+        ValueError, match="All kinds must be CoreResourceKinds instances"
+    ):
+        resource_store.get_latest_resource_identifiers_of_kinds(kinds=[invalid_kind])
+
+
+@requires_sqlite_3_38
+def test_get_latest_resource_identifiers_of_kinds_multiple_invalid_kinds(
+    resource_store: SQLStore,
+) -> None:
+    """Test get_latest_resource_identifiers_of_kinds reports all invalid kinds at once."""
+
+    # This should raise ValueError with all invalid kinds listed
+    invalid_kind1 = "invalid_kind1"  # type: ignore[arg-type]
+    invalid_kind2 = "invalid_kind2"  # type: ignore[arg-type]
+    with pytest.raises(
+        ValueError, match="All kinds must be CoreResourceKinds instances"
+    ):
+        resource_store.get_latest_resource_identifiers_of_kinds(
+            kinds=[invalid_kind1, invalid_kind2]
+        )

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import random
-import sqlite3
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -25,13 +24,12 @@ from orchestrator.schema.result import (
     MeasurementResultStateEnum,
     ValidMeasurementResult,
 )
+from tests.conftest import requires_sqlite_3_38
 
 if TYPE_CHECKING:
     from orchestrator.core.operation.config import (
         DiscoveryOperationResourceConfiguration,
     )
-
-sqlite3_version = sqlite3.sqlite_version_info
 
 
 def test_get_single_resource_by_id(
@@ -51,11 +49,7 @@ def test_get_single_resource_by_id(
     assert db_resource is not None
 
 
-# AP: the -> and ->> syntax in SQLite is only supported from version 3.38.0
-# ref: https://sqlite.org/json1.html#jptr
-@pytest.mark.skipif(
-    sqlite3_version < (3, 38, 0), reason="SQLite version 3.38.0 or higher is required"
-)
+@requires_sqlite_3_38
 def test_get_all_resources_of_kind(
     resource_generator_from_db: tuple[CoreResourceKinds, str],
     get_resource_identifiers_by_resource_kind: Callable[[str], pd.DataFrame],

--- a/website/docs/examples/vllm-performance-endpoint.md
+++ b/website/docs/examples/vllm-performance-endpoint.md
@@ -169,7 +169,9 @@ and the results (this outputs the entities in sampled order):
 ado show entities operation --use-latest
 ```
 
-Instead of `--use-latest` you can also supply the operation id directly.
+Instead of `--use-latest` you can also supply the operation id directly if you
+want to inspect a specific operation rather than the most recent one in the
+current context.
 
 ### Check final results
 

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -131,13 +131,9 @@ Where:
   example, you can create a space along with a sample store definition, or
   create an operation together with an actuator configuration and a space
   definition. See the Examples section for more details.
-- `--use-latest` allows reusing the previous identifier of a certain resource
-  kind. It is only supported for spaces and operations. The latest identifiers
-  are updated every time an `ado create` command is successful. The stored
-  identifiers are not per-context, meaning that, for example running
-  `ado create samplestore`, changing context, and running
-  `ado create --use-latest samplestore` will raise an error. Ignored if `--with`
-  is used.
+- `--use-latest` allows reusing the latest identifier of a certain resource kind
+  from the current context's metastore. It is only supported for spaces and
+  operations during `ado create`. Ignored if `--with` is used.
 - `--new-sample-store` creates a new sample store. Only available when running
   `ado create` on `space` and `samplestore`. If running
   `ado create space --new-sample-store`, the `sampleStoreIdentifier` contained
@@ -309,7 +305,7 @@ Where:
 - The `--file` (or `-f`) flag is **currently only available for spaces** and
   allows getting a description of the space, given a space configuration file.
 - `--use-latest` flag is **currently only available for spaces** and allows
-  describing the latest space created locally. It is not context aware.
+  describing the most recently created space from the current context.
 - `--actuator-id` (**optional**) can be used only when the resource type is
   experiment and is used to indicate what actuator the experiment belongs to.
 
@@ -639,8 +635,8 @@ Where:
 - `RESOURCE_ID` is the unique identifier of the resource you want to see details
   for.
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
-  resource of RESOURCE_TYPE created locally. It is not context aware. It is
-  ignored if a RESOURCE_ID is provided.
+  resource of RESOURCE_TYPE from the current context. It is ignored if a
+  RESOURCE_ID is provided.
 
 ##### Examples
 
@@ -687,8 +683,8 @@ Where:
 - `RESOURCE_ID` is the unique identifier of the resource you want to see
   entities for.
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
-  resource of RESOURCE_TYPE created locally. It is not context aware. It is
-  ignored if a RESOURCE_ID is provided.
+  resource of RESOURCE_TYPE from the current context. It is ignored if a
+  RESOURCE_ID is provided.
 - The `--file` (or `-f`) flag is **currently only available for spaces** and
   enables showing entities that match the space defined in the configuration
   file. **NOTE**: using this flag forces `--include matching`.
@@ -800,8 +796,8 @@ ado show requests operation [RESOURCE_ID] [--use-latest] \
 <!-- markdownlint-enable line-length -->
 
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
-  operation created locally. It is not context aware. It is ignored if a
-  RESOURCE_ID is provided.
+  operation from the current context. It is ignored if a RESOURCE_ID is
+  provided.
 - `--output` (or `-o`) determines the output format. Output is written to stdout
   by default, or to a file if `--output-file` is specified.
 - `--output-file` specifies a file path to write the output to. If not provided,
@@ -852,8 +848,8 @@ ado show results operation [RESOURCE_ID] [--use-latest] \
 <!-- markdownlint-enable line-length -->
 
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
-  operation created locally. It is not context aware. It is ignored if a
-  RESOURCE_ID is provided.
+  operation from the current context. It is ignored if a RESOURCE_ID is
+  provided.
 - `--output` (or `-o`) determines the output format. Output is written to stdout
   by default, or to a file if `--output-file` is specified.
 - `--output-file` specifies a file path to write the output to. If not provided,
@@ -905,8 +901,8 @@ ado show related RESOURCE_TYPE [RESOURCE_ID] [--use-latest]
 - `RESOURCE_ID` is the unique identifier of the resource you want to see related
   resources for.
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
-  resource of RESOURCE_TYPE created locally. It is not context aware. It is
-  ignored if a RESOURCE_ID is provided.
+  resource of RESOURCE_TYPE from the current context. It is ignored if a
+  RESOURCE_ID is provided.
 
 ##### Examples
 
@@ -941,7 +937,7 @@ Where:
 - `RESOURCE_TYPE` is always _discoveryspace_ (_space_)
 - `RESOURCE_IDS` are one or more space-separated space identifiers.
 - `--use-latest` will add the identifier of the latest (i.e. most recent) space
-  created locally to the RESOURCE_IDS. It is not context aware.
+  from the current context to the RESOURCE_IDS.
 - By using (optionally multiple times) the `--query` (or `-q`) flag, users can
   restrict the resources returned by requiring that a field in the resource is
   equal to a provided value or that the content of a JSON document appear in the


### PR DESCRIPTION
# Summary

This pull request refactors the CLI configuration system to remove the in-memory caching of latest resource identifiers and instead query them directly from the database when needed. This change improves data consistency, eliminates the need to persist resource IDs in configuration files, and ensures commands always work with the most current data.

Resolves #812 

# Files Changed

📄 `orchestrator/cli/commands/create.py`

Removed the `ado_configuration.store()` call after resource creation, as the configuration no longer needs to be persisted after tracking resource IDs.

📄 `orchestrator/cli/commands/describe.py`

Updated to pass `project_context` instead of the full `ado_configuration` object to `get_effective_resource_id()`, simplifying the function's dependencies.

📄 `orchestrator/cli/commands/show_details.py`

Updated to pass `project_context` instead of the full `ado_configuration` object to `get_effective_resource_id()`.

📄 `orchestrator/cli/commands/show_entities.py`

Updated to pass `project_context` instead of the full `ado_configuration` object to `get_effective_resource_id()`.

📄 `orchestrator/cli/commands/show_related.py`

Updated to pass `project_context` instead of the full `ado_configuration` object to `get_effective_resource_id()`.

📄 `orchestrator/cli/commands/show_requests.py`

Updated to pass `project_context` instead of the full `ado_configuration` object to `get_effective_resource_id()`.

📄 `orchestrator/cli/commands/show_results.py`

Updated to pass `project_context` instead of the full `ado_configuration` object to `get_effective_resource_id()`.

📄 `orchestrator/cli/commands/show_summary.py`

Refactored to query the database directly for the latest resource ID instead of reading from configuration. Added database query with spinner feedback for better UX.

📄 `orchestrator/cli/core/config.py`

Removed the `latest_resource_ids` field from `AdoConfiguration` and added a Pydantic validator to strip this deprecated field from old config files for backward compatibility. Moved the `store()` call to the `load()` method to ensure configuration is persisted after context loading.

📄 `orchestrator/cli/resources/actuator_configuration/create.py`

Removed code that saved the created actuator configuration identifier to the in-memory configuration cache.

📄 `orchestrator/cli/resources/discovery_space/create.py`

Refactored to query the database for the latest sample store identifier instead of reading from configuration. Removed code that cached created resource identifiers.

📄 `orchestrator/cli/resources/operation/create.py`

Removed the `_save_operation_identifier()` helper function and all calls to save operation identifiers to configuration. Refactored `reuse_requested_latest_identifiers()` to use a single batch database query instead of reading from configuration.

📄 `orchestrator/cli/resources/sample_store/create.py`

Removed code that saved the created sample store identifier to the in-memory configuration cache.

📄 `orchestrator/cli/utils/generic/common.py`

Refactored `get_effective_resource_id()` to accept `project_context` instead of `ado_configuration` and query the database for latest resource IDs. Improved error messages and added database query with spinner feedback.

📄 `orchestrator/cli/utils/generic/wrappers.py`

Updated return type annotation for `get_sql_store()` from `SQLStore` to `SQLResourceStore` to match actual runtime behavior.

📄 `orchestrator/metastore/sql/statements.py`

Added new `resource_select_latest_by_kinds()` function that generates SQL to fetch the most recently created resource for each specified kind using window functions (ROW_NUMBER). Supports batch queries for multiple resource kinds.

📄 `orchestrator/metastore/sqlstore.py`

Added new `get_latest_resource_identifiers_of_kinds()` method to `SQLResourceStore` that retrieves the identifiers of the most recently created resources for multiple kinds in a single database query, minimizing round-trips.

📄 `tests/fixtures/core/space.py`

Updated the `random_space_resource_from_file` fixture to set the `created` timestamp on generated space resources, ensuring proper ordering in latest resource queries.

📄 `tests/metastore/test_resourcestore.py`

Added comprehensive test coverage for the new `get_latest_resource_identifiers_of_kinds()` method, including tests for empty databases, single/multiple kinds, multiple resources of the same kind, missing kinds, and invalid input validation. Refactored SQLite version checks into a reusable `requires_sqlite_3_38` marker.