### PR TITLE
build(hooks): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,13 +35,13 @@ repos:
         additional_dependencies: ['tomli']
         args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.7
+    rev: 0.11.8
     hooks:
       - id: uv-lock
       - id: uv-export
         args: ["--frozen", "--no-emit-project", "--no-default-groups", "--output-file=requirements.txt"]
   - repo: https://github.com/hashicorp/copywrite
-    rev: v0.25.2
+    rev: v0.25.3
     hooks:
       - id: add-headers
   - repo: https://github.com/DavidAnson/markdownlint-cli2
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.9.24
+    rev: v0.9.25
     hooks:
       - id: tombi-format
         args: ["--offline"]


### PR DESCRIPTION
## Updated pre-commit hooks

| Hook | From | To |
|---|---|---|
| [uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) | 0.11.7 | 0.11.8 |
| [copywrite](https://github.com/hashicorp/copywrite) | 0.25.2 | 0.25.3 |
| [tombi-pre-commit](https://github.com/tombi-toml/tombi-pre-commit) | 0.9.24 | 0.9.25 |