### PR TITLE
fix(metastore): correctly handle intermediate fields with underscores on sqlite

### DIFF
--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -60,6 +60,11 @@ def check_field_in_sqlite_json_document(
     and constructs SQL subqueries that can be used to filter rows produced by SQLite's json_tree
     function based on whether the specified fields and values exist at the given JSON path.
 
+    Note: SQLite's json_tree quotes field names containing underscores. This function handles
+    that by quoting such field names in the generated patterns. This may produce false positives
+    in complex nested structures where the same field name appears at different nesting levels,
+    but these are filtered by the INTERSECT logic in simulate_json_contains_on_sqlite.
+
     Args:
         candidate (dict | list | str | int | float): The JSON structure or scalar value to match against.
             - If a scalar (str, int, float), generates a simple query checking for value presence.
@@ -196,9 +201,14 @@ def check_field_in_sqlite_json_document(
             # The use of % in the path is because json_tree will add list items in the path.
             # (e.g., $.config.entitySpace[2].propertyDomain). As we can't know for sure
             # whether a field is a list or not, we use the LIKE operator and a wildcard (%)
+
+            # SQLite quotes field names containing underscores in json_tree paths.
+            # Quote the field name if it contains an underscore to match SQLite's behavior.
+            field_pattern = f'"{field}"' if "_" in field else field
+
             fragments.extend(
                 check_field_in_sqlite_json_document(
-                    candidate[field], f"{path}%.{field}"
+                    candidate[field], f"{path}%.{field_pattern}"
                 )
             )
             continue
@@ -207,6 +217,9 @@ def check_field_in_sqlite_json_document(
         # with an array field, for which the path would contain
         # the index.
         if isinstance(candidate[field], _ScalarType):
+            # Note: We do NOT quote the field name in F.key because the 'key' column
+            # in json_tree is never quoted. Only intermediate fields in the 'path'
+            # column are quoted when they contain underscores.
             fragments.append(
                 f"{preamble} F.path LIKE '{path}%' AND "
                 f"F.key = '{field}' AND "

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -12,7 +12,11 @@ from testcontainers.mysql import MySqlContainer
 from typer.testing import CliRunner
 
 from orchestrator.cli.core.cli import app as ado
-from orchestrator.core import OperationResource, SampleStoreResource
+from orchestrator.core import (
+    ActuatorConfigurationResource,
+    OperationResource,
+    SampleStoreResource,
+)
 from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.metastore.sqlstore import SQLStore
@@ -120,6 +124,15 @@ def test_field_querying(
 
     sql_store.addResource(sample_store_07c0fa)
     sql_store.addResource(sample_store_resource)
+
+    actuator_config_with_underscores = ActuatorConfigurationResource.model_validate(
+        yaml.safe_load(
+            pathlib.Path(
+                "tests/resources/actuatorconfiguration/mock-ac-with-snake-case.yaml"
+            ).read_text()
+        )
+    )
+    sql_store.addResource(actuator_config_with_underscores)
 
     # ---------------------------------------------------------
     # Query scalar int field with int
@@ -351,6 +364,75 @@ def test_field_querying(
         assert (
             render_ado_resources_to_cli_output(
                 operation_43dfdf, do_not_truncate_columns=["IDENTIFIER"]
+            )
+            == result.output
+        ), result.output
+
+    # ---------------------------------------------------------
+    # Query nested fields with underscores
+    # ---------------------------------------------------------
+    # Query for nested underscore fields
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "actuatorconfigurations",
+            "-q",
+            'config.parameters.outer_field.inner_field.test_value="found_it"',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert (
+            render_ado_resources_to_cli_output(
+                actuator_config_with_underscores,
+                do_not_truncate_columns=["IDENTIFIER"],
+            )
+            == result.output
+        ), result.output
+
+    # Query with JSON object containing underscore fields
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "actuatorconfigurations",
+            "-q",
+            'config.parameters.outer_field={"inner_field": {"test_value": "found_it"}}',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert (
+            render_ado_resources_to_cli_output(
+                actuator_config_with_underscores,
+                do_not_truncate_columns=["IDENTIFIER"],
+            )
+            == result.output
+        ), result.output
+
+    # Query for mixed underscore and simple fields
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "actuatorconfigurations",
+            "-q",
+            'config.parameters.outer_field.another_field="simple"',
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert (
+            render_ado_resources_to_cli_output(
+                actuator_config_with_underscores,
+                do_not_truncate_columns=["IDENTIFIER"],
             )
             == result.output
         ), result.output

--- a/tests/resources/actuatorconfiguration/mock-ac-with-snake-case.yaml
+++ b/tests/resources/actuatorconfiguration/mock-ac-with-snake-case.yaml
@@ -1,0 +1,17 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+config:
+  actuatorIdentifier: mock
+  parameters:
+    outer_field:
+      another_field: simple
+      inner_field:
+        test_value: found_it
+    simple_field: test
+created: '2026-03-22T19:47:56.575084Z'
+identifier: actuatorconfiguration-mock-17e0864c
+status:
+  - event: created
+    recorded_at: '2026-03-22T19:47:56.575113Z'
+  - event: added
+    recorded_at: '2026-03-22T19:47:56.603225Z'


### PR DESCRIPTION
# Summary

This PR fixes a bug in SQLite JSON querying where field names containing underscores were not being properly handled. SQLite's `json_tree` function quotes field names with underscores in paths, which was causing query mismatches. The fix adds logic to detect and quote such field names when constructing SQL queries.

Fixes #897 

# Files Changed

📄 `orchestrator/metastore/sql/statements.py`

Added handling for SQLite's quoting behavior of field names containing underscores in `json_tree` paths. The `check_field_in_sqlite_json_document` function now:
- Detects field names with underscores and wraps them in quotes when building path patterns
- Adds documentation explaining the quoting behavior and potential edge cases
- Clarifies that the `key` column in `json_tree` is never quoted, only intermediate fields in the `path` column

📄 `tests/ado/get/test_ado_get.py`

Adds comprehensive test coverage for querying nested JSON fields with underscores. The tests verify:
- Querying deeply nested fields with underscores (e.g., `outer_field.inner_field.test_value`)
- Querying with JSON objects containing underscore fields
- Querying mixed underscore and simple field names
Imports `ActuatorConfigurationResource` and creates a test fixture from the new YAML file.

📄 `tests/resources/actuatorconfiguration/mock-ac-with-snake-case.yaml`

New test fixture file containing an `ActuatorConfigurationResource` with nested fields using snake_case naming (underscores). Includes fields like `outer_field`, `inner_field`, `test_value`, `another_field`, and `simple_field` to test various underscore scenarios.