### PR TITLE
feat(cli): allow using --output-file with all output types 

### DIFF
--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -54,8 +54,8 @@ In the case of (b) (latest) get the actual operation identifier as follows
 uv run ado show related operation --use-latest
 ```
 
-This will output the id of the latest operation created
-in the active ado context.
+This will output the id of the latest operation created in the active ado
+context.
 
 ## Tips
 
@@ -70,9 +70,9 @@ redirected to a file and loaded with python.
 
 ### Large output files
 
-The output produced by '-o/--output' can be very large e.g. from "show entities",
-"show requests" or "show results". Use the `--output-file` flag with the name of
-the file where to save the output and, when inspecting these files:
+The output produced by '-o/--output' can be very large e.g. from "show
+entities", "show requests" or "show results". Use the `--output-file` flag with
+the name of the file where to save the output and, when inspecting these files:
 
 - Use wc to count the file size first before using head/tail/cat etc. on it.
 - Use head -n1 to get column headers, this will not be large
@@ -191,10 +191,11 @@ An operation can create the following resources
 - operations: In this case recursively examine the operations using this skill
 - datacontainers: This contains non-ado resource outputs e.g. CSV data.
 
-To retrieve contents of data container
+To retrieve contents of data container. Use `--output-file` to ensure proper
+file handling:
 
 ```bash
-uv run ado get datacontainer -o yaml $DATACONTAINER_IDENTIFIER > datacontainer.yaml
+uv run ado get datacontainer -o yaml $DATACONTAINER_IDENTIFIER --output-file datacontainer.yaml
 ```
 
 For each output resource summarize what it is/contains.
@@ -272,10 +273,9 @@ uv run ado show entities operation OPERATION_ID \
 
 ### Step 4: Analyze the Measurement data
 
-Perform an analysis of the measurements, checking e.g. distributions of
-metrics, metric outliers, correlations between metrics.
-Take into account the domain of the experiment and meaning of metrics
-when looking for patterns.
+Perform an analysis of the measurements, checking e.g. distributions of metrics,
+metric outliers, correlations between metrics. Take into account the domain of
+the experiment and meaning of metrics when looking for patterns.
 
 ## Diagnose if an Explore or Search Operation is Running Workflow
 

--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: examining-ado-project
 description: >-
-  Builds a picture of work in an ado project: activity volume,
-  spaces and operations created over time, experiments and operation configs 
-  used etc. Use to create a project/context overview report,
-  summarize what the team has been doing in an ado project, report trends across
-  spaces/operations, or to onboard onto an ado project.
+  Builds a picture of work in an ado project: activity volume, spaces and
+  operations created over time, experiments and operation configs  used etc. Use
+  to create a project/context overview report, summarize what the team has been
+  doing in an ado project, report trends across spaces/operations, or to onboard
+  onto an ado project.
 ---
 
 # Examining an ado Project
@@ -15,16 +15,19 @@ related metadata in the ado project associated to the active context.
 
 - Run all commands from the **repository root** with `uv run` (see
   [using-ado-cli](../using-ado-cli/SKILL.md)).
-- See [projects and contexts](../../../website/docs/resources/metastore.md#contexts-and-projects)
+- See
+  [projects and contexts](../../../website/docs/resources/metastore.md#contexts-and-projects)
   for details on what projects and contexts are
 - Users may refer to an ado project using either the term "project" or "context"
 
 ## Tips
 
-- Prefer metastore listing and YAML dumps before heavy `uv run ado show` data pulls;
-  see [query-ado-data](../query-ado-data/SKILL.md).
-- For one space in depth: [examining-discovery-spaces](../examining-discovery-spaces/SKILL.md).
-- For one operation in depth: [examining-ado-operations](../examining-ado-operations/SKILL.md).
+- Prefer metastore listing and YAML dumps before heavy `uv run ado show` data
+  pulls; see [query-ado-data](../query-ado-data/SKILL.md).
+- For one space in depth:
+  [examining-discovery-spaces](../examining-discovery-spaces/SKILL.md).
+- For one operation in depth:
+  [examining-ado-operations](../examining-ado-operations/SKILL.md).
 
 ## Pre-requisites - Check active context is associated with expected project
 
@@ -33,7 +36,8 @@ Context names and project names are identical by construction.
 If asked to examine a specific named project:
 
 1. Check the active context name: `uv run ado context`
-   - If it has the correct name, continue to [next step](#1-overview-activity-and-types)
+   - If it has the correct name, continue to
+     [next step](#1-overview-activity-and-types)
    - If not, run `uv run ado get contexts` to list all available contexts
      - If one matches, switch to it: `uv run ado context $NAME`
      - If none match, inform the user that a context for the specified project
@@ -49,8 +53,8 @@ Goal: volume of work, recency, and which spaces attract the most operations.
    uv run ado get spaces --details
    ```
 
