### PR TITLE
docs(website): group examples in navigation

### DIFF
--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -145,18 +145,22 @@ nav:
       - Roadmap: getting-started/roadmap.md
       - Contributing: getting-started/contributing.md
   - Examples:
-      - examples/examples.md
-      - Taking a random walk: examples/random-walk.md
-      - Search a space with an optimizer: examples/best-configuration-search.md
-      - Search based on a custom objective function: examples/search-custom-objective.md
-      - Identify the important dimensions of a space: examples/lhu.md
-      - Measure throughput of fine-tuning locally: examples/finetune-locally.md
-      - Measure throughput of fine-tuning on a remote RayCluster: examples/finetune-remotely.md
-      - Testing the throughput of an inference endpoint: examples/vllm-performance-endpoint.md
-      - Exploring vLLM deployment performance: examples/vllm-performance-full.md
-      - Benchmarking geospatial models with vLLM: examples/vllm-performance-geospatial.md
-      - Efficiently Exploring Parameter Spaces with TRIM: examples/trim.md
-      - Characterizing Spaces Without Prior Knowledge: examples/no-priors-characterization.md
+      - Overview: examples/examples.md
+      - Search and Optimization:
+          - Taking a random walk: examples/random-walk.md
+          - Search a space with an optimizer: examples/best-configuration-search.md
+          - Search based on a custom objective function: examples/search-custom-objective.md
+      - Space Characterization:
+          - Identify the important dimensions of a space: examples/lhu.md
+          - Efficiently Exploring Parameter Spaces with TRIM: examples/trim.md
+          - Characterizing Spaces Without Prior Knowledge: examples/no-priors-characterization.md
+      - Fine-Tuning Throughput:
+          - Measure throughput of fine-tuning locally: examples/finetune-locally.md
+          - Measure throughput of fine-tuning on a remote RayCluster: examples/finetune-remotely.md
+      - vLLM Performance:
+          - Testing the throughput of an inference endpoint: examples/vllm-performance-endpoint.md
+          - Exploring vLLM deployment performance: examples/vllm-performance-full.md
+          - Benchmarking geospatial models with vLLM: examples/vllm-performance-geospatial.md
   - Core Concepts:
       - core-concepts/concepts.md
       - Properties and Domains: core-concepts/properties-and-domains.md


### PR DESCRIPTION
Organize the examples navbar into thematic sections so related guides are easier to browse and discover.