### PR TITLE
fix(vllm_performance): correct import paths in test_vllm_otlp_traces.py

### DIFF
--- a/plugins/actuators/vllm_performance/tests/test_vllm_otlp_traces.py
+++ b/plugins/actuators/vllm_performance/tests/test_vllm_otlp_traces.py
@@ -6,13 +6,14 @@ Unit tests for OTLP traces endpoint feature in vllm_performance actuator.
 Tests parameter validation, YAML generation, and backward compatibility.
 """
 
-from orchestrator.core.actuatorconfiguration.config import ActuatorConfiguration
-from plugins.actuators.vllm_performance.ado_actuators.vllm_performance.actuator_parameters import (
+from ado_actuators.vllm_performance.actuator_parameters import (
     VLLMPerformanceTestParameters,
 )
-from plugins.actuators.vllm_performance.ado_actuators.vllm_performance.k8s.yaml_support.build_components import (
+from ado_actuators.vllm_performance.k8s.yaml_support.build_components import (
     ComponentsYaml,
 )
+
+from orchestrator.core.actuatorconfiguration.config import ActuatorConfiguration
 
 
 class TestOTLPTracesEndpointParameter:


### PR DESCRIPTION
Fixes incorrect import paths in `test_vllm_otlp_traces.py` that were causing `ModuleNotFoundError` when running tests.

## Problem
The test file was using incorrect import paths with the `plugins.actuators.vllm_performance.` prefix, which doesn't exist as a module when the plugin is installed. This caused tests to fail with:
```
ModuleNotFoundError: No module named 'plugins'
```

## Solution
Changed imports from `plugins.actuators.vllm_performance.ado_actuators.vllm_performance.*` to `ado_actuators.vllm_performance.*`

## Files Changed
- `plugins/actuators/vllm_performance/tests/test_vllm_otlp_traces.py`: Fixed import paths for `VLLMPerformanceTestParameters` and `ComponentsYaml`

Closes #927