### PR TITLE
build(containers): pass SOURCE_DATE_EPOCH as arg

### DIFF
--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -5,9 +5,9 @@ FROM $BASE_IMAGE
 # Set LD_LIBRARY_PATH to avoid runtime errors (so far only experienced when running vLLM with the vllm_performance actuator)
 ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib:${LD_LIBRARY_PATH}
 
-# Set SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
+# Pass SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
 # the same timestamp.
-ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+ARG SOURCE_DATE_EPOCH
 
 USER 0
 RUN chgrp -R 0 /home/ray && \
@@ -18,13 +18,15 @@ USER 1000
 COPY --chown=1000:0 ./ ado
 
 ## Install ado
-RUN cd ado && \
+RUN export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} && \
+    cd ado && \
     uv pip install --system -r requirements.txt && \
     uv pip install --system --no-deps --strict \
     '.'
 
 ## Install ray-tune operator
-RUN cd ado && \
+RUN export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} && \
+    cd ado && \
     uv pip install --system \
     'plugins/operators/ray_tune/'
 

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -7,7 +7,7 @@ ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib:${LD_LIBRARY_PATH}
 
 # Pass SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
 # the same timestamp.
-ARG SOURCE_DATE_EPOCH
+ARG SOURCE_DATE_EPOCH=0
 
 USER 0
 RUN chgrp -R 0 /home/ray && \

--- a/Dockerfile-geo
+++ b/Dockerfile-geo
@@ -5,7 +5,7 @@ FROM $BASE_IMAGE
 
 # Pass SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
 # the same timestamp.
-ARG SOURCE_DATE_EPOCH
+ARG SOURCE_DATE_EPOCH=0
 
 ## Install ado-vllm-performance
 RUN export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} && \

--- a/Dockerfile-geo
+++ b/Dockerfile-geo
@@ -3,11 +3,12 @@ ARG CUDA_VERSION=cu121
 ARG BASE_IMAGE=quay.io/ado/ado:latest-py${PYTHON_VERSION}-${CUDA_VERSION}
 FROM $BASE_IMAGE
 
-# Set SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
+# Pass SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
 # the same timestamp.
-ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+ARG SOURCE_DATE_EPOCH
 
 ## Install ado-vllm-performance
-RUN cd ado && \
+RUN export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} && \
+    cd ado && \
     uv pip install --system \
     'plugins/actuators/vllm_performance'

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -10,9 +10,9 @@ ENV CUDA_HOME=/usr/local/cuda
 # Set LD_LIBRARY_PATH to avoid runtime errors (so far only experienced when running vLLM with the vllm_performance actuator)
 ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib:${LD_LIBRARY_PATH}
 
-# Set SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
+# Pass SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
 # the same timestamp.
-ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+ARG SOURCE_DATE_EPOCH
 
 USER 0
 RUN chgrp -R 0 /home/ray && \
@@ -23,13 +23,15 @@ USER 1000
 COPY --chown=1000:0 ./ ado
 
 ## Install ado
-RUN cd ado && \
+RUN export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} && \
+    cd ado && \
     uv pip install --system -r requirements.txt && \
     uv pip install --system --no-deps --strict \
     '.'
 
 ## Install ray-tune operator
-RUN cd ado && \
+RUN export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} && \
+    cd ado && \
     uv pip install --system \
     'plugins/operators/ray_tune/'
 

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -12,7 +12,7 @@ ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib:${LD_LIBRARY_PATH}
 
 # Pass SOURCE_DATE_EPOCH to guarantee that all the wheels built will use
 # the same timestamp.
-ARG SOURCE_DATE_EPOCH
+ARG SOURCE_DATE_EPOCH=0
 
 USER 0
 RUN chgrp -R 0 /home/ray && \


### PR DESCRIPTION
https://github.com/IBM/ado/pull/882 hadn't fixed the issue for container images.