### PR TITLE
refactor(vllm_performance): expand parameter ranges for geospatial model benchmarking

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing.yaml
@@ -66,7 +66,7 @@ test-deployment-v1:
         description: "(deployment) the number of CPUs to use"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 17]
+        domainRange: [1, 256]
         interval: 1
     - identifier: memory
       metadata:
@@ -399,7 +399,7 @@ test-deployment-guidellm-v1:
         description: "(deployment) the number of CPUs to use"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 17]
+        domainRange: [1, 256]
         interval: 1
     - identifier: memory
       metadata:

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
@@ -240,7 +240,7 @@ performance_testing-geospatial-full:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 256
+      value: 16384
     - property:
         identifier: 'n_gpus'
       value: 1
@@ -433,7 +433,7 @@ performance_testing-geospatial-full-custom-dataset:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 256
+      value: 16384
     - property:
         identifier: 'n_gpus'
       value: 1
@@ -773,7 +773,7 @@ performance_testing-geospatial-full-guidellm:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 256
+      value: 16384
     - property:
         identifier: 'n_gpus'
       value: 1
@@ -966,7 +966,7 @@ performance_testing-geospatial-guidellm-deployment-custom-dataset:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 256
+      value: 16384
     - property:
         identifier: 'n_gpus'
       value: 1

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
@@ -174,7 +174,7 @@ performance_testing-geospatial-full:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32768]
+        domainRange: [256, 32769]
         interval: 256
     - identifier: 'n_gpus'
       metadata:
@@ -367,7 +367,7 @@ performance_testing-geospatial-full-custom-dataset:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32768]
+        domainRange: [256, 32769]
         interval: 256
     - identifier: 'n_gpus'
       metadata:
@@ -707,7 +707,7 @@ performance_testing-geospatial-full-guidellm:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32768]
+        domainRange: [256, 32769]
         interval: 256
     - identifier: 'n_gpus'
       metadata:
@@ -900,7 +900,7 @@ performance_testing-geospatial-guidellm-deployment-custom-dataset:
         description: "(deployment) Maximum number of tokens to be processed in a single batch."
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32768]
+        domainRange: [256, 32769]
         interval: 256
     - identifier: 'n_gpus'
       metadata:

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
@@ -174,8 +174,8 @@ performance_testing-geospatial-full:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1024, 32768]
-        interval: 1024
+        domainRange: [256, 32768]
+        interval: 256
     - identifier: 'n_gpus'
       metadata:
         description: "(deployment) Number of GPUs to use"
@@ -367,8 +367,8 @@ performance_testing-geospatial-full-custom-dataset:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1024, 32768]
-        interval: 1024
+        domainRange: [256, 32768]
+        interval: 256
     - identifier: 'n_gpus'
       metadata:
         description: "(deployment) Number of GPUs to use"
@@ -707,8 +707,8 @@ performance_testing-geospatial-full-guidellm:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1024, 32768]
-        interval: 1024
+        domainRange: [256, 32768]
+        interval: 256
     - identifier: 'n_gpus'
       metadata:
         description: "(deployment) Number of GPUs to use"
@@ -900,8 +900,8 @@ performance_testing-geospatial-guidellm-deployment-custom-dataset:
         description: "(deployment) Maximum number of tokens to be processed in a single batch."
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 65537]
-        interval: 1
+        domainRange: [256, 32768]
+        interval: 256
     - identifier: 'n_gpus'
       metadata:
         description: "(deployment) the number of GPUs to use"

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
@@ -136,7 +136,7 @@ performance_testing-geospatial-full:
         description: "(deployment) the number of CPUs to use"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 17]
+        domainRange: [1, 256]
         interval: 1
     - identifier: memory
       metadata:
@@ -174,7 +174,7 @@ performance_testing-geospatial-full:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [8192, 32769]
+        domainRange: [256, 32769]
         interval: 1024
     - identifier: 'n_gpus'
       metadata:
@@ -240,7 +240,7 @@ performance_testing-geospatial-full:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 16384
+      value: 256
     - property:
         identifier: 'n_gpus'
       value: 1
@@ -329,7 +329,7 @@ performance_testing-geospatial-full-custom-dataset:
         description: "(deployment) the number of CPUs to use"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 17]
+        domainRange: [1, 256]
         interval: 1
     - identifier: memory
       metadata:
@@ -367,7 +367,7 @@ performance_testing-geospatial-full-custom-dataset:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [8192, 32769]
+        domainRange: [256, 32769]
         interval: 1024
     - identifier: 'n_gpus'
       metadata:
