### PR TITLE
refactor(plugins): rename configuration_model_default to example_configuration

### DIFF
--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -127,7 +127,7 @@ def characterize_operation(
     name: str,
     version: str,
     configuration_model: type[pydantic.BaseModel],
-    configuration_model_default: pydantic.BaseModel,
+    example_configuration: pydantic.BaseModel,
     description: str | None = None,
 ) -> typing.Callable[[OperatorFunction], OperatorFunction]:
     """Decorator that registers a function as a characterize operation.
@@ -136,7 +136,7 @@ def characterize_operation(
         name: Canonical operator name used in the registry.
         version: Version string included in the operator identifier.
         configuration_model: Pydantic model used to validate operation parameters.
-        configuration_model_default: Default parameter model instance.
+        example_configuration: Example parameter model instance for templating.
         description: Human-readable description shown in the registry.
 
     Returns:
@@ -166,7 +166,7 @@ def characterize_operation(
             version=version,
             description=description,
             configuration_model=configuration_model,
-            example_configuration=configuration_model_default,
+            example_configuration=example_configuration,
             type=DiscoveryOperationEnum.CHARACTERIZE,
         )
         return wrapper
@@ -275,7 +275,7 @@ def modify_operation(
     name: str,
     version: str,
     configuration_model: type[pydantic.BaseModel],
-    configuration_model_default: pydantic.BaseModel,
+    example_configuration: pydantic.BaseModel,
     description: str | None = None,
 ) -> typing.Callable[[OperatorFunction], OperatorFunction]:
     """Decorator that registers a function as a modify operation.
@@ -284,7 +284,7 @@ def modify_operation(
         name: Canonical operator name used in the registry.
         version: Version string included in the operator identifier.
         configuration_model: Pydantic model used to validate operation parameters.
-        configuration_model_default: Default parameter model instance.
+        example_configuration: Example parameter model instance for templating.
         description: Human-readable description shown in the registry.
 
     Returns:
@@ -314,7 +314,7 @@ def modify_operation(
             version=version,
             description=description,
             configuration_model=configuration_model,
-            example_configuration=configuration_model_default,
+            example_configuration=example_configuration,
             type=DiscoveryOperationEnum.MODIFY,
         )
         return wrapper
@@ -326,7 +326,7 @@ def export_operation(
     name: str,
     version: str,
     configuration_model: type[pydantic.BaseModel],
-    configuration_model_default: pydantic.BaseModel,
+    example_configuration: pydantic.BaseModel,
     description: str | None = None,
 ) -> typing.Callable[[OperatorFunction], OperatorFunction]:
     """Decorator that registers a function as an export operation.
@@ -335,7 +335,7 @@ def export_operation(
         name: Canonical operator name used in the registry.
         version: Version string included in the operator identifier.
         configuration_model: Pydantic model used to validate operation parameters.
-        configuration_model_default: Default parameter model instance.
+        example_configuration: Example parameter model instance for templating.
         description: Human-readable description shown in the registry.
 
     Returns:
@@ -365,7 +365,7 @@ def export_operation(
             version=version,
             description=description,
             configuration_model=configuration_model,
-            example_configuration=configuration_model_default,
+            example_configuration=example_configuration,
             type=DiscoveryOperationEnum.EXPORT,
         )
         return wrapper

--- a/plugins/operators/anomalous_series/anomalous_series/operator.py
+++ b/plugins/operators/anomalous_series/anomalous_series/operator.py
@@ -90,7 +90,7 @@ class DetectAnomalousSeries(pydantic.BaseModel):
     ] = True
 
     @classmethod
-    def default_parameters(cls) -> "DetectAnomalousSeries":
+    def example_configuration(cls) -> "DetectAnomalousSeries":
         return cls(
             groupby_properties=[
                 "model_name",
@@ -122,7 +122,7 @@ class DetectAnomalousSeries(pydantic.BaseModel):
     properties, other than the selected independent property.
     """,
     configuration_model=DetectAnomalousSeries,
-    configuration_model_default=DetectAnomalousSeries.default_parameters(),
+    example_configuration=DetectAnomalousSeries.example_configuration(),
     version="1.0",
 )
 def detect_anomalous_series(

--- a/plugins/operators/profile_space/profile_space/operator.py
+++ b/plugins/operators/profile_space/profile_space/operator.py
@@ -21,7 +21,7 @@ class ProfileParameters(pydantic.BaseModel):
     name="profile",
     version=version("ado-core"),
     configuration_model=ProfileParameters,
-    configuration_model_default=ProfileParameters(),
+    example_configuration=ProfileParameters(),
     description="Returns a ydata_profiling ProfileReport for the space",
 )
 # operator function can have any name but have similar parameters - see https://ibm.github.io/ado/operators/creating-operators/#operator-function-parameters

