### PR TITLE
fix(cli): disable ray's uv run runtime env hook by default

### DIFF
--- a/orchestrator/cli/core/cli.py
+++ b/orchestrator/cli/core/cli.py
@@ -1,6 +1,15 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
+# Before any other imports: Ray's ``uv`` driver hook (see
+# ``orchestrator.utilities.ray_local_init``) reads ``RAY_ENABLE_UV_RUN_RUNTIME_ENV``
+# at the first ``import ray``. The ``ado create operation`` code path eventually
+# imports ``ray``; this default keeps local ``uv run ado …`` from packaging the
+# whole worktree. Set the variable in the environment to ``1`` to opt in.
+import os
+
+os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+
 import logging
 import pathlib
 import sys

--- a/orchestrator/modules/operators/orchestrate.py
+++ b/orchestrator/modules/operators/orchestrate.py
@@ -129,13 +129,11 @@ def orchestrate(
         #     os.environ[key] = value
         #
         # ray.init(
-        #     runtime_env=RuntimeEnv(env_vars=ray_env_vars, working_dir=None),
+        #     runtime_env=RuntimeEnv(env_vars=ray_env_vars),
         #     ignore_reinit_error=True,
         # )
 
-        # Using RuntimeEnv with working_dir=None does not produce same behaviour as dict
         ray.init(
-            runtime_env={"working_dir": None},
             ignore_reinit_error=True,
         )
 

--- a/orchestrator/utilities/run_experiment.py
+++ b/orchestrator/utilities/run_experiment.py
@@ -9,6 +9,9 @@ import typing
 from collections.abc import Callable
 from typing import Annotated
 
+# Before `import ray` (see orchestrator.utilities.ray_local_init). Pytest sets this via pytest-env.
+os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+
 import ray
 import ray.exceptions
 import requests
@@ -54,13 +57,7 @@ def local_execution_closure(
         A callable that submits a local measurement request.
     """
 
-    # Assume run_experiment is being run directly
-    # We set working_dir = None to tell ray to use the CWD for all workers
-    # i.e. we are in local mode, code is local, no need to package
-    # This is required in particular because if "uv run" is used
-    # to execute a process that calls ray.init ray cannot work out that the workers
-    # can use the CWD of the main process.
-    ray.init(ignore_reinit_error=True, runtime_env={"working_dir": None})
+    ray.init(ignore_reinit_error=True)
     initialize_ray_resource_cleaner()
 
     actuators: dict[str, ActorHandle[ActuatorBase]] = {}

--- a/website/docs/getting-started/remote_run.md
+++ b/website/docs/getting-started/remote_run.md
@@ -22,6 +22,7 @@ generating the Ray runtime environment, and running `ray job submit` for you.
 > will fail with a clear error if a SQLite context is detected.
 
 <!-- markdownlint-disable-next-line MD028 -->
+
 > [!IMPORTANT] Cluster login
 >
 > If your cluster requires a port-forward, `oc` (OpenShift CLI) or `kubectl`
@@ -204,12 +205,11 @@ any plugins required in the `packages.fromPyPI` section of your
 
 > [!NOTE] Wheel paths and `fromPyPI`
 >
-> Entries in `fromPyPI` that resolve to an existing `.whl` file on
-> the machine running `ado --remote` will be transferred to the remote cluster.
-> Other entries are forwarded unchanged to the
-> cluster's `uv` install step. This includes paths that were not present
-> on submitting machine - these will be interpreted as paths to wheels
-> that are on the remote filesystem.
+> Entries in `fromPyPI` that resolve to an existing `.whl` file on the machine
+> running `ado --remote` will be transferred to the remote cluster. Other
+> entries are forwarded unchanged to the cluster's `uv` install step. This
+> includes paths that were not present on submitting machine - these will be
+> interpreted as paths to wheels that are on the remote filesystem.
 
 ### Dynamic installation from source
 
@@ -264,4 +264,40 @@ envVars:
 additionalFiles:
   - /absolute/path/to/data_file.csv
   - path/to/my_data_dir/ # directories are also supported
+```
+
+## Using Ray’s uv run driver integration with `ado`
+
+### Ray’s uv run integration
+
+Ray provides a native integration that allows `uv run ...` to function as an
+"environment-aware" driver launch. It automatically packages the
+working_dir, which defaults to the current directory, and applies uv-based runtime
+configurations directly to worker nodes. This serves as a built-in mechanism for
+seamless dependency and environment handling across a distributed cluster. For
+more details, see the [Ray documentation on using uv for package management](https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#using-uv-for-package-management)
+
+### ADO default: the integration is disabled unless you opt in
+
+By default, when you start the ado or run_experiment executables (including via
+`uv run …`), ADO sets `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` before importing ray,
+if the variable is not already set in your environment. This is done to avoid
+unintentionally packaging/uploading your entire current working directory during
+typical local development runs.
+
+### Enabling Ray’s `uv run` driver integration
+
+If you do want Ray’s `uv run` driver integration behavior, set this in your
+shell before starting ado
+
+```bash
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=1
+```
+
+To have the (uv-run-started) driver in ado connect to an existing Ray cluster, set
+RAY_ADDRESS in the environment
+
+```bash
+export RAY_ADDRESS=...
+uv run ado create op ...
 ```

--- a/website/docs/getting-started/remote_run.md
+++ b/website/docs/getting-started/remote_run.md
@@ -287,7 +287,7 @@ directory during typical local development runs.
 
 ### Enabling Ray’s `uv run` driver integration
 
-If you do want Ray’s `uv run` driver integration behavior, set this in your
+If you'd like to use Ray’s `uv run` driver integration feature, set this in your
 shell before starting ado
 
 ```bash

--- a/website/docs/getting-started/remote_run.md
+++ b/website/docs/getting-started/remote_run.md
@@ -271,19 +271,19 @@ additionalFiles:
 ### Ray’s uv run integration
 
 Ray provides a native integration that allows `uv run ...` to function as an
-"environment-aware" driver launch. It automatically packages the
-working_dir, which defaults to the current directory, and applies uv-based runtime
-configurations directly to worker nodes. This serves as a built-in mechanism for
-seamless dependency and environment handling across a distributed cluster. For
-more details, see the [Ray documentation on using uv for package management](https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#using-uv-for-package-management)
+"environment-aware" driver launch. It automatically packages the working
+directory and applies uv-based runtime configurations directly to worker nodes.
+This serves as a built-in mechanism for seamless dependency and environment
+handling across a distributed cluster. For more details, see the
+[Ray documentation on using uv for package management](https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#using-uv-for-package-management)
 
 ### ADO default: the integration is disabled unless you opt in
 
-By default, when you start the ado or run_experiment executables (including via
-`uv run …`), ADO sets `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` before importing ray,
-if the variable is not already set in your environment. This is done to avoid
-unintentionally packaging/uploading your entire current working directory during
-typical local development runs.
+The `ado` and `run_experiment` CLIs (including when invoked via `uv run …`)
+disable Ray's uv run integration by default. Unless the user has explicitly set
+`RAY_ENABLE_UV_RUN_RUNTIME_ENV`, ado sets it to `0` before importing Ray. This
+is done to avoid unintentionally packaging/uploading your entire current working
+directory during typical local development runs.
 
 ### Enabling Ray’s `uv run` driver integration
 
@@ -294,8 +294,8 @@ shell before starting ado
 export RAY_ENABLE_UV_RUN_RUNTIME_ENV=1
 ```
 
-To have the (uv-run-started) driver in ado connect to an existing Ray cluster, set
-RAY_ADDRESS in the environment
+To have the (uv-run-started) driver in ado connect to an existing Ray cluster,
+set `RAY_ADDRESS` in the environment
 
 ```bash
 export RAY_ADDRESS=...


### PR DESCRIPTION
### Context & Problem

Ray’s `uv run` integration automatically packages the current working directory for workers (#506). While useful for distributed setups, it causes significant friction for local **ado** executions (`uv run ado ...`). It unnecessarily attempts to upload the source-tree plus untracked files  to the local object store, leading to slow startup times and frequent failures in dev/agent workflows. 

Since `ado` explicitly manages remote environments via `ado --remote` this automatic Ray hook is redundant for our default paths.

### Changes in this PR

* **Opt-in rather than Opt-out:** We now disable the integration by default by setting `os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")` at `ado` entrypoints . This must happens *before* `ray` is imported.
* **Maintains User Choice:** Users who want Ray's native behavior can `export RAY_ENABLE_UV_RUN_RUNTIME_ENV=1`.
* **Removes Broken Workaround:** Drops the old `runtime_env={"working_dir": None}` hack in `ray.init()`. Newer Ray versions validate this as a path string, meaning `None` now raises a `TypeError` (#893 )
