### PR TITLE
docs(website): add dedicated section to shorthands

### DIFF
--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -35,6 +35,45 @@ ado [--context | -c <context-file.yaml>] \
 - `--log-level | -l` configures the logging level. This does not affect child
   processes.
 
+### Resource Type Shorthands
+
+Many ado CLI commands accept resource types as arguments. To make commands more
+concise, ado supports **shorthand aliases** for resource type names. You can use
+either the full name or the shorthand interchangeably in any command.
+
+#### Available Shorthands
+
+> [!WARNING]
+>
+> Shorthands are case-sensitive and must be lowercase.
+
+| Full Resource Type    | Shorthand | Example Usage                       |
+| --------------------- | --------- | ----------------------------------- |
+| actuatorconfiguration | ac        | `ado get ac`                        |
+| context               | ctx       | `ado delete ctx my-context`         |
+| datacontainer         | dcr       | `ado describe dcr container-123`    |
+| discoveryspace        | space     | `ado create space -f space.yaml`    |
+| experiment            | exp       | `ado get exp`                       |
+| measurementrequest    | request   | `ado get request`                   |
+| operation             | op        | `ado show details op operation-456` |
+| samplestore           | store     | `ado get store`                     |
+
+#### Usage Examples
+
+```shell
+# These commands are equivalent:
+ado get discoveryspace space-abc123
+ado get space space-abc123
+
+# These commands are equivalent:
+ado create actuatorconfiguration -f config.yaml
+ado create ac -f config.yaml
+
+# These commands are equivalent:
+ado delete operation op-xyz789
+ado delete op op-xyz789
+```
+
 ### ado context
 
 **ado** supports storing configuration and authentication details for multiple
@@ -107,10 +146,11 @@ ado create RESOURCE_TYPE [--file | -f <FILE.yaml>] \
 
 Where:
 
-- `RESOURCE_TYPE` is one of the supported resource types for `ado create`,
-  currently:
+- `RESOURCE_TYPE` is one of the supported resource types for `ado create`. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _actuator_
     - _actuatorconfiguration_ (_ac_)
@@ -119,7 +159,7 @@ Where:
     - _samplestore_ (_store_)
     - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--file` or `-f` is a path to the resource configuration file in YAML format.
   It is mandatory in all scenarios, except when running
@@ -227,10 +267,11 @@ ado delete RESOURCE_TYPE RESOURCE_ID \
 
 Where:
 
-- `RESOURCE_TYPE` is the type of resource you want to delete. Currently, the
-  only supported types are:
+- `RESOURCE_TYPE` is the type of resource you want to delete. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _actuatorconfiguration_ (_ac_)
     - _context_ (_ctx_)
@@ -239,17 +280,17 @@ Where:
     - _samplestore_ (_store_)
     - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource to delete.
 - `--force` enables forced deletion of resources in the following cases:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - When attempting to delete operations while other operations are executing.
     - When attempting to delete sample stores that still contain data.
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - When deleting a local context, users can specify the flags `--delete-local-db`
   or `--no-delete-local-db` to explicitly delete or preserve a local DB when
@@ -290,16 +331,17 @@ ado describe RESOURCE_TYPE [RESOURCE_ID] [--file | -f <file.yaml>] \
 
 Where:
 
-- `RESOURCE_TYPE` is the type of resource you want to describe. Currently, the
-  supported resource types are:
+- `RESOURCE_TYPE` is the type of resource you want to describe. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _experiment_
     - _datacontainer_ (_dcr_)
     - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource to describe.
 - The `--file` (or `-f`) flag is **currently only available for spaces** and
@@ -331,9 +373,11 @@ ado edit RESOURCE_TYPE RESOURCE_ID [--editor <NAME>]
 
 Where:
 
-- `RESOURCE_TYPE` is the type of resource you want to edit. Supported types are:
+- `RESOURCE_TYPE` is the type of resource you want to edit. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _actuatorconfiguration_ (_ac_)
     - _datacontainer_ (_dcr_)
@@ -341,19 +385,19 @@ Where:
     - _samplestore_ (_store_)
     - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource to edit.
 - `--editor` is the name of the editor you want to use for editing metadata. It
   must be one of the supported ones, which currently are:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `vim` (_default_)
     - `vi`
     - `nano`
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 Alternatively, you can also set the value for this flag by using the environment
 variable `ADO_EDITOR`.
@@ -409,10 +453,11 @@ ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <default | yaml | json | conf
 
 Where:
 
-- `RESOURCE_TYPE` is the type of resource you want to get. Currently, the only
-  supported types are:
+- `RESOURCE_TYPE` is the type of resource you want to get. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _actuatorconfiguration_ (_ac_)
     - _actuator_
@@ -424,12 +469,12 @@ Where:
     - _samplestore_ (_store_)
     - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the optional unique identifier of the resource to get.
 - `--output` or `-o` determine the type of output that will be displayed:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - The `table` format shows the _identifier_, the _name_, and the _age_ of
       the matching resources.
@@ -441,7 +486,7 @@ Where:
     - The `raw` format displays the raw resource as stored in the database,
       performing no validation.
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--output-file` allows writing the output to a specified file instead of
   stdout. Avoids truncating columns when used with the `table` format.
@@ -650,14 +695,16 @@ ado show details RESOURCE_TYPE [RESOURCE_ID] [--use-latest]
 
 Where:
 
-- `RESOURCE_TYPE` is one of the supported resource types:
+- `RESOURCE_TYPE` is one of the supported resource types. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
-    - _operation_ (_op_)
     - _discoveryspace_ (_space_)