--- a/plugins/operators/ray_tune/ado_ray_tune/rifferla.py
+++ b/plugins/operators/ray_tune/ado_ray_tune/rifferla.py
@@ -78,7 +78,7 @@ class RifferlaParameters(pydantic.BaseModel):
     ] = EntityFilter.SAMPLED
 
     @classmethod
-    def defaultOperationParameters(cls) -> "RifferlaParameters":
+    def example_configuration(cls) -> "RifferlaParameters":
         return cls(
             failed_metric="is_valid",
             failed_value=1,
@@ -93,7 +93,7 @@ class RifferlaParameters(pydantic.BaseModel):
     description="Refines a space to produce one that is denser in entities that have min/max of a given observed property."
     "It does this by identifying which entity space dimensions should be fixed to set values, which explored, and setting range limits for those dimensions. "
     "The method leverages Mutual Information to identify dimensions correlated with the desired observed property.",
-    configuration_model_default=RifferlaParameters.defaultOperationParameters(),
+    example_configuration=RifferlaParameters.example_configuration(),
     version=version("ado-ray-tune"),
 )
 def rifferla(

--- a/plugins/operators/trim/src/trim/operator.py
+++ b/plugins/operators/trim/src/trim/operator.py
@@ -24,7 +24,7 @@ logger_trim = logging.getLogger(__name__)
 @characterize_operation(
     name="trim",
     configuration_model=TrimParameters,
-    configuration_model_default=TrimParameters.defaultOperationParameters(),
+    example_configuration=TrimParameters.example_configuration(),
     description="""
                 Trim is used to characterise a Discovery space.
                 In its first implementation it starts from a space,

--- a/plugins/operators/trim/src/trim/trim_pydantic.py
+++ b/plugins/operators/trim/src/trim/trim_pydantic.py
@@ -153,7 +153,7 @@ class TrimParameters(BaseModel):
     # ] = False
 
     @classmethod
-    def defaultOperationParameters(cls) -> "TrimParameters":
+    def example_configuration(cls) -> "TrimParameters":
         return cls(targetOutput="TO_BE_SET")
 
     @model_validator(mode="after")

--- a/website/docs/operators/creating-operators.md
+++ b/website/docs/operators/creating-operators.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable code-block-style -->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable first-line-h1 -->
+
 !!! info end
 
     A complete example operator is provided
@@ -47,7 +48,7 @@ from orchestrator.modules.operators.collections import characterize_operation  #
     name="my_operator",  # The name of your operator.
     description="Example operator",  # What this operator does
     configuration_model=MyOperatorOptions,  # A pydantic model that describes your operators input parameters
-    configuration_model_default=MyOperatorOptions.default_parameters(),  # An example of your operators input parameters
+    example_configuration=MyOperatorOptions.example_configuration(),  # An example of your operators input parameters
     version="1.0",  # Version of the operator
 
 )
@@ -138,7 +139,7 @@ the previous section with the relevant fields called out:
     name="my_operator",
     description="Example operator",
     configuration_model=MyOperatorOptions,  # <- A pydantic model that describes your operators input parameters
-    configuration_model_default=MyOperatorOptions(), # <- An example of your operators input parameters
+    example_configuration=MyOperatorOptions(), # <- An example of your operators input parameters
     version="1.0",
 )
 ```
@@ -154,13 +155,13 @@ inputs = MyOperatorOptions.model_validate(parameters)
 
 ### Providing an example operation configuration
 
-The decorators `configuration_model_default` parameter takes an example of your
+The decorators `example_configuration` parameter takes an example of your
 operators parameters. If your operator's parameter model has defaults for all
 fields then the simplest approach is to use those as the value of
-`configuration_model_default`:
+`example_configuration`:
 
 ```python
-    configuration_model_default=MyOperatorOptions(), # <- This will use the defaults specified for all fields of your operators parameters
+    example_configuration=MyOperatorOptions(), # <- This will use the defaults specified for all fields of your operators parameters
 ```
 
 ### How your Operators input parameters model is stored and output
@@ -512,21 +513,20 @@ except InterruptedOperationError as nested_operation_error:
 ## Creating Explore Operators
 
 Explore operators sample entities from a discovery space and submit them for
-measurement.  Unlike other operator types, the logic runs inside a **Ray
-actor** and requires a class to be implemented.
+measurement. Unlike other operator types, the logic runs inside a **Ray actor**
+and requires a class to be implemented.
 
 ### Implementation
 
-1. Create a class that subclasses
-`orchestrator.modules.operators.base.Explore`
+1. Create a class that subclasses `orchestrator.modules.operators.base.Explore`
 2. Decorate it with `@explore_operation`
 3. Implement, at least, the following methods:
-   - **`operator_metadata()`** — a classmethod returning an
-     `OperatorMetadata` instance that describes your operator.
+   - **`operator_metadata()`** — a classmethod returning an `OperatorMetadata`
+     instance that describes your operator.
    - **`run()`** — an async method containing your operator logic
-   - **`onUpdate()`**, **`onCompleted`** and **`onError`** - methods
-   that handle notifications about completed measurements
-  
+   - **`onUpdate()`**, **`onCompleted`** and **`onError`** - methods that handle
+     notifications about completed measurements
+
 A simple example is show below:
 
 ```python
@@ -576,7 +576,7 @@ class MySearchOperator(Explore):
 
     # --- callbacks from DiscoverySpaceManager --------------------------------
     # onUpdate: called when a measurement completes
-    # onError:  called on an unrecoverable error 
+    # onError:  called on an unrecoverable error
 
     def onUpdate(self, measurementRequest) -> None:
         self.completed_measurements_queue.put_nowait(measurementRequest)
@@ -638,24 +638,23 @@ class MySearchOperator(Explore):
 
 ### Tips
 
-**Submit measurements in batches.**  Submitting a batch at once, then waiting
-for all of them to complete before sampling the next batch, is the simplest
-pattern.  A more advanced approach is to submit the next entity as soon as one
-measurement finishes (continuous batching), which keeps actuators busy and
-reduces idle time.
+**Submit measurements in batches.** Submitting a batch at once, then waiting for
+all of them to complete before sampling the next batch, is the simplest pattern.
+A more advanced approach is to submit the next entity as soon as one measurement
+finishes (continuous batching), which keeps actuators busy and reduces idle
+time.
 
-**Use `measure_or_replay` for all submissions.**  Do not call actuators
-directly.  `measure_or_replay` handles memoisation (reusing a prior
-measurement result when `memoize=True`) and routes the request to the correct
-actuator.
+**Use `measure_or_replay` for all submissions.** Do not call actuators directly.
+`measure_or_replay` handles memoisation (reusing a prior measurement result when
+`memoize=True`) and routes the request to the correct actuator.
 
-**Use `self.operationIdentifier()` as the `requesterid`.**  The update
-notifications you receive via `onUpdate` include the `operation_id` that
-created the request.  Filtering on `measurement_request.operation_id ==
-self.operationIdentifier()` lets you ignore notifications from other
-concurrent operations sharing the same space.
+**Use `self.operationIdentifier()` as the `requesterid`.** The update
+notifications you receive via `onUpdate` include the `operation_id` that created
+the request. Filtering on
+`measurement_request.operation_id == self.operationIdentifier()` lets you ignore
+notifications from other concurrent operations sharing the same space.
 
-**Unsubscribe before returning.**  Call
+**Unsubscribe before returning.** Call
 `self.ds_manager.unsubscribeFromUpdates.remote(subscriberName=self.actorName)`
 at the end of `run()` as a courtesy — it stops the `DiscoverySpaceManager` from
 dispatching further `onUpdate` and `onCompleted` calls to an operator that has
@@ -663,21 +662,21 @@ already finished.
 
 ### Error handling
 
-**Errors from `measure_or_replay`.**  The function raises `KeyError` (no
-actuator can handle the experiment) or `MeasurementError` (experiment is
-deprecated for the actuator version in use). These don't have to be caught
-as they are handled by `ado`. It records the operation with exit state `ERROR` including the full
-exception message.  You only need to catch them explicitly if you want finer
+**Errors from `measure_or_replay`.** The function raises `KeyError` (no actuator
+can handle the experiment) or `MeasurementError` (experiment is deprecated for
+the actuator version in use). These don't have to be caught as they are handled
+by `ado`. It records the operation with exit state `ERROR` including the full
+exception message. You only need to catch them explicitly if you want finer
 control.
 
-**Errors from the discovery space manager.**  If the discovery space manager
-encounters an unrecoverable problem it calls `onError`. This arrives asynchronously
-and without explicit handling run() could wait forever for a new measurement result
-to arrive. A recommended pattern to handle this is shown in the example above: `onError`
-puts the exception onto the same `asyncio.Queue` that `onUpdate` uses for
-completed measurements.  In the wait loop, check whether the item dequeued is an
-`Exception` to detect this sentinel and exit early, then return a failed
-`OperationOutput`.
+**Errors from the discovery space manager.** If the discovery space manager
+encounters an unrecoverable problem it calls `onError`. This arrives
+asynchronously and without explicit handling run() could wait forever for a new
+measurement result to arrive. A recommended pattern to handle this is shown in
+the example above: `onError` puts the exception onto the same `asyncio.Queue`
+that `onUpdate` uses for completed measurements. In the wait loop, check whether
+the item dequeued is an `Exception` to detect this sentinel and exit early, then
+return a failed `OperationOutput`.
 
 ## Operator plugin packages
 


### PR DESCRIPTION
# Summary

This pull request refactors parameter naming across operator decorators and configuration models to improve clarity. The parameter `configuration_model_default` has been renamed to `example_configuration` throughout the codebase to better reflect its purpose as an example for templating rather than a default value. Similarly, class methods that generate these example configurations have been renamed from `default_parameters()` and `defaultOperationParameters()` to the more descriptive `example_configuration()`.

Resolves #650 

# Files Changed

📄 `orchestrator/modules/operators/collections.py`

Renamed the `configuration_model_default` parameter to `example_configuration` in three operator decorator functions (`characterize_operation`, `modify_operation`, and `export_operation`). Updated corresponding docstrings to clarify that this parameter provides an "example parameter model instance for templating" rather than a "default parameter model instance". The internal usage of this parameter was also updated to use the new name consistently.

📄 `plugins/operators/anomalous_series/anomalous_series/operator.py`

Renamed the `default_parameters()` class method to `example_configuration()` in the `DetectAnomalousSeries` configuration model. Updated the decorator call to use the new `example_configuration` parameter name instead of `configuration_model_default`.

📄 `plugins/operators/profile_space/profile_space/operator.py`

Updated the `@characterize_operation` decorator to use the new `example_configuration` parameter name instead of `configuration_model_default` for the ProfileParameters configuration.

📄 `plugins/operators/ray_tune/ado_ray_tune/rifferla.py`

Renamed the `defaultOperationParameters()` class method to `example_configuration()` in the `RifferlaParameters` configuration model. Updated the decorator call to use the new `example_configuration` parameter name.

📄 `plugins/operators/trim/src/trim/operator.py`

Updated the `@characterize_operation` decorator to use the new `example_configuration` parameter name and call the renamed `example_configuration()` method instead of `defaultOperationParameters()`.

📄 `plugins/operators/trim/src/trim/trim_pydantic.py`

Renamed the `defaultOperationParameters()` class method to `example_configuration()` in the `TrimParameters` configuration model to align with the new naming convention.