### PR TITLE
fix(operators): prevent infinite recursion when calling non-explore operators

### DIFF
--- a/orchestrator/modules/operators/_general_orchestration.py
+++ b/orchestrator/modules/operators/_general_orchestration.py
@@ -1,6 +1,7 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
+import inspect
 import logging
 import typing
 
@@ -21,6 +22,24 @@ from orchestrator.modules.operators.base import OperatorFunction
 moduleLog = logging.getLogger("general_orchestration")
 
 
+def _operator_callable_for_harness(registered: OperatorFunction) -> OperatorFunction:
+    """Resolve the callable to execute inside :func:`_run_operation_harness`.
+
+    Operators registered via ``characterize_operation`` / ``modify_operation`` /
+    ``export_operation`` store a *wrapper* in :class:`~orchestrator.core.operation.config.OperatorMetadata`
+    that delegates to :func:`orchestrate_general_operation`. The harness must run the
+    underlying implementation (``functools.wraps`` sets ``__wrapped__``); otherwise
+    ``run_closure`` re-invokes the wrapper and recurses without bound.
+
+    Args:
+        registered: The callable stored on the operator metadata (wrapper or not).
+
+    Returns:
+        The innermost unwrapped callable, or *registered* if there is no wrapper chain.
+    """
+    return typing.cast("OperatorFunction", inspect.unwrap(registered))
+
+
 def run_general_operation_core_closure(
     operation_function: OperatorFunction,
     discovery_space: DiscoverySpace,
@@ -29,9 +48,8 @@ def run_general_operation_core_closure(
 ) -> typing.Callable[[], OperationOutput | None]:
 
     def _run_general_operation_core() -> OperationOutput | None:
-        return operation_function(
-            discovery_space, operationInfo, **operation_parameters
-        )
+        implementation = _operator_callable_for_harness(operation_function)
+        return implementation(discovery_space, operationInfo, **operation_parameters)
 
     return _run_general_operation_core
 

--- a/plugins/operators/no-priors-characterization/src/no_priors_characterization/operator.py
+++ b/plugins/operators/no-priors-characterization/src/no_priors_characterization/operator.py
@@ -46,12 +46,15 @@ def no_priors_characterization(
         OperationOutput containing the operation resources and metadata
     """
     # Lazy import to avoid circular import issues during plugin loading
+    import orchestrator.modules.operators.randomwalk  # noqa: F401 — registers explore.random_walk
+    from orchestrator.modules.operators.collections import explore
     from orchestrator.modules.operators.randomwalk import (
         CustomSamplerConfiguration,
         RandomWalkParameters,
         SamplerModuleConf,
-        random_walk,
     )
+
+    random_walk = explore.operators["random_walk"].function
 
     params = NoPriorsParameters.model_validate(kwargs)
     logger.info(

--- a/plugins/operators/trim/src/trim/operator.py
+++ b/plugins/operators/trim/src/trim/operator.py
@@ -55,13 +55,15 @@ def trim(
         OperationOutput containing the operation resources and metadata
     """
     # Lazy import to avoid circular import issues during plugin loading
-    from orchestrator.modules.operators.collections import characterize
+    import orchestrator.modules.operators.randomwalk  # noqa: F401 — registers explore.random_walk
+    from orchestrator.modules.operators.collections import characterize, explore
     from orchestrator.modules.operators.randomwalk import (
         CustomSamplerConfiguration,
         RandomWalkParameters,
         SamplerModuleConf,
-        random_walk,
     )
+
+    random_walk = explore.operators["random_walk"].function
 
     params = TrimParameters.model_validate(kwargs)
     logger_trim.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ test = [
   "pfas-custom-functions",
   "profile-space",
   "robotic-lab",
+  "trim-custom-experiments",
 ]
 
 [build-system]
@@ -153,6 +154,7 @@ optimization-test-functions = { workspace = true, editable = true }
 pfas-custom-functions = { workspace = true, editable = true }
 profile-space = { workspace = true, editable = true }
 robotic-lab = { workspace = true, editable = true }
+trim-custom-experiments = { path = "examples/trim/custom_experiments", editable = true }
 detect-secrets = { git = "https://github.com/ibm/detect-secrets.git", rev = "master" }
 
 [tool.uv-dynamic-versioning]

--- a/requirements.txt
+++ b/requirements.txt
@@ -422,6 +422,7 @@ googleapis-common-protos==1.74.0 \
     # via google-api-core
 greenlet==3.4.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' \
     --hash=sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267 \
+    --hash=sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077 \
     --hash=sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82 \
     --hash=sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97 \
     --hash=sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a \
@@ -435,20 +436,27 @@ greenlet==3.4.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or 
     --hash=sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c \
     --hash=sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711 \
     --hash=sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82 \
+    --hash=sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d \
     --hash=sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58 \
     --hash=sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08 \
     --hash=sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940 \
+    --hash=sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81 \
+    --hash=sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76 \
     --hash=sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996 \
     --hash=sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a \
     --hash=sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71 \
+    --hash=sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f \
     --hash=sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de \
     --hash=sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2 \
     --hash=sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab \
     --hash=sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc \
     --hash=sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875 \
+    --hash=sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508 \
     --hash=sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b \
+    --hash=sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55 \
     --hash=sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83 \
     --hash=sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6 \
+    --hash=sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb \
     --hash=sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2 \
     --hash=sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e \
     --hash=sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff \

--- a/tests/actuators/test_actuators.py
+++ b/tests/actuators/test_actuators.py
@@ -138,7 +138,7 @@ def test_custom_experiments(
         "custom_experiments"
     )
 
-    assert len(c.experiments) == 5
+    assert len(c.experiments) == 7
 
     for e in c.experiments:
         assert catalog.experimentForReference(e.reference) is not None

--- a/tests/actuators/test_actuators.py
+++ b/tests/actuators/test_actuators.py
@@ -113,8 +113,8 @@ def test_custom_experiments(
     # SV 7/02/26
     # This test needs to be updated every time a new custom experiment is added to ado
     assert (
-        len(catalog.experiments) == 5
-    ), "Expected 5 experiments in the custom_experiments catalog for testing "
+        len(catalog.experiments) == 7
+    ), "Expected 7 experiments in the custom_experiments catalog for testing "
 
     identifiers = {e.identifier for e in catalog.experiments}
     assert {
@@ -123,7 +123,9 @@ def test_custom_experiments(
         "min_gpu_recommender",
         "avoid_oom_recommender",
         "nevergrad_opt_3d_test_func",
-    } == identifiers, f"Expected the experiments to be called - acid_test, calculate_density, min_gpu_recommender, and nevergrad_opt_3d_test_func but they are called {identifiers}"
+        "calculate_pressure_ideal_gas",
+        "calculate_pressure_gas",
+    } == identifiers, f"Expected the experiments to be called - acid_test, calculate_density, min_gpu_recommender, calculate_pressure_ideal_gas, calculate_pressure_gas, and nevergrad_opt_3d_test_func but they are called {identifiers}"
     loaded = custom_experiments.loadedExperiment.remote(
         orchestrator.schema.reference.ExperimentReference(
             actuatorIdentifier="custom_experiments", experimentIdentifier="acid_test"

--- a/tests/operators/test_general_orchestration.py
+++ b/tests/operators/test_general_orchestration.py
@@ -1,0 +1,26 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import inspect
+
+import pytest
+
+import orchestrator.modules.operators.randomwalk  # noqa: F401 — loads operator plugins
+from orchestrator.modules.operators._general_orchestration import (
+    _operator_callable_for_harness,
+)
+from orchestrator.modules.operators.collections import characterize
+
+
+@pytest.mark.parametrize(
+    "operator_name",
+    ["profile", "no_priors_characterization"],
+)
+def test_operator_callable_for_harness_unwraps_decorated_operator(
+    operator_name: str,
+) -> None:
+    """Decorated operators register a wrapper; harness must call the implementation."""
+    registered = characterize.operators[operator_name].function
+    assert registered is not None
+    resolved = _operator_callable_for_harness(registered)
+    assert resolved is inspect.unwrap(registered)

--- a/tests/operators/test_trim_example_integration.py
+++ b/tests/operators/test_trim_example_integration.py
@@ -1,0 +1,116 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""End-to-end trim operator integration test (example space + custom experiments)."""
+
+import pathlib
+from collections.abc import Callable
+
+import pytest
+import trim_custom_experiments.experiments  # noqa: F401 — registers ideal-gas experiment
+import yaml
+from no_priors_characterization.no_priors_pydantic import NoPriorsParameters
+from testcontainers.mysql import MySqlContainer
+
+import orchestrator.modules.operators.randomwalk  # noqa: F401
+from orchestrator.core.discoveryspace.config import DiscoverySpaceConfiguration
+from orchestrator.core.discoveryspace.space import DiscoverySpace
+from orchestrator.core.operation.resource import (
+    OperationExitStateEnum,
+    OperationResourceEventEnum,
+)
+from orchestrator.core.resources import ADOResourceEventEnum
+from orchestrator.core.samplestore.config import (
+    SampleStoreConfiguration,
+    SampleStoreModuleConf,
+    SampleStoreSpecification,
+)
+from orchestrator.core.samplestore.sql import SQLSampleStore
+from orchestrator.metastore.project import ProjectContext
+from orchestrator.modules.operators.collections import characterize
+
+pytest.importorskip("autogluon")
+
+from trim.trim_pydantic import (
+    AutoGluonArgs,
+    SamplingBudget,
+    StoppingCriterion,
+    TrimParameters,
+)
+
+
+@pytest.fixture
+def trim_minimal_discovery_space(
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_sample_store: Callable[[SampleStoreConfiguration], SQLSampleStore],
+    create_space: Callable[[DiscoverySpaceConfiguration, str], DiscoverySpace],
+) -> DiscoverySpace:
+    """Discovery space with ideal-gas experiment (empty sample store — trim may run no-priors)."""
+    space_conf = DiscoverySpaceConfiguration.model_validate(
+        yaml.safe_load(
+            pathlib.Path("tests/resources/trim/space_minimal.yaml").read_text()
+        )
+    )
+    sample_store = create_sample_store(
+        SampleStoreConfiguration(
+            specification=SampleStoreSpecification(
+                module=SampleStoreModuleConf(
+                    moduleClass="SQLSampleStore",
+                    moduleName="orchestrator.core.samplestore.sql",
+                ),
+            )
+        )
+    )
+    space = create_space(space_conf, sample_store.identifier)
+    return DiscoverySpace.from_stored_configuration(
+        project_context=valid_ado_project_context,
+        space_identifier=space.uri,
+    )
+
+
+@pytest.mark.timeout(900)
+def test_trim_example_operation_succeeds(
+    trim_minimal_discovery_space: DiscoverySpace,
+) -> None:
+    """Run trim on the minimal pressure example; passes if the operation completes successfully."""
+    # Trim requires >1 distinct target value before modeling. AutoGluon's internal
+    # train/test split needs several rows (fails for n_samples=2). Budget must not
+    # exceed tests/resources/trim/space_minimal.yaml entity count (currently 8).
+    params = TrimParameters(
+        targetOutput="pressure",
+        samplingBudget=SamplingBudget(minPoints=8, maxPoints=8),
+        iterationSize=5,
+        outputDirectory="trim_integration_models",
+        stoppingCriterion=StoppingCriterion(enabled=False),
+        autoGluonArgs=AutoGluonArgs(
+            fitArgs={
+                "time_limit": 60,
+                "presets": "medium",
+                "excluded_model_types": ["GBM"],
+            },
+            tabularPredictorArgs={
+                "problem_type": "regression",
+                "verbosity": 0,
+            },
+        ),
+        noPriorParameters=NoPriorsParameters(
+            targetOutput="pressure",
+            samples=8,
+            batchSize=2,
+            sampling_strategy="random",
+        ),
+    )
+    trim_fn = characterize.operators["trim"].function
+    assert trim_fn is not None
+
+    output = trim_fn(
+        trim_minimal_discovery_space,
+        **params.model_dump(),
+    )
+
+    assert output.operation is not None
+    assert output.exitStatus is not None
+    assert output.exitStatus.exit_state == OperationExitStateEnum.SUCCESS
+    assert output.exitStatus.event == OperationResourceEventEnum.FINISHED
+    assert output.operation.status[-1].event == ADOResourceEventEnum.UPDATED

--- a/tests/resources/trim/space_minimal.yaml
+++ b/tests/resources/trim/space_minimal.yaml
@@ -1,0 +1,22 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+# Discrete grid for trim integration tests: current Cartesian size is 8 entities.
+# Keep minPoints/maxPoints in tests/operators/test_trim_example_integration.py <= 8.
+metadata:
+  name: trim_integration_minimal
+entitySpace:
+  - identifier: temperature
+    propertyDomain:
+      domainRange: [270, 274]
+      interval: 2.0
+  - identifier: volume
+    propertyDomain:
+      domainRange: [1, 3]
+      interval: 1.0
+  - identifier: mol
+    propertyDomain:
+      domainRange: [0.1, 0.3]
+      interval: 0.1
+experiments:
+  - actuatorIdentifier: custom_experiments
+    experimentIdentifier: calculate_pressure_ideal_gas

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,7 @@ test = [
     { name = "pfas-custom-functions" },
     { name = "profile-space" },
     { name = "robotic-lab" },
+    { name = "trim-custom-experiments" },
 ]
 
 [package.metadata]
@@ -193,6 +194,7 @@ test = [
     { name = "pfas-custom-functions", editable = "examples/pfas-generative-models/custom_actuator_function" },
     { name = "profile-space", editable = "plugins/operators/profile_space" },
     { name = "robotic-lab", editable = "plugins/actuators/example_actuator" },
+    { name = "trim-custom-experiments", editable = "examples/trim/custom_experiments" },
 ]
 
 [[package]]
@@ -244,10 +246,10 @@ requires-dist = [
 name = "ado-sfttrainer"
 source = { editable = "plugins/actuators/sfttrainer" }
 dependencies = [
-    { name = "aim" },
-    { name = "jwt" },
-    { name = "psutil" },
-    { name = "transformers" },
+    { name = "aim", marker = "python_full_version < '3.13'" },
+    { name = "jwt", marker = "python_full_version < '3.13'" },
+    { name = "psutil", marker = "python_full_version < '3.13'" },
+    { name = "transformers", marker = "python_full_version < '3.13'" },
 ]
 
 [package.metadata]
@@ -312,31 +314,31 @@ name = "aim"
 version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aim-ui" },
-    { name = "aimrecords" },
-    { name = "aimrocks" },
-    { name = "aiofiles" },
-    { name = "alembic" },
-    { name = "boto3" },
-    { name = "cachetools" },
-    { name = "click" },
-    { name = "cryptography" },
-    { name = "fastapi" },
-    { name = "filelock" },
-    { name = "jinja2" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "psutil" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "requests" },
-    { name = "restrictedpython" },
-    { name = "sqlalchemy" },
-    { name = "tqdm" },
-    { name = "uvicorn" },
-    { name = "watchdog" },
-    { name = "websockets" },
+    { name = "aim-ui", marker = "python_full_version < '3.13'" },
+    { name = "aimrecords", marker = "python_full_version < '3.13'" },
+    { name = "aimrocks", marker = "python_full_version < '3.13'" },
+    { name = "aiofiles", marker = "python_full_version < '3.13'" },
+    { name = "alembic", marker = "python_full_version < '3.13'" },
+    { name = "boto3", marker = "python_full_version < '3.13'" },
+    { name = "cachetools", marker = "python_full_version < '3.13'" },
+    { name = "click", marker = "python_full_version < '3.13'" },
+    { name = "cryptography", marker = "python_full_version < '3.13'" },
+    { name = "fastapi", marker = "python_full_version < '3.13'" },
+    { name = "filelock", marker = "python_full_version < '3.13'" },
+    { name = "jinja2", marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "packaging", marker = "python_full_version < '3.13'" },
+    { name = "pillow", marker = "python_full_version < '3.13'" },
+    { name = "psutil", marker = "python_full_version < '3.13'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
+    { name = "pytz", marker = "python_full_version < '3.13'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "restrictedpython", marker = "python_full_version < '3.13'" },
+    { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
+    { name = "tqdm", marker = "python_full_version < '3.13'" },
+    { name = "uvicorn", marker = "python_full_version < '3.13'" },
+    { name = "watchdog", marker = "python_full_version < '3.13'" },
+    { name = "websockets", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/25/c825c73ec2f48c93324f631dba6e4cdac3bb60a7fde36e0b916820ae62a5/aim-3.29.1.tar.gz", hash = "sha256:30fb70f983844eebd270049206c839e6dc09ce9de500048dc97a7a8b22ed83fb", size = 1660733, upload-time = "2025-05-08T09:51:58.892Z" }
 wheels = [
@@ -366,7 +368,7 @@ name = "aimrecords"
 version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "base58" },
+    { name = "base58", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/10/21182ef96acbd9a5ca4008556ba8590cbc1af833eccbf59d53308fa6d928/aimrecords-0.0.7.tar.gz", hash = "sha256:9b562fa5b5109b4b3dd4f83be0061cadbac63fa8031f281b8b5c8ae29967072f", size = 12667, upload-time = "2020-11-09T13:29:29.071Z" }
 wheels = [
@@ -548,10 +550,10 @@ name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mako" },
-    { name = "sqlalchemy" },
+    { name = "mako", marker = "python_full_version < '3.13'" },
+    { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
@@ -2612,14 +2614,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/bc/e30e1e3d5e8860b0e0ce4d2b16b2681b77fd13542fc0d72f7e3c22d16eff/greenlet-3.4.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6", size = 284315, upload-time = "2026-04-08T17:02:52.322Z" },
     { url = "https://files.pythonhosted.org/packages/5b/cc/e023ae1967d2a26737387cac083e99e47f65f58868bd155c4c80c01ec4e0/greenlet-3.4.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82", size = 601916, upload-time = "2026-04-08T16:24:35.533Z" },
     { url = "https://files.pythonhosted.org/packages/67/32/5be1677954b6d8810b33abe94e3eb88726311c58fa777dc97e390f7caf5a/greenlet-3.4.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31", size = 616399, upload-time = "2026-04-08T16:30:54.536Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0a/3a4af092b09ea02bcda30f33fd7db397619132fe52c6ece24b9363130d34/greenlet-3.4.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508", size = 621077, upload-time = "2026-04-08T16:40:34.946Z" },
     { url = "https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398", size = 611978, upload-time = "2026-04-08T15:56:31.335Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/39/3786520a7d5e33ee87b3da2531f589a3882abf686a42a3773183a41ef010/greenlet-3.4.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb", size = 416893, upload-time = "2026-04-08T16:43:02.392Z" },
     { url = "https://files.pythonhosted.org/packages/bd/69/6525049b6c179d8a923256304d8387b8bdd4acab1acf0407852463c6d514/greenlet-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b", size = 1571957, upload-time = "2026-04-08T16:26:17.041Z" },
     { url = "https://files.pythonhosted.org/packages/4e/6c/bbfb798b05fec736a0d24dc23e81b45bcee87f45a83cfb39db031853bddc/greenlet-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf", size = 1637223, upload-time = "2026-04-08T15:57:27.556Z" },
     { url = "https://files.pythonhosted.org/packages/b7/7d/981fe0e7c07bd9d5e7eb18decb8590a11e3955878291f7a7de2e9c668eb7/greenlet-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab", size = 237902, upload-time = "2026-04-08T17:03:14.16Z" },
     { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
     { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
     { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
     { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
     { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
     { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
@@ -2627,7 +2633,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -2635,7 +2643,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -3174,7 +3184,7 @@ name = "jwt"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/20/21254c9e601e6c29445d1e8854c2a81bdb554e07a82fb1f9846137a6965c/jwt-1.4.0.tar.gz", hash = "sha256:f6f789128ac247142c79ee10f3dba6e366ec4e77c9920d18c1592e28aa0a7952", size = 24911, upload-time = "2025-06-23T13:28:38.289Z" }
 wheels = [
@@ -3394,7 +3404,7 @@ name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
@@ -7697,6 +7707,10 @@ sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
+
+[[package]]
+name = "trim-custom-experiments"
+source = { editable = "examples/trim/custom_experiments" }
 
 [[package]]
 name = "triton"


### PR DESCRIPTION
Bug reported in #884, bug created in #805

The operator function decorators wrap an operator function, so that when the wrapper is called,  the general operator orchestration function is called to execute the wrapped function (the operator function the developer writes and decorates)

Pre #805 an internal function was receiving the un-decorated, original operator function and calling it. 
in #805 this functions interface was changed so it received the decorated function, however the call was not updated to account for this (it should have accessed the wrapped function and called it).

As a result that internal call called the wrapper, which called the outermost orchestration function again and a recursive loop kicks off. 

operator_wrapper() -> general_orchestration(operator metadata) -> ... -> Internal Function(operator wrapper) -> operator_wrapper() 

Instead of 

operator_wrapper() -> general_orchestration(operator metadata) -> ... -> Internal Function(operator wrapper)  -> unwrap(operator_wrapper)() 