### PR TITLE
feat(cli): add table output to show summary and change format names

### DIFF
--- a/orchestrator/cli/commands/show_summary.py
+++ b/orchestrator/cli/commands/show_summary.py
@@ -132,7 +132,9 @@ def show_summary_for_resources(
         typer.Option(
             "--output",
             "-o",
-            help="The format in which to output the summary.",
+            help="The format in which to output the summary. "
+            "Options: table (rich console table), md-table (markdown table), "
+            "md-report (markdown prose report), csv (CSV format).",
         ),
     ] = AdoShowSummarySupportedOutputFormats.TABLE.value,
     output_file: Annotated[
@@ -151,7 +153,7 @@ def show_summary_for_resources(
         bool,
         typer.Option(
             "--render",
-            help="Render the output in the console. Only supported for markdown and table output.",
+            help="Render the output in the console. Only supported for markdown table and markdown report output.",
         ),
     ] = False,
 ) -> None:
@@ -167,13 +169,13 @@ def show_summary_for_resources(
 
 
 
-    # Show a high-level summary of the discovery space as a Markdown table
+    # Show a high-level summary of the discovery space as a rich table
 
     ado show summary space <space-id>
 
 
 
-    # Show a high-level summary of the latest discovery space as a Markdown table
+    # Show a high-level summary of the latest discovery space as a rich table
 
     ado show summary space --use-latest
 
@@ -185,9 +187,9 @@ def show_summary_for_resources(
 
 
 
-    # Show a detailed summary of the discovery space as a Markdown document
+    # Show a detailed summary of the discovery space as a Markdown report
 
-    ado show summary space <space-id> -o md
+    ado show summary space <space-id> -o md-report
     """
     ado_configuration: AdoConfiguration = ctx.obj
 

--- a/orchestrator/cli/models/types.py
+++ b/orchestrator/cli/models/types.py
@@ -23,6 +23,8 @@ _CONFIG = "config"
 _CSV = "csv"
 _JSON = "json"
 _MARKDOWN_SHORT = "md"
+_MARKDOWN_REPORT = "md-report"
+_MARKDOWN_TABLE = "md-table"
 _NAME = "name"
 _RAW = "raw"
 _TABLE = "table"
@@ -174,8 +176,9 @@ class AdoShowResultsSupportedResourceTypes(Enum):
 
 #################### ado show summary ####################
 class AdoShowSummarySupportedOutputFormats(enum.Enum):
-    MARKDOWN = _MARKDOWN_SHORT
     TABLE = _TABLE
+    MARKDOWN_TABLE = _MARKDOWN_TABLE
+    MARKDOWN_REPORT = _MARKDOWN_REPORT
     CSV = _CSV
 
 

--- a/orchestrator/cli/resources/discovery_space/show_summary.py
+++ b/orchestrator/cli/resources/discovery_space/show_summary.py
@@ -74,13 +74,15 @@ def show_discovery_space_summary(parameters: AdoShowSummaryCommandParameters) ->
             )
             raise typer.Exit(1)
 
-        result = ""
-        if parameters.output_format == AdoShowSummarySupportedOutputFormats.MARKDOWN:
+        if (
+            parameters.output_format
+            == AdoShowSummarySupportedOutputFormats.MARKDOWN_REPORT
+        ):
 
             if parameters.include_properties:
                 console_print(
                     f"{WARN}It's not possible to restrict the constitutive properties shown "
-                    f"when using {AdoShowSummarySupportedOutputFormats.MARKDOWN.value} output.",
+                    f"when using {AdoShowSummarySupportedOutputFormats.MARKDOWN_REPORT.value} output.",
                     stderr=True,
                 )
 
@@ -98,9 +100,31 @@ def show_discovery_space_summary(parameters: AdoShowSummaryCommandParameters) ->
                 ]
             ).fillna("")
 
+            if parameters.output_format == AdoShowSummarySupportedOutputFormats.TABLE:
+
+                import rich.box
+
+                from orchestrator.utilities.rich import (
+                    dataframe_to_rich_table,
+                    render_to_string,
+                )
+
+                # When writing to file, avoid truncating columns by default
+                table = dataframe_to_rich_table(
+                    df,
+                    show_edge=True,
+                    show_index=True,
+                    box=rich.box.SQUARE,
+                    do_not_truncate_columns=parameters.output_file is not None,
+                )
+                result = render_to_string(table, auto_width=True)
+
             if parameters.output_format == AdoShowSummarySupportedOutputFormats.CSV:
                 result = df.to_csv()
-            elif parameters.output_format == AdoShowSummarySupportedOutputFormats.TABLE:
+            elif (
+                parameters.output_format
+                == AdoShowSummarySupportedOutputFormats.MARKDOWN_TABLE
+            ):
                 result = df.to_markdown()
 
         if parameters.output_file:

--- a/orchestrator/cli/resources/discovery_space/show_summary.py
+++ b/orchestrator/cli/resources/discovery_space/show_summary.py
@@ -135,7 +135,10 @@ def show_discovery_space_summary(parameters: AdoShowSummaryCommandParameters) ->
             )
             return
 
-        if parameters.render_output:
+        if parameters.render_output and parameters.output_format in {
+            AdoShowSummarySupportedOutputFormats.MARKDOWN_REPORT,
+            AdoShowSummarySupportedOutputFormats.MARKDOWN_TABLE,
+        }:
             from rich.markdown import Markdown
 
             result = Markdown(result)

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -998,14 +998,15 @@ Where:
   specified multiple times (even in conjunction with `-q` to further filter
   results).
 - `--with-property | -p` displays values for a subset of the constitutive
-  properties. Cannot be used when the output format is `md`.
+  properties. Cannot be used when the output format is `md-report`.
 - `--output` (or `-o`) allows choosing the output format in which the
   information should be displayed. Can be one of either:
 
 <!-- prettier-ignore-start -->
 
-    - `md` - for Markdown text.
-    - `table` (**default**) - for Markdown tables.
+    - `table` (**default**) - for a formatted table output.
+    - `md-table` - for a table in Markdown format.
+    - `md-report` - for a report in Markdown format.
     - `csv` - for CSV format.
 
 <!-- prettier-ignore-end -->
@@ -1015,7 +1016,7 @@ Where:
 
 ##### Examples
 
-###### Get the summary of a space as a Markdown table
+###### Get the summary of a space as a rich table
 
 ```shell
 ado show summary space space-abc123-456def
@@ -1023,7 +1024,7 @@ ado show summary space space-abc123-456def
 
 <!-- markdownlint-disable line-length -->
 
-###### Get the summary of a space as a Markdown table and include the constitutive property MY_PROPERTY
+###### Get the summary of a space as a rich table and include the constitutive property MY_PROPERTY
 
 <!-- markdownlint-enable line-length -->
 
@@ -1031,22 +1032,22 @@ ado show summary space space-abc123-456def
 ado show summary space space-abc123-456def -p MY_PROPERTY
 ```
 
-###### Get the summary of multiple spaces as a Markdown table via identifiers
+###### Get the summary of multiple spaces as a rich table via identifiers
 
 ```shell
 ado show summary space space-abc123-456def space-ghi789-123jkl
 ```
 
-###### Get the summary of multiple spaces as a Markdown table via key-value labels
+###### Get the summary of multiple spaces as a rich table via key-value labels
 
 ```shell
 ado show summary space -l issue=123
 ```
 
-###### Get the summary of a space as a Markdown text
+###### Get the summary of a space as a Markdown report
 
 ```shell
-ado show summary space space-abc123-456def -o md
+ado show summary space space-abc123-456def -o md-report
 ```
 
 ###### Get the summary of a multiple spaces as a CSV file via key-value labels


### PR DESCRIPTION
# Summary

This pull request refactors the output format options for the `ado show summary` command to provide more explicit and clearer format naming. The changes distinguish between different output types: rich console tables, markdown tables, markdown reports, and CSV format. The default output format is now explicitly a rich console table instead of markdown.

Resolves #834 

# Files Changed

📄 `orchestrator/cli/commands/show_summary.py`

Updated help text and documentation for the `--output` option to clearly describe all available output formats (table, md-table, md-report, csv). Also clarified that the `--render` option only works with markdown table and markdown report outputs. Updated command examples to reflect the new format naming conventions.

📄 `orchestrator/cli/models/types.py`

Added new constants `_MARKDOWN_REPORT` and `_MARKDOWN_TABLE` to distinguish between different markdown output types. Updated the `AdoShowSummarySupportedOutputFormats` enum to replace the generic `MARKDOWN` option with two specific options: `MARKDOWN_TABLE` and `MARKDOWN_REPORT`, making the output format choices more explicit.

📄 `orchestrator/cli/resources/discovery_space/show_summary.py`

Refactored the output format handling logic to support the new format naming scheme. Added support for rendering rich console tables (TABLE format) with proper formatting and column truncation settings. Updated the conditional logic to use `MARKDOWN_REPORT` and `MARKDOWN_TABLE` instead of the generic `MARKDOWN` format. Fixed the render output condition to only apply to markdown-based formats.