-   Use **age** (list is age-sorted, most recent last), **name**, **description**,
-   and **labels** to infer themes and activity.
+   Use **age** (list is age-sorted, most recent last), **name**,
+   **description**, and **labels** to infer themes and activity.
 
 2. **Operations (tabular, with metadata)**
 
@@ -60,10 +64,10 @@ Goal: volume of work, recency, and which spaces attract the most operations.
 
    Relates operations to target spaces; age and labels summarize recent work.
 
-    **Heuristic — operation IDs:** many ids encode the operator and a version
-    segment, e.g. `OPERATOR_NAME-VERSION-...-UID` (exact shape varies). Use this
-    together with `uv run ado get operator --details` to understand more about
-    the operators used.
+   **Heuristic — operation IDs:** many ids encode the operator and a version
+   segment, e.g. `OPERATOR_NAME-VERSION-...-UID` (exact shape varies). Use this
+   together with `uv run ado get operator --details` to understand more about
+   the operators used.
 
 **Synthesis:** cluster mentally (or in notes) by **creation time** to see bursts
 of activity; count operations **per space** from the operations listing to see
@@ -75,15 +79,16 @@ Goal: experiments/actuators in use, operation parameters, and how much was
 **submitted** for measurement (entities selected by explore-style operators—may
 differ from completed measurements if runs failed).
 
-Dump full resource documents for easier scripted or batched reading:
+Dump full resource documents for easier scripted or batched reading. Use
+`--output-file` to ensure proper file handling:
 
 ```bash
-uv run ado get spaces -o yaml > spaces.yaml
-uv run ado get operations -o yaml > operations.yaml
+uv run ado get spaces -o yaml --output-file spaces.yaml
+uv run ado get operations -o yaml --output-file operations.yaml
 ```
 
