### PR TITLE
feat(cli): support --use-latest in ado get

### DIFF
--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -39,7 +39,6 @@ For `ado get` and `ado show` subcommands:
   stdout. Prefer this over shell redirection for large output so encoding and
   table rendering stay consistent.
 
-
 ## Commands That do not exist
 
 These plausible-sounding commands do not exist in ado. Do not write them:
@@ -97,6 +96,12 @@ uv run ado get space SPACE_ID -o yaml
 
 # Or write the same YAML to a file
 uv run ado get space SPACE_ID -o yaml --output-file space.yaml
+
+# Get the latest space as YAML
+uv run ado get space --use-latest -o yaml
+
+# Get the latest operation as YAML
+uv run ado get operation --use-latest -o yaml
 ```
 
 ### ado create

--- a/orchestrator/cli/commands/context.py
+++ b/orchestrator/cli/commands/context.py
@@ -114,6 +114,7 @@ def list_contexts(
         resource_type=AdoGetSupportedResourceTypes.CONTEXT,
         show_deprecated=False,
         show_details=False,
+        use_latest=False,
     )
 
     # NOTE: there will always be at least one context (local)

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -73,6 +73,15 @@ def get_resource(
             show_default=False,
         ),
     ] = None,
+    use_latest: Annotated[
+        bool,
+        typer.Option(
+            "--use-latest",
+            help="Get the latest identifier of the selected resource type. "
+            "Ignored if a resource identifier is also specified.",
+            show_default=False,
+        ),
+    ] = False,
     query: Annotated[
         list[str] | None,
         typer.Option(
@@ -286,6 +295,12 @@ def get_resource(
     # Save the configuration of a discovery space as YAML
     ado get space <space-id> -o yaml > space.yaml
 
+    # Get the latest space as YAML
+    ado get space --use-latest -o yaml
+
+    # Get the latest operation as YAML
+    ado get operation --use-latest -o yaml
+
     # List actuators and details about them
     ado get actuators --details
 
@@ -296,6 +311,16 @@ def get_resource(
     ado get experiments --details
     """
     ado_configuration: AdoConfiguration = ctx.obj
+
+    # Resolve --use-latest to actual resource_id
+    if use_latest:
+        from orchestrator.cli.utils.generic.common import get_effective_resource_id
+
+        resource_id = get_effective_resource_id(
+            explicit_resource_id=resource_id,
+            resource_type=resource_type.value,
+            project_context=ado_configuration.project_context,
+        )
 
     if resource_type != AdoGetSupportedResourceTypes.DISCOVERY_SPACE and (
         matching_point or matching_space or matching_space_id
@@ -374,6 +399,7 @@ def get_resource(
         resource_type=resource_type,
         show_deprecated=show_deprecated,
         show_details=show_details,
+        use_latest=use_latest,
     )
 
     method_mapping = {

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -68,7 +68,8 @@ def get_resource(
         typer.Argument(
             help=(
                 "The id of the resource to get. "
-                "If unspecified, the command will return all resources of the specified type."
+                "If unspecified, the command will return all resources of the specified type "
+                "(unless --use-latest is used)."
             ),
             show_default=False,
         ),

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -45,6 +45,7 @@ class AdoGetCommandParameters(pydantic.BaseModel):
     resource_type: AdoGetSupportedResourceTypes
     show_deprecated: bool
     show_details: bool
+    use_latest: bool
 
 
 class AdoCreateCommandParameters(pydantic.BaseModel):

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -436,3 +436,301 @@ def test_field_querying(
             )
             == result.output
         ), result.output
+
+
+@requires_sqlite_3_38
+def test_get_space_with_use_latest(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+) -> None:
+    """Test getting the latest space using --use-latest flag"""
+    from orchestrator.core import DiscoverySpaceResource
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two spaces explicitly
+    from datetime import datetime, timezone
+
+    # Load file content once
+    space_data = yaml.safe_load(
+        pathlib.Path("tests/resources/space/discoveryspace_resource.json").read_text()
+    )
+
+    # Create first space
+    space_1 = DiscoverySpaceResource.model_validate(space_data)
+    space_1.identifier = "space-test-older"
+    space_1.created = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    sql_store.addResource(space_1)
+
+    # Create second space
+    space_2 = DiscoverySpaceResource.model_validate(space_data)
+    space_2.identifier = "space-test-latest"
+    space_2.created = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    sql_store.addResource(space_2)
+
+    # Test with YAML output format
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "space",
+            "--use-latest",
+            "-o",
+            "yaml",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        # Should return the latest space (space_2)
+        assert space_2.identifier in result.output
+        # Verify it's using the correct space
+        assert f"using space {space_2.identifier}" in result.output.lower()
+        # Should NOT return the first space
+        assert space_1.identifier not in result.output
+
+
+@requires_sqlite_3_38
+def test_get_operation_with_use_latest(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    sample_store_resource: SampleStoreResource,
+) -> None:
+    """Test getting the latest operation using --use-latest flag"""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two operations with different identifiers
+    from datetime import datetime, timezone
+
+    # Load file content once
+    operation_data = yaml.safe_load(
+        pathlib.Path(
+            "tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml"
+        ).read_text()
+    )
+
+    # Create first operation
+    operation_1 = OperationResource.model_validate(operation_data)
+    operation_1.identifier = "operation-test-older"
+    operation_1.created = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    sql_store.addResource(operation_1)
+
+    # Create second operation
+    operation_2 = OperationResource.model_validate(operation_data)
+    operation_2.identifier = "operation-test-latest"
+    operation_2.created = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    sql_store.addResource(operation_2)
+
+    # Test with YAML output format
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operation",
+            "--use-latest",
+            "-o",
+            "yaml",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        # Should return the latest operation (operation_2)
+        assert operation_2.identifier in result.output
+        # Verify it's using the correct operation
+        assert f"using operation {operation_2.identifier}" in result.output.lower()
+        # Should NOT return the first operation
+        assert operation_1.identifier not in result.output
+
+
+@requires_sqlite_3_38
+def test_get_with_use_latest_and_explicit_id(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+) -> None:
+    """Test that explicit ID takes precedence over --use-latest"""
+    from orchestrator.core import DiscoverySpaceResource
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two spaces with different identifiers
+    from datetime import datetime, timezone
+
+    # Load file content once
+    space_data = yaml.safe_load(
+        pathlib.Path("tests/resources/space/discoveryspace_resource.json").read_text()
+    )
+
+    # Create first space
+    space_1 = DiscoverySpaceResource.model_validate(space_data)
+    space_1.identifier = "space-test-older"
+    space_1.created = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    sql_store.addResource(space_1)
+
+    # Create second space
+    space_2 = DiscoverySpaceResource.model_validate(space_data)
+    space_2.identifier = "space-test-latest"
+    space_2.created = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    sql_store.addResource(space_2)
+
+    # Test with both explicit ID and --use-latest
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "space",
+            space_1.identifier,
+            "--use-latest",
+            "-o",
+            "yaml",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        # Verify warning message about precedence
+        assert (
+            "explicitly specified resource ids take precedence" in result.output.lower()
+        )
+        # Verify the correct space is returned (space_1, not space_2)
+        assert space_1.identifier in result.output
+        # Should NOT return the latest space since explicit ID takes precedence
+        assert space_2.identifier not in result.output
+
+
+@requires_sqlite_3_38
+def test_get_with_use_latest_table_format(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+) -> None:
+    """Test --use-latest with table output format (default)"""
+    from orchestrator.core import DiscoverySpaceResource
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two spaces with different identifiers
+    from datetime import datetime, timezone
+
+    # Load file content once
+    space_data = yaml.safe_load(
+        pathlib.Path("tests/resources/space/discoveryspace_resource.json").read_text()
+    )
+
+    # Create first space
+    space_1 = DiscoverySpaceResource.model_validate(space_data)
+    space_1.identifier = "space-test-older"
+    space_1.created = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    sql_store.addResource(space_1)
+
+    # Create second space
+    space_2 = DiscoverySpaceResource.model_validate(space_data)
+    space_2.identifier = "space-test-latest"
+    space_2.created = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    sql_store.addResource(space_2)
+
+    # Test with table format (default)
+    result = runner.invoke(
+        ado, ["--override-ado-app-dir", tmp_path, "get", "space", "--use-latest"]
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        # Should return the latest space (space_2)
+        assert space_2.identifier in result.output
+        # Should NOT return the first space
+        assert space_1.identifier not in result.output
+
+
+@requires_sqlite_3_38
+def test_get_with_use_latest_name_format(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+) -> None:
+    """Test --use-latest with name output format"""
+    from orchestrator.core import DiscoverySpaceResource
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two spaces with different identifiers
+    from datetime import datetime, timezone
+
+    # Load file content once
+    space_data = yaml.safe_load(
+        pathlib.Path("tests/resources/space/discoveryspace_resource.json").read_text()
+    )
+
+    # Create first space
+    space_1 = DiscoverySpaceResource.model_validate(space_data)
+    space_1.identifier = "space-test-older"
+    space_1.created = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    sql_store.addResource(space_1)
+
+    # Create second space
+    space_2 = DiscoverySpaceResource.model_validate(space_data)
+    space_2.identifier = "space-test-latest"
+    space_2.created = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    sql_store.addResource(space_2)
+
+    # Test with name format
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "space",
+            "--use-latest",
+            "-o",
+            "name",
+        ],
+    )
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        # Name format should output just the identifier
+        assert space_2.identifier in result.output
+        # Should NOT return the first space
+        assert space_1.identifier not in result.output
+        # Should not contain table formatting
+        assert "IDENTIFIER" not in result.output

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -455,6 +455,7 @@ The complete syntax of the `ado get` command is as follows:
 ```shell
 ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <default | yaml | json | config | raw>] \
                                     [--output-file <path>] \
