### PR TITLE
fix(vllm_performance): do not override env if existing in deployment template

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/k8s/yaml_support/build_components.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/k8s/yaml_support/build_components.py
@@ -211,23 +211,12 @@ class ComponentsYaml:
         limits["cpu"] = str(n_cpus)
         limits["memory"] = memory
         limits["nvidia.com/gpu"] = str(n_gpus)
-        # env variables to to set parameters for docker execution
-        container["env"] = [
-            {"name": "MODEL", "value": model},
-            {"name": "GPU_MEMORY_UTILIZATION", "value": str(gpu_memory_utilization)},
-            {"name": "DTYPE", "value": dtype.value},
-            {"name": "CPU_OFFLOAD_GB", "value": str(cpu_offload)},
-            {"name": "MAX_NUM_BATCHED_TOKENS", "value": str(max_batch_tokens)},
-            {"name": "MAX_NUM_SEQ", "value": str(max_num_seq)},
-            {"name": "TENSOR_PARALLEL_SIZE", "value": str(n_gpus)},
-        ]
 
-        container["env"] = []
+        if "env" not in container:
+            container["env"] = []
         if hf_token is not None:
-            container["env"] = [{"name": "HF_TOKEN", "value": hf_token}]
+            container["env"].append({"name": "HF_TOKEN", "value": hf_token})
         if claim_name is not None:
-            if "env" not in container:
-                container["env"] = []
             container["env"].extend(
                 [
                     {


### PR DESCRIPTION
The actuator code is currently overriding the container env configuration even is something is already present int the deployment template. Instead, if something is the template we should just extend with any additional variable.

This PR fixes the above issue.