### PR TITLE
feat(utilities): enable auto width detection for rich renderables

### DIFF
--- a/orchestrator/utilities/rich.py
+++ b/orchestrator/utilities/rich.py
@@ -200,16 +200,27 @@ def dataframe_to_rich_table(
     return table
 
 
-def render_to_string(renderable: "RenderableType", width: int | None = None) -> str:
+def render_to_string(
+    renderable: "RenderableType",
+    width: int | None = None,
+    auto_width: bool = False,
+) -> str:
     """Render a rich renderable to a string.
 
     Args:
         renderable: A RenderableType object (e.g., Table, Panel, Text, etc.)
         width: Optional width for the console. If None, uses default width.
+        auto_width: If True, automatically set console width to match the renderable's
+            width (if available). This prevents truncation when writing to files.
+            Takes precedence over the width parameter.
 
     Returns:
         A string representation of the rendered output
     """
+    # If auto_width is requested and the renderable has a width attribute, use it
+    if auto_width and hasattr(renderable, "width") and renderable.width is not None:
+        width = renderable.width
+
     console = Console(width=width, force_terminal=False, legacy_windows=False)
     with console.capture() as capture:
         console.print(renderable)

--- a/tests/utilities/cli_rendering.py
+++ b/tests/utilities/cli_rendering.py
@@ -71,4 +71,4 @@ def render_ado_resources_to_cli_output(
         do_not_truncate_columns=do_not_truncate_columns,
     )
 
-    return render_to_string(table, width=table.width)
+    return render_to_string(table, auto_width=True)


### PR DESCRIPTION
# Summary

Enhanced the `render_to_string` utility function to support automatic width detection for renderables, preventing content truncation when rendering to files. This change simplifies the API by allowing the function to automatically use the renderable's width instead of requiring manual width specification.

# Files Changed

📄 `orchestrator/utilities/rich.py`

Added an `auto_width` parameter to the `render_to_string` function. When enabled, the function automatically detects and uses the renderable's width attribute (if available), preventing content truncation. This parameter takes precedence over the manual `width` parameter. The implementation checks if the renderable has a `width` attribute and uses it when `auto_width=True`.

📄 `tests/utilities/cli_rendering.py`

Updated the `render_ado_resources_to_cli_output` function to use the new `auto_width=True` parameter instead of manually passing `width=table.width`. This simplifies the function call and demonstrates the intended usage of the new feature.