@@ -381,7 +381,7 @@ performance_testing-geospatial-full-custom-dataset:
         description: "(deployment) The GPU type to use"
       propertyDomain:
         variableType: "CATEGORICAL_VARIABLE_TYPE"
-        values: ['NVIDIA-A100-80GB-PCIe', 'NVIDIA-A100-SXM4-80GB']
+        values: ['NVIDIA-A100-80GB-PCIe', 'NVIDIA-A100-SXM4-80GB', 'NVIDIA-H100-PCIe']
     - identifier: 'skip_tokenizer_init'
       metadata:
         description: "(deployment) skip tokenizer initialization"
@@ -433,7 +433,7 @@ performance_testing-geospatial-full-custom-dataset:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 16384
+      value: 256
     - property:
         identifier: 'n_gpus'
       value: 1
@@ -669,7 +669,7 @@ performance_testing-geospatial-full-guidellm:
         description: "(deployment) the number of CPUs to use"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 17]
+        domainRange: [1, 256]
         interval: 1
     - identifier: memory
       metadata:
@@ -707,7 +707,7 @@ performance_testing-geospatial-full-guidellm:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [8192, 32769]
+        domainRange: [256, 32769]
         interval: 1024
     - identifier: 'n_gpus'
       metadata:
@@ -773,7 +773,7 @@ performance_testing-geospatial-full-guidellm:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 16384
+      value: 256
     - property:
         identifier: 'n_gpus'
       value: 1
@@ -860,7 +860,7 @@ performance_testing-geospatial-guidellm-deployment-custom-dataset:
         description: "(deployment) the number of CPUs to use"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [1, 17]
+        domainRange: [1, 256]
         interval: 1
     - identifier: memory
       metadata:
@@ -966,7 +966,7 @@ performance_testing-geospatial-guidellm-deployment-custom-dataset:
       value: 256
     - property:
         identifier: 'max_batch_tokens'
-      value: 16384
+      value: 256
     - property:
         identifier: 'n_gpus'
       value: 1

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiments/performance_testing_geospatial.yaml
@@ -174,7 +174,7 @@ performance_testing-geospatial-full:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32769]
+        domainRange: [1024, 32768]
         interval: 1024
     - identifier: 'n_gpus'
       metadata:
@@ -367,7 +367,7 @@ performance_testing-geospatial-full-custom-dataset:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32769]
+        domainRange: [1024, 32768]
         interval: 1024
     - identifier: 'n_gpus'
       metadata:
@@ -707,7 +707,7 @@ performance_testing-geospatial-full-guidellm:
         description: "(deployment) maximum number of batched tokens per iteration"
       propertyDomain:
         variableType: 'DISCRETE_VARIABLE_TYPE'
-        domainRange: [256, 32769]
+        domainRange: [1024, 32768]
         interval: 1024
     - identifier: 'n_gpus'
       metadata:

--- a/website/docs/actuators/vllm_performance.md
+++ b/website/docs/actuators/vllm_performance.md
@@ -148,7 +148,7 @@ entity:
   n_cpus: 8
   memory: 128Gi
   gpu_type: NVIDIA-A100-80GB-PCIe
-  max_batch_tokens: 8192
+  max_batch_tokens: 256
   max_num_seq: 32
   n_gpus: 1
   request_rate: 10

--- a/website/docs/actuators/vllm_performance.md
+++ b/website/docs/actuators/vllm_performance.md
@@ -148,7 +148,7 @@ entity:
   n_cpus: 8
   memory: 128Gi
   gpu_type: NVIDIA-A100-80GB-PCIe
-  max_batch_tokens: 256
+  max_batch_tokens: 16384
   max_num_seq: 32
   n_gpus: 1
   request_rate: 10

--- a/website/docs/actuators/vllm_performance.md
+++ b/website/docs/actuators/vllm_performance.md
@@ -148,7 +148,7 @@ entity:
   n_cpus: 8
   memory: 128Gi
   gpu_type: NVIDIA-A100-80GB-PCIe
-  max_batch_tokens: 16384
+  max_batch_tokens: 8192
   max_num_seq: 32
   n_gpus: 1
   request_rate: 10


### PR DESCRIPTION
## Summary

Expands vLLM performance testing parameter ranges to enable benchmarking of geospatial models (IBM-NASA Prithvi) which require different resource configurations than standard LLMs.

## Changes

- CPU range: 17 → 256 max cores
- Batch tokens: 8192 → 256 min, 16384 → 256 default
- Added NVIDIA-H100-PCIe GPU support
- Updated documentation example

## Impact

Enables comprehensive benchmarking of geospatial models with varied CPU allocations, smaller batch sizes suitable for image processing workloads, and H100 GPU support.