+                                    [--use-latest] \
                                     [--exclude-default | --no-exclude-default] \
                                     [--exclude-unset | --no-exclude-unset ] \
                                     [--exclude-none | --no-exclude-none ] \
@@ -492,6 +493,9 @@ Where:
     <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the optional unique identifier of the resource to get.
+- `--use-latest` retrieves the most recently created resource of the specified
+  type. This flag is ignored if a `RESOURCE_ID` is also provided (the explicit
+  ID takes precedence).
 - `--output` or `-o` determine the type of output that will be displayed:
 
     <!-- prettier-ignore-start -->
@@ -654,6 +658,18 @@ ado get operation randomwalk-0.5.0-123abc -o yaml
 
 ```shell
 ado get operations -o name
+```
+
+##### Getting the latest Discovery Space as YAML
+
+```shell
+ado get space --use-latest -o yaml
+```
+
+##### Getting the latest Operation as YAML
+
+```shell
+ado get operation --use-latest -o yaml
 ```
 
 ##### Displaying all current experiments

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -492,7 +492,9 @@ Where:
 
     <!-- prettier-ignore-end -->
 
-- `RESOURCE_ID` is the optional unique identifier of the resource to get.
+- `RESOURCE_ID` is the optional unique identifier of the resource to get. If not
+  specified, all resources of the given type are returned (unless `--use-latest`
+  is used).
 - `--use-latest` retrieves the most recently created resource of the specified
   type. This flag is ignored if a `RESOURCE_ID` is also provided (the explicit
   ID takes precedence).


