### PR TITLE
feat(cli): add support for deleting multiple resources in ado delete

### DIFF
--- a/orchestrator/cli/commands/delete.py
+++ b/orchestrator/cli/commands/delete.py
@@ -6,11 +6,6 @@ from typing import Annotated
 
 import typer
 
-from orchestrator.cli.exceptions.handlers import (
-    handle_no_related_resource,
-    handle_resource_deletion_error,
-    handle_resource_does_not_exist,
-)
 from orchestrator.cli.models.choice import HiddenPluralChoice
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
 from orchestrator.cli.models.types import AdoDeleteSupportedResourceTypes
@@ -22,6 +17,7 @@ from orchestrator.cli.resources.data_container.delete import delete_data_contain
 from orchestrator.cli.resources.discovery_space.delete import delete_discovery_space
 from orchestrator.cli.resources.operation.delete import delete_operation
 from orchestrator.cli.resources.sample_store.delete import delete_sample_store
+from orchestrator.cli.utils.output.prints import console_print
 from orchestrator.metastore.base import (
     DeleteFromDatabaseError,
     NoRelatedResourcesError,
@@ -32,6 +28,66 @@ if typing.TYPE_CHECKING:
     from orchestrator.cli.core.config import AdoConfiguration
 
 CONTEXT_ONLY_PANEL_NAME = "Context-only options"
+
+
+def _report_deletion_results(
+    resource_type: AdoDeleteSupportedResourceTypes,
+    successes: list[str],
+    failures: list[tuple[str, Exception]],
+    ado_configuration: "AdoConfiguration",
+) -> None:
+    """
+    Report the results of batch deletion operations.
+
+    Args:
+        resource_type: The type of resource being deleted
+        successes: List of successfully deleted resource IDs
+        failures: List of (resource_id, exception) tuples for failed deletions
+        ado_configuration: The ado configuration
+    """
+    from orchestrator.cli.utils.output.prints import (
+        SUCCESS,
+        console_print,
+        magenta,
+    )
+
+    total = len(successes) + len(failures)
+
+    # If only one resource and it succeeded, use simple success message
+    if total == 1 and len(successes) == 1:
+        console_print(SUCCESS)
+        return
+
+    # Report individual results
+    for resource_id in successes:
+        console_print(
+            f":white_check_mark: Successfully deleted: {magenta(resource_id)}"
+        )
+
+    for resource_id, error in failures:
+        error_msg = str(error)
+        # Extract meaningful error message
+        if isinstance(error, ResourceDoesNotExistError):
+            error_msg = "Resource does not exist"
+        elif isinstance(error, NoRelatedResourcesError):
+            error_msg = "No related resources found"
+        elif isinstance(error, DeleteFromDatabaseError):
+            error_msg = "Failed to delete from database"
+        elif "children" in error_msg.lower():
+            error_msg = "Cannot delete due to dependent resources"
+
+        console_print(
+            f":x: Failed to delete {magenta(resource_id)}: {error_msg}", stderr=True
+        )
+
+    # Summary
+    if total > 1:
+        console_print("\nSummary:")
+        console_print(f"  - Successfully deleted {len(successes)} resource(s)")
+        if failures:
+            console_print(
+                f"  - Failed to delete {len(failures)} resource(s)", stderr=True
+            )
 
 
 def delete_resource(
@@ -45,11 +101,11 @@ def delete_resource(
             click_type=HiddenPluralChoice(AdoDeleteSupportedResourceTypes),
         ),
     ],
-    resource_id: Annotated[
-        str,
+    resource_ids: Annotated[
+        list[str],
         typer.Argument(
             ...,
-            help="The id of the resource to delete.",
+            help="The id(s) of the resource(s) to delete. Multiple IDs can be provided.",
             show_default=False,
         ),
     ],
@@ -91,6 +147,9 @@ def delete_resource(
     # Delete an operation and its results
     ado delete operation <operation-id>
 
+    # Delete multiple operations
+    ado delete operation <op-id-1> <op-id-2> <op-id-3>
+
     # Delete a sample store that contains data
     ado delete samplestore <sample-store-id> --force
 
@@ -99,13 +158,6 @@ def delete_resource(
     """
 
     ado_configuration: AdoConfiguration = ctx.obj
-
-    parameters = AdoDeleteCommandParameters(
-        ado_configuration=ado_configuration,
-        delete_local_db=delete_local_db,
-        force=force,
-        resource_id=resource_id,
-    )
 
     method_mapping = {
         AdoDeleteSupportedResourceTypes.ACTUATOR_CONFIGURATION: delete_actuator_configuration,
@@ -116,18 +168,46 @@ def delete_resource(
         AdoDeleteSupportedResourceTypes.OPERATION: delete_operation,
     }
 
-    try:
-        method_mapping[resource_type](parameters=parameters)
-    except ResourceDoesNotExistError as e:
-        handle_resource_does_not_exist(
-            error=e, project_context=ado_configuration.project_context
+    # Process each resource ID
+    successes: list[str] = []
+    failures: list[tuple[str, Exception]] = []
+
+    for resource_id in resource_ids:
+        # Create parameters with single resource_id for backward compatibility
+        single_params = AdoDeleteCommandParameters(
+            ado_configuration=ado_configuration,
+            delete_local_db=delete_local_db,
+            force=force,
+            resource_ids=[resource_id],
         )
-    except NoRelatedResourcesError as e:
-        handle_no_related_resource(
-            error=e, project_context=ado_configuration.project_context
-        )
-    except DeleteFromDatabaseError as e:
-        handle_resource_deletion_error(error=e)
+
+        try:
+            method_mapping[resource_type](parameters=single_params)
+            successes.append(resource_id)
+        except (
+            ResourceDoesNotExistError,
+            NoRelatedResourcesError,
+            DeleteFromDatabaseError,
+        ) as e:
+            failures.append((resource_id, e))
+        except typer.Exit:
+            # Resource-specific delete functions may raise typer.Exit
+            # Treat this as a failure for this resource
+            failures.append((resource_id, Exception("Deletion failed")))
+        finally:
+            console_print("")
+
+    # Report results
+    _report_deletion_results(
+        resource_type=resource_type,
+        successes=successes,
+        failures=failures,
+        ado_configuration=ado_configuration,
+    )
+
+    # Exit with error if any deletions failed
+    if failures:
+        raise typer.Exit(1)
 
 
 def register_delete_command(app: typer.Typer) -> None:

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -63,7 +63,7 @@ class AdoDeleteCommandParameters(pydantic.BaseModel):
     ado_configuration: AdoConfiguration
     delete_local_db: bool | None
     force: bool
-    resource_id: str
+    resource_ids: list[str]
 
 
 class AdoDescribeCommandParameters(pydantic.BaseModel):

--- a/orchestrator/cli/resources/actuator_configuration/delete.py
+++ b/orchestrator/cli/resources/actuator_configuration/delete.py
@@ -21,21 +21,23 @@ from orchestrator.metastore.base import (
 
 
 def delete_actuator_configuration(parameters: AdoDeleteCommandParameters) -> None:
+    # Extract the single resource_id from the list
+    resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
     with Status(ADO_SPINNER_QUERYING_DB) as spinner:
         if not sql.containsResourceWithIdentifier(
-            identifier=parameters.resource_id,
+            identifier=resource_id,
             kind=CoreResourceKinds.ACTUATORCONFIGURATION,
         ):
             spinner.stop()
             raise ResourceDoesNotExistError(
-                resource_id=parameters.resource_id,
+                resource_id=resource_id,
                 kind=CoreResourceKinds.ACTUATORCONFIGURATION,
             )
 
         children_resources = sql.getRelatedObjectResourceIdentifiers(
-            identifier=parameters.resource_id
+            identifier=resource_id
         )
 
         if not children_resources.empty:
@@ -43,7 +45,7 @@ def delete_actuator_configuration(parameters: AdoDeleteCommandParameters) -> Non
             console_print(
                 cannot_delete_resource_due_to_children_resources(
                     resource_kind=CoreResourceKinds.ACTUATORCONFIGURATION,
-                    resource_id=parameters.resource_id,
+                    resource_id=resource_id,
                     children_resources=children_resources,
                 ),
                 stderr=True,
@@ -52,7 +54,7 @@ def delete_actuator_configuration(parameters: AdoDeleteCommandParameters) -> Non
 
         spinner.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
-            sql.delete_actuator_configuration(parameters.resource_id)
+            sql.delete_actuator_configuration(resource_id)
         except DeleteFromDatabaseError:
             spinner.stop()
             raise

--- a/orchestrator/cli/resources/context/delete.py
+++ b/orchestrator/cli/resources/context/delete.py
@@ -19,12 +19,14 @@ from orchestrator.utilities.dictionaries import get_nested_value
 
 
 def delete_context(parameters: AdoDeleteCommandParameters) -> None:
+    # Extract the single resource_id from the list
+    resource_id = parameters.resource_ids[0]
 
     available_contexts = parameters.ado_configuration.available_contexts
-    if parameters.resource_id not in available_contexts:
+    if resource_id not in available_contexts:
         console_print(
             context_not_in_available_contexts_error_str(
-                requested_context=parameters.resource_id,
+                requested_context=resource_id,
                 available_contexts=available_contexts,
             ),
             stderr=True,
@@ -32,16 +34,14 @@ def delete_context(parameters: AdoDeleteCommandParameters) -> None:
         raise typer.Exit(1)
 
     configuration_file = parameters.ado_configuration.project_context_path_for_context(
-        parameters.resource_id
+        resource_id
     )
     context_dict = yaml.safe_load(configuration_file.read_text())
 
     # AP: the db might not exist if the user has never used the local context
     if (
         get_nested_value(context_dict, "metadataStore.scheme") == "sqlite"
-        and parameters.ado_configuration.local_db_path_for_context(
-            parameters.resource_id
-        ).exists()
+        and parameters.ado_configuration.local_db_path_for_context(resource_id).exists()
     ):
         if parameters.delete_local_db is None:
             parameters.delete_local_db = Confirm.ask(
@@ -53,7 +53,7 @@ def delete_context(parameters: AdoDeleteCommandParameters) -> None:
                 )
 
         local_db_path = parameters.ado_configuration.local_db_path_for_context(
-            parameters.resource_id
+            resource_id
         )
         if parameters.delete_local_db:
             console_print(f"{INFO}Deleting local db {local_db_path}\n", stderr=True)
@@ -66,11 +66,11 @@ def delete_context(parameters: AdoDeleteCommandParameters) -> None:
     configuration_file.unlink()
     console_print(SUCCESS, stderr=True)
 
-    if parameters.resource_id == parameters.ado_configuration.active_context:
+    if resource_id == parameters.ado_configuration.active_context:
         parameters.ado_configuration.active_context = None
         parameters.ado_configuration.store()
         console_print(
-            f"{WARN}{parameters.resource_id} was your default context.\n"
+            f"{WARN}{resource_id} was your default context.\n"
             f"{HINT}Set a different one with {cyan('ado context')} or {cyan('ado create context')}",
             stderr=True,
         )

--- a/orchestrator/cli/resources/data_container/delete.py
+++ b/orchestrator/cli/resources/data_container/delete.py
@@ -21,27 +21,29 @@ from orchestrator.metastore.base import (
 
 
 def delete_data_container(parameters: AdoDeleteCommandParameters) -> None:
+    # Extract the single resource_id from the list
+    resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
     with Status(ADO_SPINNER_QUERYING_DB) as status:
         if not sql.containsResourceWithIdentifier(
-            identifier=parameters.resource_id,
+            identifier=resource_id,
             kind=CoreResourceKinds.DATACONTAINER,
         ):
             status.stop()
             raise ResourceDoesNotExistError(
-                resource_id=parameters.resource_id, kind=CoreResourceKinds.DATACONTAINER
+                resource_id=resource_id, kind=CoreResourceKinds.DATACONTAINER
             )
 
         children_resources = sql.getRelatedObjectResourceIdentifiers(
-            identifier=parameters.resource_id
+            identifier=resource_id
         )
         if not children_resources.empty:
             status.stop()
             console_print(
                 cannot_delete_resource_due_to_children_resources(
                     resource_kind=CoreResourceKinds.DATACONTAINER,
-                    resource_id=parameters.resource_id,
+                    resource_id=resource_id,
                     children_resources=children_resources,
                 ),
                 stderr=True,
@@ -50,7 +52,7 @@ def delete_data_container(parameters: AdoDeleteCommandParameters) -> None:
 
         status.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
-            sql.delete_discovery_space(identifier=parameters.resource_id)
+            sql.delete_discovery_space(identifier=resource_id)
         except DeleteFromDatabaseError:
             status.stop()
             raise

--- a/orchestrator/cli/resources/discovery_space/delete.py
+++ b/orchestrator/cli/resources/discovery_space/delete.py
@@ -21,28 +21,30 @@ from orchestrator.metastore.base import (
 
 
 def delete_discovery_space(parameters: AdoDeleteCommandParameters) -> None:
+    # Extract the single resource_id from the list
+    resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
     with Status(ADO_SPINNER_QUERYING_DB) as status:
         if not sql.containsResourceWithIdentifier(
-            identifier=parameters.resource_id,
+            identifier=resource_id,
             kind=CoreResourceKinds.DISCOVERYSPACE,
         ):
             status.stop()
             raise ResourceDoesNotExistError(
-                resource_id=parameters.resource_id,
+                resource_id=resource_id,
                 kind=CoreResourceKinds.DISCOVERYSPACE,
             )
 
         children_resources = sql.getRelatedObjectResourceIdentifiers(
-            identifier=parameters.resource_id
+            identifier=resource_id
         )
         if not children_resources.empty:
             status.stop()
             console_print(
                 cannot_delete_resource_due_to_children_resources(
                     resource_kind=CoreResourceKinds.DISCOVERYSPACE,
-                    resource_id=parameters.resource_id,
+                    resource_id=resource_id,
                     children_resources=children_resources,
                 ),
                 stderr=True,
@@ -51,7 +53,7 @@ def delete_discovery_space(parameters: AdoDeleteCommandParameters) -> None:
 
         status.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
-            sql.delete_discovery_space(identifier=parameters.resource_id)
+            sql.delete_discovery_space(identifier=resource_id)
         except DeleteFromDatabaseError:
             status.stop()
             raise

--- a/orchestrator/cli/resources/operation/delete.py
+++ b/orchestrator/cli/resources/operation/delete.py
@@ -29,27 +29,29 @@ from orchestrator.metastore.base import (
 
 
 def delete_operation(parameters: AdoDeleteCommandParameters) -> None:
+    # Extract the single resource_id from the list
+    resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
     with Status(ADO_SPINNER_QUERYING_DB) as status:
 
         if not sql.containsResourceWithIdentifier(
-            identifier=parameters.resource_id,
+            identifier=resource_id,
             kind=CoreResourceKinds.OPERATION,
         ):
             raise ResourceDoesNotExistError(
-                resource_id=parameters.resource_id, kind=CoreResourceKinds.OPERATION
+                resource_id=resource_id, kind=CoreResourceKinds.OPERATION
             )
 
         children_resources = sql.getRelatedObjectResourceIdentifiers(
-            identifier=parameters.resource_id
+            identifier=resource_id
         )
         if not children_resources.empty:
             status.stop()
             console_print(
                 cannot_delete_resource_due_to_children_resources(
                     resource_kind=CoreResourceKinds.OPERATION,
-                    resource_id=parameters.resource_id,
+                    resource_id=resource_id,
                     children_resources=children_resources,
                 ),
                 stderr=True,
@@ -59,14 +61,14 @@ def delete_operation(parameters: AdoDeleteCommandParameters) -> None:
         status.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
             sql.delete_operation(
-                identifier=parameters.resource_id,
+                identifier=resource_id,
                 ignore_running_operations=parameters.force,
             )
         except NotSupportedOnSQLiteError as e:
             status.stop()
             console_print(
                 f"{ERROR}Checking for running operations using the same sample store as "
-                f"operation {magenta(parameters.resource_id)} is not supported on local contexts.\n"
+                f"operation {magenta(resource_id)} is not supported on local contexts.\n"
                 f"{HINT}Make sure there are no such operations, and force the deletion by adding the "
                 f"{cyan('--force')} flag.",
                 stderr=True,

--- a/orchestrator/cli/resources/sample_store/delete.py
+++ b/orchestrator/cli/resources/sample_store/delete.py
@@ -25,20 +25,22 @@ from orchestrator.metastore.base import (
 
 
 def delete_sample_store(parameters: AdoDeleteCommandParameters) -> None:
+    # Extract the single resource_id from the list
+    resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
     with Status(ADO_SPINNER_QUERYING_DB) as spinner:
         if not sql.containsResourceWithIdentifier(
-            identifier=parameters.resource_id,
+            identifier=resource_id,
             kind=CoreResourceKinds.SAMPLESTORE,
         ):
             spinner.stop()
             raise ResourceDoesNotExistError(
-                resource_id=parameters.resource_id, kind=CoreResourceKinds.SAMPLESTORE
+                resource_id=resource_id, kind=CoreResourceKinds.SAMPLESTORE
             )
 
         children_resources = sql.getRelatedObjectResourceIdentifiers(
-            identifier=parameters.resource_id
+            identifier=resource_id
         )
 
         if not children_resources.empty:
@@ -46,7 +48,7 @@ def delete_sample_store(parameters: AdoDeleteCommandParameters) -> None:
             console_print(
                 cannot_delete_resource_due_to_children_resources(
                     resource_kind=CoreResourceKinds.SAMPLESTORE,
-                    resource_id=parameters.resource_id,
+                    resource_id=resource_id,
                     children_resources=children_resources,
                 ),
                 stderr=True,
@@ -56,7 +58,7 @@ def delete_sample_store(parameters: AdoDeleteCommandParameters) -> None:
         spinner.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
             sql.delete_sample_store(
-                identifier=parameters.resource_id, force_deletion=parameters.force
+                identifier=resource_id, force_deletion=parameters.force
             )
         except NonEmptySampleStorePreventingDeletionError as e:
             spinner.stop()

--- a/tests/ado/delete/test_ado_delete_actuator_configuration.py
+++ b/tests/ado/delete/test_ado_delete_actuator_configuration.py
@@ -102,6 +102,5 @@ def test_delete_nonexistent_actuator_configuration(
         ],
     )
     assert result.exit_code == 1, result.output
-    assert (
-        "ERROR:  The database does not contain a resource with id does-not-exist and kind actuatorconfiguration."
-    ) in result.output.strip()
+    assert "Failed to delete does-not-exist" in result.output
+    assert "Resource does not exist" in result.output

--- a/tests/ado/delete/test_ado_delete_multiple.py
+++ b/tests/ado/delete/test_ado_delete_multiple.py
@@ -1,0 +1,282 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import pathlib
+from collections.abc import Callable
+
+from typer.testing import CliRunner
+
+from orchestrator.cli.core.cli import app as ado
+from orchestrator.core.resources import CoreResourceKinds
+from orchestrator.core.samplestore.sql import SQLSampleStore
+from orchestrator.metastore.project import ProjectContext
+from orchestrator.metastore.sqlstore import SQLStore
+from orchestrator.schema.experiment import Experiment
+from orchestrator.schema.request import (
+    MeasurementRequest,
+)
+from tests.conftest import requires_sqlite_3_38
+
+
+@requires_sqlite_3_38
+def test_delete_multiple_operations_success(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    sql_store: SQLStore,
+    ml_multi_cloud_benchmark_performance_experiment: Experiment,
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+    random_identifier: Callable[[], str],
+) -> None:
+    """Test deleting multiple operations successfully."""
+    assert ml_multi_cloud_benchmark_performance_experiment is not None
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create three operations
+    operation_ids = [random_identifier() for _ in range(3)]
+    sample_stores = []
+
+    for operation_id in operation_ids:
+        sample_store, _, _ = simulate_ml_multi_cloud_random_walk_operation(
+            number_entities=2,
+            number_requests=2,
+            measurements_per_result=1,
+            operation_id=operation_id,
+        )
+        sample_stores.append(sample_store)
+
+    # Verify operations exist
+    for i, operation_id in enumerate(operation_ids):
+        assert sql_store.containsResourceWithIdentifier(
+            identifier=operation_id,
+            kind=CoreResourceKinds.OPERATION,
+        )
+        assert (
+            sample_stores[i].measurement_requests_count_for_operation(
+                operation_id=operation_id
+            )
+            == 2
+        )
+
+    # Delete all three operations
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "delete",
+            "operation",
+            *operation_ids,
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Successfully deleted" in result.output
+    assert operation_ids[0] in result.output
+    assert operation_ids[1] in result.output
+    assert operation_ids[2] in result.output
+
+    # Verify all operations are deleted
+    for i, operation_id in enumerate(operation_ids):
+        assert not sql_store.containsResourceWithIdentifier(
+            identifier=operation_id,
+            kind=CoreResourceKinds.OPERATION,
+        )
+        assert (
+            sample_stores[i].measurement_requests_count_for_operation(
+                operation_id=operation_id
+            )
+            == 0
+        )
+
+
+@requires_sqlite_3_38
+def test_delete_multiple_operations_partial_failure(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    sql_store: SQLStore,
+    ml_multi_cloud_benchmark_performance_experiment: Experiment,
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+    random_identifier: Callable[[], str],
+) -> None:
+    """Test deleting multiple operations where some don't exist."""
+    assert ml_multi_cloud_benchmark_performance_experiment is not None
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two operations
+    valid_op_1 = random_identifier()
+    valid_op_2 = random_identifier()
+    invalid_op = "non-existent-operation-id"
+
+    sample_store_1, _, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=2,
+        measurements_per_result=1,
+        operation_id=valid_op_1,
+    )
+    sample_store_2, _, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=2,
+        measurements_per_result=1,
+        operation_id=valid_op_2,
+    )
+
+    # Try to delete two valid and one invalid operation
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "delete",
+            "operation",
+            valid_op_1,
+            invalid_op,
+            valid_op_2,
+            "--force",
+        ],
+    )
+
+    # Should exit with error code due to partial failure
+    assert result.exit_code == 1, result.output
+
+    # Check output contains success and failure messages
+    assert "Successfully deleted" in result.output
+    assert "Failed to delete" in result.output
+    assert valid_op_1 in result.output
+    assert valid_op_2 in result.output
+    assert invalid_op in result.output
+
+    # Verify valid operations are deleted
+    assert not sql_store.containsResourceWithIdentifier(
+        identifier=valid_op_1,
+        kind=CoreResourceKinds.OPERATION,
+    )
+    assert (
+        sample_store_1.measurement_requests_count_for_operation(operation_id=valid_op_1)
+        == 0
+    )
+    assert not sql_store.containsResourceWithIdentifier(
+        identifier=valid_op_2,
+        kind=CoreResourceKinds.OPERATION,
+    )
+    assert (
+        sample_store_2.measurement_requests_count_for_operation(operation_id=valid_op_2)
+        == 0
+    )
+
+
+@requires_sqlite_3_38
+def test_delete_single_operation_backward_compatible(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    sql_store: SQLStore,
+    ml_multi_cloud_benchmark_performance_experiment: Experiment,
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+    random_identifier: Callable[[], str],
+) -> None:
+    """Test that single operation deletion still works (backward compatibility)."""
+    assert ml_multi_cloud_benchmark_performance_experiment is not None
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    operation_id = random_identifier()
+    sample_store, _, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=2,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+
+    # Delete single operation (original behavior)
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "delete",
+            "operation",
+            operation_id,
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Verify operation is deleted
+    assert not sql_store.containsResourceWithIdentifier(
+        identifier=operation_id,
+        kind=CoreResourceKinds.OPERATION,
+    )
+    assert (
+        sample_store.measurement_requests_count_for_operation(operation_id=operation_id)
+        == 0
+    )
+
+
+@requires_sqlite_3_38
+def test_delete_multiple_operations_all_fail(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    sql_store: SQLStore,
+) -> None:
+    """Test deleting multiple non-existent operations."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Try to delete three non-existent operations
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "delete",
+            "operation",
+            "non-existent-1",
+            "non-existent-2",
+            "non-existent-3",
+            "--force",
+        ],
+    )
+
+    # Should exit with error code
+    assert result.exit_code == 1, result.output
+
+    # Check output contains failure messages
+    assert "Failed to delete" in result.output
+    assert "non-existent-1" in result.output
+    assert "non-existent-2" in result.output
+    assert "non-existent-3" in result.output
+    assert "Summary" in result.output
+    assert "Failed to delete 3 resource(s)" in result.output
+
+
+# Made with Bob

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -260,7 +260,7 @@ The **ado** CLI provides the delete command to delete
 The complete syntax of the `ado delete` command is as follows:
 
 ```shell
-ado delete RESOURCE_TYPE RESOURCE_ID \
+ado delete RESOURCE_TYPE RESOURCE_ID [RESOURCE_ID ...] \
            [--force] \
            [--delete-local-db] [--no-delete-local-db]
 ```
@@ -282,7 +282,9 @@ Where:
 
     <!-- prettier-ignore-end -->
 
-- `RESOURCE_ID` is the unique identifier of the resource to delete.
+- `RESOURCE_ID` is the unique identifier of the resource to delete. Multiple
+  resource IDs can be provided to delete multiple resources of the same type in
+  a single command.
 - `--force` enables forced deletion of resources in the following cases:
 
     <!-- prettier-ignore-start -->
@@ -311,10 +313,28 @@ ado delete context my-context
 ado delete context my-local-context --no-delete-local-db
 ```
 
-##### Deleting a space
+##### Deleting a single space
 
 ```shell
 ado delete space space-abc123-456def
+```
+
+##### Deleting multiple operations
+
+```shell
+ado delete operation op-id-1 op-id-2 op-id-3
+```
+
+##### Deleting multiple operations with force flag
+
+```shell
+ado delete operation op-id-1 op-id-2 op-id-3 --force
+```
+
+##### Deleting multiple discovery spaces
+
+```shell
+ado delete space space-1 space-2 space-3
 ```
 
 ### ado describe


### PR DESCRIPTION
# Summary

This pull request adds support for deleting multiple resources in a single command to the `ado delete` CLI. Previously, users could only delete one resource at a time. Now they can specify multiple resource IDs as arguments (e.g., `ado delete operation op-1 op-2 op-3`), with comprehensive reporting of successes and failures.

Closes #776 

# Files Changed

📄 `orchestrator/cli/commands/delete.py`

Added batch deletion support with a new `_report_deletion_results()` function that provides detailed feedback. Changed `resource_id` parameter to `resource_ids` (list), implemented loop to process each resource individually, and added comprehensive error handling with summary reporting. Removed direct exception handler imports in favor of inline error handling.

📄 `orchestrator/cli/models/parameters.py`

Updated `AdoDeleteCommandParameters` model to change `resource_id` field from `str` to `resource_ids: list[str]` to support multiple resource IDs.

📄 `orchestrator/cli/resources/actuator_configuration/delete.py`

Updated to extract the single resource_id from the `resource_ids` list (maintaining backward compatibility with the new list-based parameter structure). All references to `parameters.resource_id` changed to use the extracted `resource_id` variable.

📄 `orchestrator/cli/resources/context/delete.py`

Updated to extract the single resource_id from the `resource_ids` list. All references to `parameters.resource_id` changed to use the extracted `resource_id` variable.

📄 `orchestrator/cli/resources/data_container/delete.py`

Updated to extract the single resource_id from the `resource_ids` list. All references to `parameters.resource_id` changed to use the extracted `resource_id` variable.

📄 `orchestrator/cli/resources/discovery_space/delete.py`

Updated to extract the single resource_id from the `resource_ids` list. All references to `parameters.resource_id` changed to use the extracted `resource_id` variable.

📄 `orchestrator/cli/resources/operation/delete.py`

Updated to extract the single resource_id from the `resource_ids` list. All references to `parameters.resource_id` changed to use the extracted `resource_id` variable.

📄 `orchestrator/cli/resources/sample_store/delete.py`

Updated to extract the single resource_id from the `resource_ids` list. All references to `parameters.resource_id` changed to use the extracted `resource_id` variable.

📄 `tests/ado/delete/test_ado_delete_actuator_configuration.py`

Updated test assertions to match new error message format that reports "Failed to delete" and "Resource does not exist" instead of the old detailed ERROR message.

📄 `tests/ado/delete/test_ado_delete_multiple.py`

New test file with comprehensive test coverage for multiple deletion scenarios: successful deletion of multiple operations, partial failures (mix of valid/invalid IDs), backward compatibility with single deletion, and complete failure scenarios.