### PR TITLE
feat(cli): add --output-file flag to ado get

### DIFF
--- a/orchestrator/cli/commands/context.py
+++ b/orchestrator/cli/commands/context.py
@@ -108,6 +108,7 @@ def list_contexts(
         matching_space=None,
         minimize_output=True,
         no_trunc=False,
+        output_file=None,
         output_format=output_format,
         resource_id=None,
         resource_type=AdoGetSupportedResourceTypes.CONTEXT,

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -183,6 +183,19 @@ def get_resource(
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
         ),
     ] = False,
+    output_file: Annotated[
+        pathlib.Path | None,
+        typer.Option(
+            "--output-file",
+            help="Write output to the specified file instead of stdout.",
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            resolve_path=True,
+            show_default=False,
+            rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
+        ),
+    ] = None,
     show_deprecated: Annotated[
         bool,
         typer.Option(
@@ -284,6 +297,18 @@ def get_resource(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
+    # Validate that output_file is only used with file-based formats
+    if output_file and output_format in (
+        AdoGetSupportedOutputFormats.DEFAULT,
+        AdoGetSupportedOutputFormats.NAME,
+    ):
+        console_print(
+            f"{ERROR} --output-file cannot be used with --output {output_format.value}. "
+            f"Use --output yaml, --output json, or --output config instead.",
+            stderr=True,
+        )
+        raise typer.Exit(1)
+
     if resource_type != AdoGetSupportedResourceTypes.DISCOVERY_SPACE and (
         matching_point or matching_space or matching_space_id
     ):
@@ -355,6 +380,7 @@ def get_resource(
         matching_space=matching_space,
         minimize_output=minimize_output,
         no_trunc=no_trunc,
+        output_file=output_file,
         output_format=output_format,
         resource_id=resource_id,
         resource_type=resource_type,

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -39,6 +39,7 @@ class AdoGetCommandParameters(pydantic.BaseModel):
     matching_space: pathlib.Path | None
     minimize_output: bool
     no_trunc: bool | list[str]
+    output_file: pathlib.Path | None
     output_format: AdoGetSupportedOutputFormats
     resource_id: str | None
     resource_type: AdoGetSupportedResourceTypes

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -125,11 +125,17 @@ def handle_ado_get_special_formats(
                 )
 
         status.stop()
-        console_print(
-            format_resource_for_ado_get_custom_format(
-                to_print=resources, parameters=parameters
-            )
+        output_content = format_resource_for_ado_get_custom_format(
+            to_print=resources, parameters=parameters
         )
+
+        if parameters.output_file:
+            parameters.output_file.write_text(output_content)
+            console_print(
+                f"{SUCCESS}Output written to {parameters.output_file}", stderr=True
+            )
+        else:
+            console_print(output_content)
 
 
 def handle_ado_get_default_format(

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -393,7 +393,8 @@ The complete syntax of the `ado get` command is as follows:
 <!-- markdownlint-disable line-length -->
 
 ```shell
-ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <table | yaml | json | config | raw>] \
+ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <default | yaml | json | config | raw>] \
+                                    [--output-file <path>] \
                                     [--exclude-default | --no-exclude-default] \
                                     [--exclude-unset | --no-exclude-unset ] \
                                     [--exclude-none | --no-exclude-none ] \
@@ -446,6 +447,10 @@ Where:
 
 <!-- prettier-ignore-end -->
 
+- `--output-file` allows writing the output to a specified file instead of
+  stdout. This flag is only supported when using the `yaml`, `json`, `config`,
+  or `raw` output formats. It cannot be used with the `default` or `name`
+  formats.
 - `--exclude-default` (set by default) allows excluding fields that use default
   values from the output. Alternatively, the `--no-exclude-default` flag can be
   used to show them.
@@ -607,6 +612,18 @@ ado get request measurement-request-123 --from-operation randomwalk-0.5.0-123abc
 ```
 
 <!-- markdownlint-enable line-length -->
+
+##### Saving a Discovery Space configuration to a file
+
+```shell
+ado get space my-space-id -o yaml --output-file space.yaml
+```
+
+##### Saving all operations as JSON
+
+```shell
+ado get operations -o json --output-file operations.json
+```
 
 ### ado show
 


### PR DESCRIPTION
# Summary

Adds support for writing `ado get` command output to a file using the new `--output-file` option. This enhancement allows users to save resource information directly to a file instead of stdout, improving automation and scripting capabilities.

Resolves #824

# Files Changed

📄 `orchestrator/cli/commands/get.py`

Added a new `--output-file` command-line option to the `get_resource` command that accepts a file path for writing output. Includes validation logic to ensure the option is only used with file-based output formats (yaml, json, config) and raises an error if used with incompatible formats (default, name). The output file parameter is then passed to the resource handler.

📄 `orchestrator/cli/models/parameters.py`

Added `output_file` field (type: `pathlib.Path | None`) to the `AdoGetCommandParameters` model to support passing the output file path through the command execution pipeline.

📄 `orchestrator/cli/utils/resources/handlers.py`

Modified `handle_ado_get_special_formats` function to write formatted output to a file when `output_file` is specified in parameters. When a file is provided, the content is written to disk and a success message is displayed to stderr; otherwise, output is printed to stdout as before.