### PR DESCRIPTION
# Summary

This PR adds a `--use-latest` flag to the `ado get` command that allows users to retrieve the most recently created resource of a specified type without needing to know its identifier. When both an explicit resource ID and `--use-latest` are provided, the explicit ID takes precedence.

Resolves #853 

# Files Changed

📄 `orchestrator/cli/commands/get.py`

Added a new `--use-latest` boolean option to the `get_resource` command. When enabled, the flag resolves to the actual resource ID of the most recently created resource of the specified type. Updated help text to reflect the new option, added documentation examples showing usage with spaces and operations, and integrated the resolution logic before the main command execution. The flag is ignored if an explicit resource identifier is also provided.

📄 `orchestrator/cli/models/parameters.py`

Added the `use_latest` boolean field to the `AdoGetCommandParameters` Pydantic model to support passing the new flag through the command parameter structure.

📄 `tests/ado/get/test_ado_get.py`

Added comprehensive test coverage for the new `--use-latest` functionality including:
- `test_get_space_with_use_latest`: Verifies that the latest space is retrieved when using the flag
- `test_get_operation_with_use_latest`: Verifies that the latest operation is retrieved when using the flag
- `test_get_with_use_latest_and_explicit_id`: Ensures explicit IDs take precedence over `--use-latest`
- `test_get_with_use_latest_table_format`: Tests the flag with default table output format
- `test_get_with_use_latest_name_format`: Tests the flag with name-only output format