### PR TITLE
feat(core): hash entity identifiers if too long for db engine

### DIFF
--- a/orchestrator/schema/entity.py
+++ b/orchestrator/schema/entity.py
@@ -45,15 +45,32 @@ def entity_identifier_from_properties_and_values(point: dict[str, typing.Any]) -
     """
     Creates an entity identifier based on a set of constitutive property ids and values for those properties
 
+    If the identifier exceeds safe length (700 characters), it is hashed to ensure database compatibility.
+
     Parameters:
         point: A dictionary of constitutive property id, value pairs
 
     Returns:
-        An entity identifier
+        An entity identifier (human-readable if short, hashed if long)
     """
 
     parts = [f"{key}.{point[key]}" for key in sorted(point.keys())]
-    return "-".join(parts)
+    full_identifier = "-".join(parts)
+
+    # Use 700 as threshold to leave margin below 768 limit
+    MAX_SAFE_LENGTH = 700
+
+    if len(full_identifier) > MAX_SAFE_LENGTH:
+        import hashlib
+
+        # Hash long identifiers to ensure they fit in database
+        hash_hex = hashlib.sha256(
+            full_identifier.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
+        # Prefix to indicate it's a hash
+        return f"hash-{hash_hex}"
+
+    return full_identifier
 
 
 class Entity(pydantic.BaseModel):

--- a/tests/schema/test_entity.py
+++ b/tests/schema/test_entity.py
@@ -862,3 +862,67 @@ def test_entity_identifier_from_properties_and_values_sorted() -> None:
     assert (
         id_numeric == expected_numeric
     ), f"Expected identifier to be {expected_numeric}, but got {id_numeric}"
+
+
+def test_entity_identifier_short_not_hashed() -> None:
+    """Test that short identifiers remain unchanged (not hashed)."""
+    point = {"prop1": "val1", "prop2": "val2"}
+    identifier = entity_identifier_from_properties_and_values(point)
+    assert identifier == "prop1.val1-prop2.val2"
+    assert not identifier.startswith("hash-")
+
+
+def test_entity_identifier_long_hashed() -> None:
+    """Test that long identifiers are hashed when they exceed the safe length."""
+    # Create point with many properties to exceed 700 chars (produces 4539 chars)
+    point = {f"property_{i}": f"value_{i}" * 10 for i in range(50)}
+    identifier = entity_identifier_from_properties_and_values(point)
+
+    # Verify it's a hash (starts with "hash-" prefix)
+    assert identifier.startswith(
+        "hash-"
+    ), "Long identifier should be hashed with 'hash-' prefix"
+
+    # Verify the identifier is within database limits
+    assert (
+        len(identifier) < 768
+    ), f"Identifier length {len(identifier)} exceeds database limit"
+
+    # Verify it's a valid SHA256 hash (64 hex chars + 5 char prefix = 69 total)
+    assert len(identifier) == 69, f"Expected hash length 69, got {len(identifier)}"
+
+
+def test_entity_identifier_different_points_different_identifiers() -> None:
+    """Test that different points produce different identifiers."""
+    point1 = {"prop1": "val1"}
+    point2 = {"prop1": "val2"}
+    id1 = entity_identifier_from_properties_and_values(point1)
+    id2 = entity_identifier_from_properties_and_values(point2)
+    assert id1 != id2, "Different points should produce different identifiers"
+
+    # Test with long identifiers
+    long_point1 = {f"property_{i}": f"value_{i}" * 10 for i in range(50)}
+    long_point2 = {f"property_{i}": f"different_{i}" * 10 for i in range(50)}
+    long_id1 = entity_identifier_from_properties_and_values(long_point1)
+    long_id2 = entity_identifier_from_properties_and_values(long_point2)
+    assert (
+        long_id1 != long_id2
+    ), "Different long points should produce different hashed identifiers"
+
+
+def test_entity_identifier_threshold_boundary() -> None:
+    """Test behavior at the 700 character threshold."""
+    # Create an identifier just under the threshold
+    point = {f"p{i}": f"v{i}" * 20 for i in range(14)}
+    point_identifier = "-".join([f"{k}.{point[k]}" for k in sorted(point.keys())])
+    assert len(point_identifier) == 699, "Identifier should be 699 characters"
+
+    point_id = entity_identifier_from_properties_and_values(point)
+    assert not point_id.startswith(
+        "hash-"
+    ), "Identifier under threshold should not be hashed"
+
+    # Add one entry and bring the point above the threshold
+    point["p14"] = "v14" * 20
+    point_id = entity_identifier_from_properties_and_values(point)
+    assert point_id.startswith("hash-"), "Identifier over threshold should be hashed"


### PR DESCRIPTION
# Summary

This PR adds automatic hashing for long entity identifiers to prevent database field length violations. The entity identifier is used as a primary key in SQLSampleStore. When an entity identifier exceeds 700 characters, it is now hashed using SHA256 to ensure it stays within the 768-character INNODB (MySQL) database limit for columns used as indexes while maintaining uniqueness and determinism.

**NOTE**: this issue stems from a limitation of the INNODB engine on MySQL when used with the utf8mb4 charset. Attempting to create a VARCHAR column with an index on it (such as a primary key) that is above 768 characters would fail with the following error:

> SQL Error [1071] [42000]: Specified key was too long; max key length is 3072 bytes

3072/4 = 768 is the maximum length possible

Resolves #382

# Files Changed

📄 `orchestrator/schema/entity.py`

Modified the `entity_identifier_from_properties_and_values` function to handle long identifiers. The function now checks if the generated identifier exceeds 700 characters (safe threshold below the 768-character database limit). If it does, the identifier is hashed using SHA256 and prefixed with "hash-" to indicate it's a hashed value. Short identifiers remain human-readable for debugging purposes.

📄 `tests/schema/test_entity.py`

Added comprehensive test coverage for the new identifier hashing functionality:
- `test_entity_identifier_short_not_hashed`: Verifies short identifiers remain unchanged and human-readable
- `test_entity_identifier_long_hashed`: Confirms long identifiers (4539+ chars) are properly hashed with the "hash-" prefix and stay within database limits (69 chars total)
- `test_entity_identifier_different_points_different_identifiers`: Ensures different input points produce unique identifiers for both short and long cases
- `test_entity_identifier_threshold_boundary`: Tests edge cases at exactly the 700-character threshold to verify the cutoff works correctly