### PR TITLE
refactor(cli): --use-latest flag in show summary now behaves like other commands

### DIFF
--- a/orchestrator/cli/commands/show_summary.py
+++ b/orchestrator/cli/commands/show_summary.py
@@ -6,7 +6,6 @@ import typing
 from typing import Annotated
 
 import typer
-from rich.status import Status
 
 from orchestrator.cli.models.choice import HiddenPluralChoice
 from orchestrator.cli.models.parameters import AdoShowSummaryCommandParameters
@@ -17,21 +16,16 @@ from orchestrator.cli.models.types import (
 from orchestrator.cli.resources.discovery_space.show_summary import (
     show_discovery_space_summary,
 )
-from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.input.parsers import (
     parse_key_value_pairs,
 )
 from orchestrator.cli.utils.output.prints import (
-    ADO_SPINNER_QUERYING_DB,
     ERROR,
     console_print,
-    latest_identifier_for_resource_not_found,
-    using_latest_identifier_for_resource,
 )
 from orchestrator.cli.utils.queries.parser import (
     prepare_query_filters_for_db,
 )
-from orchestrator.core import CoreResourceKinds
 from orchestrator.core.samplestore.base import (
     FailedToDecodeStoredEntityError,
     FailedToDecodeStoredMeasurementResultForEntityError,
@@ -66,8 +60,8 @@ def show_summary_for_resources(
         bool,
         typer.Option(
             "--use-latest",
-            help="Adds the latest identifier of the selected resource type to "
-            "the identifiers to show a summary for.",
+            help="Show summary for the latest identifier of the selected resource type. "
+            "Ignored if resource identifiers are also specified.",
             show_default=False,
         ),
     ] = False,
@@ -179,34 +173,15 @@ def show_summary_for_resources(
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
-    resource_kind = CoreResourceKinds(resource_type.value)
+    if use_latest:
+        from orchestrator.cli.utils.generic.common import get_effective_resource_id
 
-    # Fetch the latest resource ID from the database
-    sql_store = get_sql_store(ado_configuration.project_context)
-    with Status(ADO_SPINNER_QUERYING_DB):
-        latest_ids = sql_store.get_latest_resource_identifiers_of_kinds(
-            kinds=[resource_kind]
+        # Handle single ID case - get_effective_resource_id handles precedence
+        resource_id = get_effective_resource_id(
+            explicit_resource_id=ids[0] if ids else None,
+            resource_type=resource_type.value,
+            project_context=ado_configuration.project_context,
         )
-
-    resource_id = latest_ids.get(resource_kind)
-    if not resource_id:
-        console_print(
-            latest_identifier_for_resource_not_found(
-                resource_kind=resource_kind, hide_resource_in_flag=True
-            ),
-            stderr=True,
-        )
-        raise typer.Exit(1)
-    console_print(
-        using_latest_identifier_for_resource(
-            resource_kind=resource_kind, resource_identifier=resource_id
-        ),
-        stderr=True,
-    )
-
-    if ids:
-        ids.append(resource_id)
-    else:
         ids = [resource_id]
 
     try:

--- a/orchestrator/cli/resources/discovery_space/show_summary.py
+++ b/orchestrator/cli/resources/discovery_space/show_summary.py
@@ -110,12 +110,16 @@ def show_discovery_space_summary(parameters: AdoShowSummaryCommandParameters) ->
                 )
 
                 # When writing to file, avoid truncating columns by default
+                # Always avoid truncating the "Space ID" column
+                do_not_truncate = (
+                    True if parameters.output_file is not None else ["Space ID"]
+                )
                 table = dataframe_to_rich_table(
                     df,
                     show_edge=True,
                     show_index=True,
                     box=rich.box.SQUARE,
-                    do_not_truncate_columns=parameters.output_file is not None,
+                    do_not_truncate_columns=do_not_truncate,
                 )
                 result = render_to_string(table, auto_width=True)
 

--- a/tests/ado/show_summary/__init__.py
+++ b/tests/ado/show_summary/__init__.py
@@ -1,0 +1,4 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+# Made with Bob

--- a/tests/ado/show_summary/test_show_summary_use_latest.py
+++ b/tests/ado/show_summary/test_show_summary_use_latest.py
@@ -1,0 +1,171 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Tests for the --use-latest flag behavior in show_summary command."""
+
+import pathlib
+from collections.abc import Callable
+
+from typer.testing import CliRunner
+
+from orchestrator.cli.core.cli import app as ado
+from orchestrator.core.discoveryspace.space import DiscoverySpace
+from orchestrator.metastore.project import ProjectContext
+from tests.conftest import requires_sqlite_3_38
+
+
+@requires_sqlite_3_38
+def test_show_summary_use_latest_alone(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    pfas_space: DiscoverySpace,
+    ml_multi_cloud_space: DiscoverySpace,
+) -> None:
+    """Test that --use-latest alone uses the latest space ID, not an older one."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # We have two spaces: pfas_space (created first) and ml_multi_cloud_space (created second, so it's latest)
+    # Run show summary with --use-latest
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "summary",
+            "space",
+            "--use-latest",
+        ],
+    )
+
+    # Should succeed
+    assert result.exit_code == 0
+
+    # Should show the LATEST space ID (ml_multi_cloud_space), not the older one (pfas_space)
+    assert ml_multi_cloud_space.uri in result.output
+    # Verify it's not showing the older space
+    assert pfas_space.uri not in result.output
+
+
+@requires_sqlite_3_38
+def test_show_summary_use_latest_with_explicit_id(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    pfas_space: DiscoverySpace,
+    ml_multi_cloud_space: DiscoverySpace,
+) -> None:
+    """Test that explicit ID takes precedence over --use-latest with a warning."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # We have two spaces: pfas_space (older) and ml_multi_cloud_space (latest)
+    # Request the older space explicitly with --use-latest
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "summary",
+            "space",
+            pfas_space.uri,
+            "--use-latest",
+        ],
+    )
+
+    # Should succeed
+    assert result.exit_code == 0
+
+    # Should show warning about explicit ID taking precedence
+    assert "explicitly specified resource ids take precedence" in result.output.lower()
+
+    # Should show the EXPLICIT (older) space ID in output, not the latest one
+    assert pfas_space.uri in result.output
+    # Verify it's not showing the latest space
+    assert ml_multi_cloud_space.uri not in result.output
+
+
+@requires_sqlite_3_38
+def test_show_summary_multiple_ids_without_use_latest(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    pfas_space: DiscoverySpace,
+) -> None:
+    """Test that multiple IDs work without --use-latest."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Get the first space ID
+    space_id_1 = pfas_space.uri
+
+    # For this test, we'll just use the same ID twice to verify the command accepts multiple IDs
+    # In a real scenario, you'd create a second space
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "summary",
+            "space",
+            space_id_1,
+            space_id_1,
+        ],
+    )
+
+    # Should succeed (even with duplicate IDs, the command should work)
+    assert result.exit_code == 0
+
+    # Should show the complete space ID (Space ID column is never truncated)
+    assert space_id_1 in result.output
+
+
+@requires_sqlite_3_38
+def test_show_summary_use_latest_without_spaces(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+) -> None:
+    """Test that --use-latest fails gracefully when no spaces exist."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Run show summary with --use-latest when no spaces exist
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "summary",
+            "space",
+            "--use-latest",
+        ],
+    )
+
+    # Should fail with appropriate error
+    assert result.exit_code == 1
+    assert "unable to find" in result.output.lower()
+
+
+# Made with Bob


### PR DESCRIPTION
# Summary

This pull request refactors the `--use-latest` flag behavior in the `show summary` command to improve clarity and fix logic issues. The changes ensure that when both `--use-latest` and explicit resource IDs are provided, the explicit IDs take precedence (with a warning), and the flag is ignored. Additionally, the Space ID column is now always displayed without truncation in discovery space summaries.

Resolves #835 

# Files Changed

📄 `orchestrator/cli/commands/show_summary.py`

Refactored the `--use-latest` flag implementation to simplify logic and fix precedence issues. The new implementation uses a helper function `get_effective_resource_id` to handle the precedence between explicit IDs and the latest ID. Removed direct database queries and spinner status from this file, delegating that responsibility to the helper function. Updated the help text to clarify that the flag is ignored when explicit resource identifiers are provided.

📄 `orchestrator/cli/resources/discovery_space/show_summary.py`

Modified the table rendering logic to ensure the "Space ID" column is never truncated in console output, while still allowing all columns to be untruncated when writing to a file. This improves readability by always showing complete space identifiers.

📄 `tests/ado/show_summary/__init__.py`

Added new test module initialization file for show_summary command tests.

📄 `tests/ado/show_summary/test_show_summary_use_latest.py`

Added comprehensive test coverage for the `--use-latest` flag behavior, including:
- Testing that `--use-latest` alone uses the most recent space ID
- Verifying that explicit IDs take precedence over `--use-latest` with appropriate warnings
- Testing multiple IDs without the flag
- Testing graceful failure when no spaces exist