-On **large metastores**, these files can be very large—prefer `uv run ado get …
--q …` filters, scripts, or the SQL store API (see
+On **large metastores**, these files can be very large—prefer
+`uv run ado get … -q …` filters, scripts, or the SQL store API (see
 [query-ado-data](../query-ado-data/SKILL.md)) before dumping everything.
 
 When interpreting YAML fields, confirm paths against resource schemas:
@@ -93,25 +98,25 @@ uv run ado template discoveryspace --include-schema
 uv run ado template operation --include-schema
 ```
 
-From **space** YAML: note **experiment** and **actuator** identifiers
-referenced by each space.
+From **space** YAML: note **experiment** and **actuator** identifiers referenced
+by each space.
 
 Gain further information on the experiments using
 
 ```bash
 # Outputs description of actuators used
-uv run ado get actuators --details 
-# Outputs description of experiments used 
-uv run ado get experiments --details 
-# Outputs detailed information on an experiment 
+uv run ado get actuators --details
+# Outputs description of experiments used
+uv run ado get experiments --details
+# Outputs detailed information on an experiment
 # Use to drill down into most used experiments
 uv run ado describe experiment $EXPERIMENT_ID
 ```
 
-From **operation** YAML: note actuatorconfigurations used (if any),
-read **parameters** (operator-specific), target
-**discoveryspace** references, and any fields that indicate **entity count /
-batch / sample** configuration for explore operations.
+From **operation** YAML: note actuatorconfigurations used (if any), read
+**parameters** (operator-specific), target **discoveryspace** references, and
+any fields that indicate **entity count / batch / sample** configuration for
+explore operations.
 
 **Synthesize:**
 
@@ -123,9 +128,9 @@ batch / sample** configuration for explore operations.
 
 ## 3. Space relationships and entity-space shape
 
-From step 2, pick a handful of **commonly operated on or recent** spaces. For each,
-inspect its fragment in `spaces.yaml`, focusing on **entity space** structure
-(dimensions, bounds, representation).
+From step 2, pick a handful of **commonly operated on or recent** spaces. For
+each, inspect its fragment in `spaces.yaml`, focusing on **entity space**
+structure (dimensions, bounds, representation).
 
 Find **Spaces that match these spaces** (refinement, expansion, or parallel
 configurations)
@@ -138,10 +143,11 @@ Use the output to
 
 - Group spaces that match
 - Within each group identify subgroups whose spaces are identical
-- If multiple subgroups identify the hierarchy between them (broadest to narrowest)
+- If multiple subgroups identify the hierarchy between them (broadest to
+  narrowest)
 - Within subgroups identify what if measurement space is different between them
-- Combine this information with the sequence of space creation to
-  understand how researchers have been evolving the spaces
+- Combine this information with the sequence of space creation to understand how
+  researchers have been evolving the spaces
 
 Optionally complement with one-hop links:
 
@@ -159,8 +165,9 @@ Write a concise markdown report
 - Write the report as `project_<YYYY-MM-DD>_report.md`.
 - If a report already exists, check whether there has been meaningful activity
   since it was written before replacing it:
-  1. Run `uv run ado get spaces --details` and `uv run ado get operations
-     --details` and note the age of the most recent resource.
+  1. Run `uv run ado get spaces --details` and
+     `uv run ado get operations --details` and note the age of the most recent
+     resource.
   2. If the most recent resource is **younger** than the date of the existing
      report, there has been new activity — proceed to write a new report.
   3. If not, ask the user whether they want to replace it.
@@ -186,7 +193,8 @@ Write a concise markdown report
 
 ### Operations overview
 
-- Operator mix and whether **parameters** or **operator choice** evolve over time.
+- Operator mix and whether **parameters** or **operator choice** evolve over
+  time.
 - Which operations **submitted** the most entities (from operation YAML/config).
 - What **analysis**-style operations ran (infer from operator names and
   parameters).

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -297,18 +297,6 @@ def get_resource(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
-    # Validate that output_file is only used with file-based formats
-    if output_file and output_format in (
-        AdoGetSupportedOutputFormats.DEFAULT,
-        AdoGetSupportedOutputFormats.NAME,
-    ):
-        console_print(
-            f"{ERROR} --output-file cannot be used with --output {output_format.value}. "
-            f"Use --output yaml, --output json, or --output config instead.",
-            stderr=True,
-        )
-        raise typer.Exit(1)
-
     if resource_type != AdoGetSupportedResourceTypes.DISCOVERY_SPACE and (
         matching_point or matching_space or matching_space_id
     ):

--- a/orchestrator/cli/commands/show_entities.py
+++ b/orchestrator/cli/commands/show_entities.py
@@ -178,15 +178,6 @@ def show_entities_for_resources(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
-    # Validate that output_file is only used with file-based formats
-    if output_file and output_format == AdoShowEntitiesSupportedOutputFormats.TABLE:
-        console_print(
-            f"{ERROR} --output-file cannot be used with --output console. "
-            f"Use --output csv or --output json instead.",
-            stderr=True,
-        )
-        raise typer.Exit(1)
-
     if use_latest:
         resource_id = get_effective_resource_id(
             explicit_resource_id=resource_id,

--- a/orchestrator/cli/commands/show_requests.py
+++ b/orchestrator/cli/commands/show_requests.py
@@ -122,15 +122,6 @@ def show_requests_for_resources(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
-    # Validate that output_file is only used with file-based formats
-    if output_file and output_format == AdoShowRequestsSupportedOutputFormats.TABLE:
-        console_print(
-            f"{ERROR} --output-file cannot be used with --output console. "
-            f"Use --output csv or --output json instead.",
-            stderr=True,
-        )
-        raise typer.Exit(1)
-
     if not resource_id and not use_latest:
         console_print(
             f"{ERROR}You must specify either a resource id or the --use-latest flag",

--- a/orchestrator/cli/commands/show_results.py
+++ b/orchestrator/cli/commands/show_results.py
@@ -117,15 +117,6 @@ def show_results_for_resources(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
-    # Validate that output_file is only used with file-based formats
-    if output_file and output_format == AdoShowResultsSupportedOutputFormats.TABLE:
-        console_print(
-            f"{ERROR} --output-file cannot be used with --output console. "
-            f"Use --output csv or --output json instead.",
-            stderr=True,
-        )
-        raise typer.Exit(1)
-
     if not resource_id and not use_latest:
         console_print(
             f"{ERROR}You must specify either a resource id or the --use-latest flag",

--- a/orchestrator/cli/commands/show_summary.py
+++ b/orchestrator/cli/commands/show_summary.py
@@ -191,18 +191,6 @@ def show_summary_for_resources(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
-    # Validate that output_file is only used with file-based formats
-    if output_file and output_format in (
-        AdoShowSummarySupportedOutputFormats.MARKDOWN,
-        AdoShowSummarySupportedOutputFormats.TABLE,
-    ):
-        console_print(
-            f"{ERROR} --output-file cannot be used with --output {output_format.value}. "
-            f"Use --output csv instead.",
-            stderr=True,
-        )
-        raise typer.Exit(1)
-
     resource_kind = CoreResourceKinds(resource_type.value)
 
     # Fetch the latest resource ID from the database

--- a/orchestrator/cli/utils/output/dataframes.py
+++ b/orchestrator/cli/utils/output/dataframes.py
@@ -34,27 +34,57 @@ def df_to_output(
     Args:
         df: The dataframe to output
         output_format: The format to use (table, json, or csv)
-        output_file: Optional file path. If None, output goes to stdout (except for table format)
-        no_trunc: Whether to avoid truncating columns in table output
+        output_file: Optional file path. If None, output goes to stdout.
+            When writing table format to a file, columns are not truncated by default.
+        no_trunc: Whether to avoid truncating columns in table output (console only).
+            Ignored when output_file is provided as truncation is automatically disabled.
     """
     if df.empty:
         console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
         return
 
+    # Convert output_file to Path if it's a string
+    if output_file is not None and isinstance(output_file, str):
+        output_file = Path(output_file)
+
     # For csv and json formats
     match output_format:
         case "table":
-            output = dataframe_to_rich_table(
+            # When writing to file, avoid truncating columns by default
+            do_not_truncate = True if output_file else no_trunc
+
+            table = dataframe_to_rich_table(
                 df,
                 show_edge=True,
                 show_index=True,
                 box=rich.box.SQUARE,
-                do_not_truncate_columns=no_trunc,
+                do_not_truncate_columns=do_not_truncate,
             )
+            if output_file:
+                # Convert table to string for file output
+                from orchestrator.utilities.rich import render_to_string
+
+                output_str = render_to_string(table, auto_width=True)
+                output_file.write_text(output_str)
+                console_print(
+                    f"{SUCCESS} Output saved as {magenta(str(output_file))}",
+                    stderr=True,
+                )
+            else:
+                console_print(table)
+                if (
+                    df.shape[0] >= DATAFRAME_ROWS_THRESHOLD
+                    or df.shape[1] >= DATAFRAME_COLS_THRESHOLD
+                ):
+                    console_print(
+                        f"{HINT}The output is very large. Consider redirecting it to a file",
+                        stderr=True,
+                    )
+            return
         case "csv":
             output = df.to_csv()
         case "json":
-            output = df.to_json()
+            output = df.to_json() or ""
 
     if not output_file:
         console_print(output)

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -8,6 +8,7 @@ import pydantic
 import rich.rule
 import typer
 import yaml
+from rich.console import RenderableType
 from rich.status import Status
 
 from orchestrator.cli.models.types import (
@@ -106,17 +107,19 @@ def _handle_name_format(
             else "IDENTIFIER"
         )
         if identifier_column in dataframe.columns:
-            for identifier in dataframe[identifier_column]:
-                console_print(identifier)
+            output = "\n".join(
+                str(identifier) for identifier in dataframe[identifier_column]
+            )
+            _write_or_print_output(output, parameters.output_file)
         return
 
     # If resources provided, extract identifiers
     if resources is not None:
         if isinstance(resources, list):
-            for resource in resources:
-                console_print(resource.identifier)
+            output = "\n".join(resource.identifier for resource in resources)
         else:
-            console_print(resources.identifier)
+            output = resources.identifier
+        _write_or_print_output(output, parameters.output_file)
         return
 
     # Otherwise use efficient DB query
@@ -141,7 +144,7 @@ def _handle_name_format(
                     resource_id=parameters.resource_id, kind=resource_type
                 )
             status.stop()
-            console_print(parameters.resource_id)
+            _write_or_print_output(parameters.resource_id, parameters.output_file)
         else:
             # Multiple resources: use efficient getResourceIdentifiersOfKind
             identifiers_df = sql_store.getResourceIdentifiersOfKind(
@@ -154,8 +157,10 @@ def _handle_name_format(
                 console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
                 return
             # Output one identifier per line
-            for identifier in identifiers_df["IDENTIFIER"]:
-                console_print(identifier)
+            output = "\n".join(
+                str(identifier) for identifier in identifiers_df["IDENTIFIER"]
+            )
+            _write_or_print_output(output, parameters.output_file)
 
 
 def _handle_table_format(
@@ -173,17 +178,22 @@ def _handle_table_format(
             console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
             return
 
-        console_print(
-            dataframe_to_rich_table(
-                df,
-                box=rich.box.SQUARE,
-                show_index=True,
-                show_edge=True,
-                do_not_truncate_columns=(
-                    ["IDENTIFIER"] if not parameters.no_trunc else parameters.no_trunc
-                ),
+        # When writing to file, avoid truncating columns by default
+        if parameters.output_file:
+            do_not_truncate = True
+        else:
+            do_not_truncate = (
+                ["IDENTIFIER"] if not parameters.no_trunc else parameters.no_trunc
             )
+
+        table = dataframe_to_rich_table(
+            df,
+            box=rich.box.SQUARE,
+            show_index=True,
+            show_edge=True,
+            do_not_truncate_columns=do_not_truncate,
         )
+        _write_or_print_output(table, parameters.output_file)
         return
 
     # If dataframe provided, use it directly
@@ -351,9 +361,21 @@ def _handle_structured_formats(
     _write_or_print_output(output_content, parameters.output_file)
 
 
-def _write_or_print_output(content: str, output_file: pathlib.Path | None) -> None:
-    """Helper to write to file or print to console."""
+def _write_or_print_output(
+    content: str | RenderableType, output_file: pathlib.Path | None
+) -> None:
+    """Helper to write to file or print to console.
+
+    Args:
+        content: String content or rich renderable to output
+        output_file: Optional file path. If provided, content is written to file.
+    """
     if output_file:
+        # Convert to string if it's a rich renderable
+        if not isinstance(content, str):
+            from orchestrator.utilities.rich import render_to_string
+
+            content = render_to_string(content, auto_width=True)
         output_file.write_text(content)
         console_print(f"{SUCCESS}Output written to {output_file}", stderr=True)
     else:

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -67,6 +67,11 @@ def handle_ado_get(
         resource_type: Type of resource to fetch (for DB queries)
         dataframe: Pre-built DataFrame (for custom data sources)
         resources: Pre-fetched resources (for custom filtering)
+
+    Raises:
+        ValueError: If an identifier column (either "IDENTIFIER" or the value of
+            parameters.no_trunc if it's a list with a single element) is not found
+            in the provided dataframe when using NAME output format.
     """
     match parameters.output_format:
         case AdoGetSupportedOutputFormats.NAME:
@@ -93,7 +98,14 @@ def _handle_name_format(
     dataframe: "pd.DataFrame | None",
     resources: "list[ADOResource] | ADOResource | None",
 ) -> None:
-    """Handle NAME output format - output identifiers only (most efficient)."""
+    """
+    Handle NAME output format - output identifiers only (most efficient).
+
+    Raises:
+        ValueError: If an identifier column (either "IDENTIFIER" or the value of
+            parameters.no_trunc if it's a list with a single element) is not found
+            in the provided dataframe.
+    """
 
     # If dataframe provided, extract identifier column
     if dataframe is not None:
@@ -106,11 +118,15 @@ def _handle_name_format(
             if isinstance(parameters.no_trunc, list) and len(parameters.no_trunc) == 1
             else "IDENTIFIER"
         )
-        if identifier_column in dataframe.columns:
-            output = "\n".join(
-                str(identifier) for identifier in dataframe[identifier_column]
+        if identifier_column not in dataframe.columns:
+            raise ValueError(
+                f"Identifier column '{identifier_column}' not found in dataframe. "
+                f"Available columns: {', '.join(dataframe.columns)}"
             )
-            _write_or_print_output(output, parameters.output_file)
+        output = "\n".join(
+            str(identifier) for identifier in dataframe[identifier_column]
+        )
+        _write_or_print_output(output, parameters.output_file)
         return
 
     # If resources provided, extract identifiers

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -1004,9 +1004,9 @@ Where:
 
 <!-- prettier-ignore-start -->
 
-    - `md` - for Markdown text (written to stdout or file).
-    - `table` (**default**) - for Markdown tables (written to stdout or file).
-    - `csv` - for CSV format (written to stdout or file).
+    - `md` - for Markdown text.
+    - `table` (**default**) - for Markdown tables.
+    - `csv` - for CSV format.
 
 <!-- prettier-ignore-end -->
 

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -444,9 +444,7 @@ Where:
 <!-- prettier-ignore-end -->
 
 - `--output-file` allows writing the output to a specified file instead of
-  stdout. This flag is only supported when using the `yaml`, `json`, `config`,
-  or `raw` output formats. It cannot be used with the `default` or `name`
-  formats.
+  stdout. Avoids truncating columns when used with the `table` format.
 - `--exclude-default` (set by default) allows excluding fields that use default
   values from the output. Alternatively, the `--no-exclude-default` flag can be
   used to show them.
@@ -621,6 +619,18 @@ ado get space my-space-id -o yaml --output-file space.yaml
 ado get operations -o json --output-file operations.json
 ```
 
+##### Saving resource identifiers to a file
+
+```shell
+ado get spaces -o name --output-file space-ids.txt
+```
+
+##### Saving table output to a file
+
+```shell
+ado get spaces --output-file spaces-table.txt
+```
+
 ### ado show
 
 When interacting with resources, we might be interested in seeing some of their
@@ -793,6 +803,12 @@ ado show entities operation randomwalk-0.5.0-123abc -o json \
                                                     --property my-property-2
 ```
 
+###### Save table output of entities to a file
+
+```shell
+ado show entities space space-abc123-456def --output-file entities-table.txt
+```
+
 #### ado show requests
 
 _show requests_ supports displaying the `MeasurementRequest`s that were part of
@@ -845,6 +861,12 @@ ado show requests operation randomwalk-0.5.0-123abc --hide type --hide "experime
 
 <!-- markdownlint-enable line-length -->
 
+###### Save table output of requests to a file
+
+```shell
+ado show requests operation randomwalk-0.5.0-123abc --output-file requests-table.txt
+```
+
 #### ado show results
 
 _show results_ supports displaying the `MeasurementResult`s that were part of an
@@ -891,6 +913,12 @@ ado show results operation randomwalk-0.5.0-123abc -o csv --output-file results.
 
 ```shell
 ado show results operation randomwalk-0.5.0-123abc --hide uid
+```
+
+###### Save table output of results to a file
+
+```shell
+ado show results operation randomwalk-0.5.0-123abc --output-file results-table.txt
 ```
 
 #### ado show related
@@ -1026,6 +1054,18 @@ Or to write to a file directly:
 
 ```shell
 ado show summary space -l issue=123 -o csv --output-file summary.csv
+```
+
+###### Save table summary output to a file
+
+```shell
+ado show summary space my-space-id --output-file summary-table.txt
+```
+
+###### Save markdown summary output to a file
+
+```shell
+ado show summary space my-space-id -o md --output-file summary.md
 ```
 
 ###### Get the summary of spaces that include granite-7b-base in the property domain

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -777,6 +777,9 @@ Where:
 
 ###### Show matching entities in a Space with target format and output them as CSV
 
+Recommended approach using `--output-file` (ensures columns aren't truncated and
+handles file write errors):
+
 ```shell
  ado show entities space space-abc123-456def --include matching \
                                              --property-format target \
@@ -845,7 +848,8 @@ ado show requests operation [RESOURCE_ID] [--use-latest] \
 ado show requests operation randomwalk-0.5.0-123abc -o csv > requests.csv
 ```
 
-Or to write to a file directly:
+Or to write to a file directly (recommended - ensures columns aren't truncated
+and handles file write errors):
 
 ```shell
 ado show requests operation randomwalk-0.5.0-123abc -o csv --output-file requests.csv
@@ -903,7 +907,8 @@ ado show results operation [RESOURCE_ID] [--use-latest] \
 ado show results operation randomwalk-0.5.0-123abc -o csv > results.csv
 ```
 
-Or to write to a file directly:
+Or to write to a file directly (recommended - ensures columns aren't truncated
+and handles file write errors):
 
 ```shell
 ado show results operation randomwalk-0.5.0-123abc -o csv --output-file results.csv
@@ -1050,7 +1055,8 @@ ado show summary space space-abc123-456def -o md
 ado show summary space -l issue=123 -o csv > summary.csv
 ```
 
-Or to write to a file directly:
+Or to write to a file directly (recommended - ensures columns aren't truncated
+and handles file write errors):
 
 ```shell
 ado show summary space -l issue=123 -o csv --output-file summary.csv


### PR DESCRIPTION
# Summary

This pull request removes redundant output format validation logic from CLI commands and enhances output file handling to support writing table format to files. Previously, validation prevented using `--output-file` with certain display formats (like `table`, `console`, `default`, and `name`), but this restriction has been removed to allow more flexible output options.

Resolves #839 and closes #788

# Files Changed

📄 `orchestrator/cli/commands/get.py`

Removed validation that prevented using `--output-file` with `DEFAULT` and `NAME` output formats. This restriction is no longer necessary as the output handlers now properly support file output for all formats.

📄 `orchestrator/cli/commands/show_entities.py`

Removed validation that prevented using `--output-file` with `TABLE` output format. File output is now supported for table format.

📄 `orchestrator/cli/commands/show_requests.py`

Removed validation that prevented using `--output-file` with `TABLE` output format for the show requests command.

📄 `orchestrator/cli/commands/show_results.py`

Removed validation that prevented using `--output-file` with `TABLE` output format for the show results command.

📄 `orchestrator/cli/commands/show_summary.py`

Removed validation that prevented using `--output-file` with `MARKDOWN` and `TABLE` output formats for the show summary command.

📄 `orchestrator/cli/utils/output/dataframes.py`

Enhanced the `df_to_output` function to support writing table format to files. When outputting to a file, tables are now rendered to string format using `render_to_string` with automatic width. Column truncation is automatically disabled when writing to files. Also added proper handling for empty JSON output.

📄 `orchestrator/cli/utils/resources/handlers.py`

Refactored output handling in multiple format handlers (`_handle_name_format`, `_handle_table_format`) to use the centralized `_write_or_print_output` helper function. Enhanced `_write_or_print_output` to accept both string content and rich renderables, automatically converting renderables to strings when writing to files. This ensures consistent file output behavior across all format types.