+    - _operation_ (_op_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource you want to see details
   for.
@@ -698,14 +745,16 @@ ado show entities RESOURCE_TYPE [RESOURCE_ID] [--use-latest] [--file | -f <file.
 
 Where:
 
-- `RESOURCE_TYPE` is one of the supported resource types:
+- `RESOURCE_TYPE` is one of the supported resource types. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
-    - _operation_ (_op_)
     - _discoveryspace_ (_space_)
+    - _operation_ (_op_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource you want to see
   entities for.
@@ -718,25 +767,25 @@ Where:
 - `--property-format` defines the naming format used for measured properties in
   the output, one of:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `observed`: properties are named `$experimentid.$property_id`.
       There will be one row per entity.
     - `target`: properties are named `$property_id`.
       There will be one row per (entity, experiment) pair.
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--output` (or `-o`) is the format in which to display the entity data. One
   of:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `table` (print to stdout)
     - `csv` (write CSV to stdout, or to file if `--output-file` is specified)
     - `json` (write JSON to stdout, or to file if `--output-file` is specified)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--output-file` specifies a file path to write the output to (except for table
   format which always prints to stdout).
@@ -746,7 +795,7 @@ Where:
 - `--include` (**exclusive to spaces**) determines what type of entities to
   include. One of:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `sampled`: Entities that have been measured by explore operations on the
       `discoveryspace`
@@ -757,12 +806,12 @@ Where:
     - `missing`: Entities in the `discoveryspace` that are not in the
       `samplestore` the `discoveryspace` uses
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--aggregate` allows applying an aggregation to the result values in case
   multiple are present. One of:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `mean`
     - `median`
@@ -771,7 +820,7 @@ Where:
     - `min`
     - `max`
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 ##### Examples
 
@@ -937,15 +986,19 @@ The complete syntax of the `ado show related` command is as follows:
 ado show related RESOURCE_TYPE [RESOURCE_ID] [--use-latest]
 ```
 
-- `RESOURCE_TYPE` is one of the supported resource types:
+- `RESOURCE_TYPE` is one of the supported resource types. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
+    - _actuatorconfiguration_ (_ac_)
+    - _datacontainer_ (_dcr_)
+    - _discoveryspace_ (_space_)
     - _operation_ (_op_)
     - _samplestore_ (_store_)
-    - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource you want to see related
   resources for.
@@ -983,7 +1036,8 @@ ado show summary RESOURCE_TYPE [RESOURCE_IDS...] [--use-latest] \
 
 Where:
 
-- `RESOURCE_TYPE` is always _discoveryspace_ (_space_)
+- `RESOURCE_TYPE` is always discoveryspace (space). See
+  [Resource Type Shorthands](#resource-type-shorthands) for the shorthand alias.
 - `RESOURCE_IDS` are one or more space-separated space identifiers.
 - `--use-latest` will add the identifier of the latest (i.e. most recent) space
   from the current context to the RESOURCE_IDS.
@@ -1002,14 +1056,14 @@ Where:
 - `--output` (or `-o`) allows choosing the output format in which the
   information should be displayed. Can be one of either:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `table` (**default**) - for a formatted table output.
     - `md-table` - for a table in Markdown format.
     - `md-report` - for a report in Markdown format.
     - `csv` - for CSV format.
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--output-file` specifies a file path to write the output to. If not provided,
   output is written to stdout.
@@ -1112,17 +1166,20 @@ ado template RESOURCE_TYPE [--output-file <PATH>] \
 
 Where:
 
-- `RESOURCE_TYPE` is one of the supported resource types:
+- `RESOURCE_TYPE` is one of the supported resource types. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _actuator_
     - _actuatorconfiguration_ (_ac_)
     - _context_ (_ctx_)
-    - _operation_ (_op_)
     - _discoveryspace_ (_space_)
+    - _operation_ (_op_)
+    - _samplestore_ (_store_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--output-file` can be used to specify a file path where the template will be
   saved. If not specified, the template will be written to stdout.
@@ -1134,7 +1191,7 @@ Where:
 - `--operator-type` (**exclusive for operations**) is the type of operator to
   generate a template for. Must be one of the supported operator types:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - `characterize`
     - `search`
@@ -1144,7 +1201,7 @@ Where:
     - `fuse`
     - `learn`
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--actuator-configuration` (**exclusive for actuatorconfigurations**) is the
   identifier of the actuator to output. If unset, a generic actuator
@@ -1216,17 +1273,19 @@ ado upgrade RESOURCE_TYPE [--apply-legacy-migrator <VALIDATOR_ID>] \
 
 Where:
 
-- `RESOURCE_TYPE` is one of the supported resource types:
+- `RESOURCE_TYPE` is one of the supported resource types. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
 
-<!-- prettier-ignore-start -->
+    <!-- prettier-ignore-start -->
 
     - _actuatorconfiguration_ (_ac_)
     - _datacontainer_ (_dcr_)
+    - _discoveryspace_ (_space_)
     - _operation_ (_op_)
     - _samplestore_ (_store_)
-    - _discoveryspace_ (_space_)
 
-<!-- prettier-ignore-end -->
+    <!-- prettier-ignore-end -->
 
 - `--apply-legacy-migrator` applies a specific legacy migrator by identifier
   during the upgrade process. This option can be specified multiple times to


### PR DESCRIPTION
Resolves #827 by adding a dedicated shorthand section. Fixes auto code block detection in ado.md