### PR TITLE
refactor(metastore): order resources returned by age

### DIFF
--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -385,6 +385,10 @@ class SQLResourceStore(ResourceStore):
         are not present in the database are simply omitted from the
         returned mapping.
 
+        The returned dictionary is sorted by the `created` timestamp of each
+        resource in ascending order (oldest first), matching the AGE sorting
+        behavior used in CLI commands.
+
         ``identifiers`` may be passed as either a plain list or a
         :class:`pandas.Series`; if a series is supplied it is converted
         to a list first.
@@ -400,8 +404,10 @@ class SQLResourceStore(ResourceStore):
             dict[str, orchestrator.core.resources.ADOResource]:
                 A mapping where each key is an identifier found in the
                 database and the value is the corresponding deserialized
-                resource instance. If a particular identifier does not
-                exist, it will not appear in the returned dictionary.
+                resource instance. Resources are ordered by their `created`
+                timestamp in ascending order (oldest first). If a
+                particular identifier does not exist, it will not appear
+                in the returned dictionary.
 
         Raises:
             ValueError: If ignore_validation_errors is False and a resource
@@ -446,7 +452,8 @@ class SQLResourceStore(ResourceStore):
                     else:
                         retval[identifier] = resource
 
-        return retval
+        # Sort by resource.created ascending (oldest first, matching AGE sort behavior)
+        return dict(sorted(retval.items(), key=lambda item: item[1].created))
 
     def getResourceIdentifiersOfKind(
         self,

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -90,6 +90,55 @@ def test_get_resources_and_get_resource_identifiers_of_kind(
 
 
 @requires_sqlite_3_38
+def test_get_resources_sorted_by_created_ascending(
+    sql_store: SQLStore,
+    random_space_resource_from_file: Callable[[str | None], DiscoverySpaceResource],
+    create_resources: Callable[
+        [list[orchestrator.core.resources.ADOResource], SQLStore], None
+    ],
+) -> None:
+    """Test that getResources returns resources sorted by created timestamp in ascending order (oldest first)."""
+    import datetime
+
+    # Create multiple resources from file with explicit created timestamps
+    space1 = random_space_resource_from_file()
+    space1.created = datetime.datetime(
+        2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+
+    space2 = random_space_resource_from_file()
+    space2.created = datetime.datetime(
+        2024, 1, 2, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+
+    space3 = random_space_resource_from_file()
+    space3.created = datetime.datetime(
+        2024, 1, 3, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+
+    # Add resources to database using create_resources fixture
+    create_resources([space1, space2, space3])
+
+    # Get all three resources
+    identifiers = [space1.identifier, space2.identifier, space3.identifier]
+    resources = sql_store.getResources(identifiers)
+
+    # Convert to list to check order
+    resource_list = list(resources.values())
+
+    # Verify we got all three resources
+    assert len(resource_list) == 3
+
+    # Verify they are sorted by created timestamp in ascending order (oldest first)
+    assert resource_list[0].created <= resource_list[1].created
+    assert resource_list[1].created <= resource_list[2].created
+
+    # Verify the oldest is space1 and most recent is space3
+    assert resource_list[0].identifier == space1.identifier
+    assert resource_list[2].identifier == space3.identifier
+
+
+@requires_sqlite_3_38
 def test_get_related_resource_identifiers(
     sql_store_with_resources_preloaded: SQLStore, resource_type: CoreResourceKinds
 ) -> None:


### PR DESCRIPTION
# Summary

This PR adds sorting functionality to the `getResources` method in `SQLResourceStore` to return resources ordered by their `created` timestamp in ascending order (oldest first). This change ensures consistency with the AGE sorting behavior used in CLI commands.

Resolve #902 with a bit of a hack. Proper rework of metastore methods will be delegated to https://github.com/IBM/ado/issues/903

# Files Changed

📄 `orchestrator/metastore/sqlstore.py`

Updated the `getResources` method to sort the returned dictionary by the `created` timestamp of each resource in ascending order. The method now returns resources ordered from oldest to newest, matching the AGE sorting behavior used in CLI commands. Documentation was also enhanced to clearly describe this sorting behavior.

📄 `tests/metastore/test_resourcestore.py`

Added a new test `test_get_resources_sorted_by_created_ascending` to verify that the `getResources` method correctly returns resources sorted by their `created` timestamp in ascending order. The test creates three resources with explicit timestamps, retrieves them, and validates that they are returned in the correct chronological order (oldest first).