### PR TITLE
refactor(core): move dictionary utilities

### DIFF
--- a/orchestrator/cli/resources/context/delete.py
+++ b/orchestrator/cli/resources/context/delete.py
@@ -15,7 +15,7 @@ from orchestrator.cli.utils.output.prints import (
     context_not_in_available_contexts_error_str,
     cyan,
 )
-from orchestrator.core.legacy.utils import get_nested_value
+from orchestrator.utilities.dictionaries import get_nested_value
 
 
 def delete_context(parameters: AdoDeleteCommandParameters) -> None:

--- a/orchestrator/core/legacy/migrators/actuatorconfiguration/vllm_performance_image_secret_rename.py
+++ b/orchestrator/core/legacy/migrators/actuatorconfiguration/vllm_performance_image_secret_rename.py
@@ -4,13 +4,13 @@
 """Legacy migrator for vllm_performance actuator image_secret field rename"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import (
+from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import (
     get_nested_value,
     has_nested_field,
     remove_nested_field,
     set_nested_value,
 )
-from orchestrator.core.resources import CoreResourceKinds
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/discoveryspace/entitysource_to_samplestore.py
+++ b/orchestrator/core/legacy/migrators/discoveryspace/entitysource_to_samplestore.py
@@ -4,12 +4,12 @@
 """Legacy migrator for renaming entitySourceIdentifier to sampleStoreIdentifier"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import (
+from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import (
     get_nested_value,
     remove_nested_field,
     set_nested_value,
 )
-from orchestrator.core.resources import CoreResourceKinds
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/discoveryspace/properties_field_removal.py
+++ b/orchestrator/core/legacy/migrators/discoveryspace/properties_field_removal.py
@@ -4,8 +4,8 @@
 """Legacy migrator for removing deprecated properties field from discovery spaces"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import remove_nested_field
 from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import remove_nested_field
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/operation/actuators_field_removal.py
+++ b/orchestrator/core/legacy/migrators/operation/actuators_field_removal.py
@@ -4,8 +4,8 @@
 """Legacy migrator for removing deprecated actuators field from operations"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import remove_nested_field
 from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import remove_nested_field
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/operation/randomwalk_mode_to_sampler_config.py
+++ b/orchestrator/core/legacy/migrators/operation/randomwalk_mode_to_sampler_config.py
@@ -4,13 +4,13 @@
 """Legacy migrator for migrating random_walk parameters to samplerConfig"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import (
+from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import (
     get_nested_value,
     has_nested_field,
     remove_nested_field,
     set_nested_value,
 )
-from orchestrator.core.resources import CoreResourceKinds
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/resource/entitysource_to_samplestore.py
+++ b/orchestrator/core/legacy/migrators/resource/entitysource_to_samplestore.py
@@ -4,8 +4,8 @@
 """Legacy migrator for migrating entitysource kind to samplestore kind"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import has_nested_field, set_nested_value
 from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import has_nested_field, set_nested_value
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/samplestore/entitysource_migrations.py
+++ b/orchestrator/core/legacy/migrators/samplestore/entitysource_migrations.py
@@ -4,12 +4,12 @@
 """Legacy validators for migrating entitysource to samplestore naming"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import (
+from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import (
     get_nested_value,
     has_nested_field,
     set_nested_value,
 )
-from orchestrator.core.resources import CoreResourceKinds
 
 
 @legacy_migrator(
@@ -280,7 +280,7 @@ def remove_specification_storage_location(data: dict) -> dict:
         return data
 
     # Remove config.specification.storageLocation if it exists
-    from orchestrator.core.legacy.utils import remove_nested_field
+    from orchestrator.utilities.dictionaries import remove_nested_field
 
     remove_nested_field(data, "config.specification.storageLocation")
 

--- a/orchestrator/core/legacy/migrators/samplestore/gt4sd_transformer_migration.py
+++ b/orchestrator/core/legacy/migrators/samplestore/gt4sd_transformer_migration.py
@@ -4,12 +4,12 @@
 """Legacy migrator for migrating GT4SDTransformer to CSVSampleStore"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import (
+from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import (
     get_nested_value,
     has_nested_field,
     set_nested_value,
 )
-from orchestrator.core.resources import CoreResourceKinds
 
 
 @legacy_migrator(

--- a/orchestrator/core/legacy/migrators/samplestore/v1_to_v2_csv_migration.py
+++ b/orchestrator/core/legacy/migrators/samplestore/v1_to_v2_csv_migration.py
@@ -4,8 +4,8 @@
 """Legacy migrator for migrating CSV sample stores from v1 to v2 format"""
 
 from orchestrator.core.legacy.registry import legacy_migrator
-from orchestrator.core.legacy.utils import get_nested_value, has_nested_field
 from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.utilities.dictionaries import get_nested_value, has_nested_field
 
 
 @legacy_migrator(

--- a/orchestrator/utilities/dictionaries.py
+++ b/orchestrator/utilities/dictionaries.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-"""Utility functions for legacy migrators"""
+"""Utility functions for working with nested dictionaries"""
 
 
 def get_parent_dict_and_key(data: dict, path: str) -> tuple[dict | None, str | None]:

--- a/tests/core/test_legacy_utils.py
+++ b/tests/core/test_legacy_utils.py
@@ -3,7 +3,7 @@
 
 """Tests for legacy migrator utility functions"""
 
-from orchestrator.core.legacy.utils import (
+from orchestrator.utilities.dictionaries import (
     get_nested_value,
     get_parent_dict_and_key,
     has_nested_field,


### PR DESCRIPTION
# Summary

This pull request refactors utility functions for working with nested dictionaries by moving them from `orchestrator/core/legacy/utils.py` to a new location at `orchestrator/utilities/dictionaries.py`. This change improves code organization by placing these general-purpose dictionary utilities in a more appropriate location, as they are not specifically legacy-related. All imports throughout the codebase have been updated to reference the new module location.

Closes #840 