### PR TITLE
build(core): add entry point for random walk operator

### DIFF
--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -376,8 +376,6 @@ def export_operation(
 def load_operators() -> None:
     from importlib.metadata import entry_points
 
-    import orchestrator.modules.operators.randomwalk  # noqa: F401
-
     for operator_plugin in entry_points(group="ado.operators"):
         try:
             operator_plugin.load()

--- a/plugins/operators/trim/src/trim/operator.py
+++ b/plugins/operators/trim/src/trim/operator.py
@@ -54,8 +54,6 @@ def trim(
     Returns:
         OperationOutput containing the operation resources and metadata
     """
-    # Lazy import to avoid circular import issues during plugin loading
-    import orchestrator.modules.operators.randomwalk  # noqa: F401 — registers explore.random_walk
     from orchestrator.modules.operators.collections import characterize, explore
     from orchestrator.modules.operators.randomwalk import (
         CustomSamplerConfiguration,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ Repository = "https://github.com/IBM/ado"
 ado = "orchestrator.cli.core.cli:app"
 run_experiment = "orchestrator.utilities.run_experiment:main"
 
+[project.entry-points."ado.operators"]
+randomwalk = "orchestrator.modules.operators.randomwalk"
+
 [dependency-groups]
 dev = [
   "black>=25.1.0",


### PR DESCRIPTION
Prior to use random walk operator from collection, users would have to import the random walk module to trigger its addition to the collection