### PR TITLE
feat(vllm-performance): Install dependencies in benchmark execution worker

### DIFF
--- a/orchestrator/utilities/environment.py
+++ b/orchestrator/utilities/environment.py
@@ -2,146 +2,94 @@
 # SPDX-License-Identifier: MIT
 import logging
 import os
-from importlib.metadata import requires
 
 import ray
+from packaging.requirements import Requirement
 
 logger = logging.getLogger(__name__)
 
 
-def _get_dependency_from_package_metadata(
-    package_name: str, extra_name: str
-) -> str | None:
+def extract_package_specs_from_job_env(
+    package_names: list[str],
+) -> dict[str, dict[str, str | None]]:
     """
-    Extract dependency specification from installed package metadata.
+    Parse package specifications from the Ray job's uv environment.
+
+    Given a list of package names, returns information about those packages
+    if they are present in the worker job's uv venv.
 
     Args:
-        package_name: Name of the package to query (e.g., 'ado-vllm-performance')
-        extra_name: Name of the optional dependency group (e.g., 'vllm', 'guidellm')
+        package_names: List of package names to look for (e.g., ['ado-vllm-performance', 'numpy'])
 
     Returns:
-        Dependency specification from the package's optional-dependencies, or None if not found
-    """
-    try:
-        # Get the package requirements
-        # The requires() function returns a list of requirement strings
-        # Format: "package>=version; extra == 'extra_name'"
-        package_requires = requires(package_name) or []
-        for req in package_requires:
-            # Parse requirements that match our extra
-            if f'extra == "{extra_name}"' in req or f"extra == '{extra_name}'" in req:
-                # Extract just the package specification (before the semicolon)
-                dep_spec = req.split(";")[0].strip()
-                logger.debug(
-                    f"Extracted dependency for '{extra_name}' from {package_name} metadata: {dep_spec}"
-                )
-                return dep_spec
-    except Exception as e:
-        logger.debug(f"Could not read metadata for package '{package_name}': {e}")
-
-    return None
-
-
-def inherit_ray_job_env_and_add_extra(base_package_name: str, extra: str) -> dict:
-    """
-    Build a Ray runtime environment that inherits packages from the job's runtime
-    environment and adds an extra dependency by extracting its version from the
-    base package's metadata.
-
-    This is useful for actuators that need to add experiment-specific dependencies
-    (e.g., 'vllm', 'guidellm') that are defined as extras in the base package.
-
-    The function handles two cases:
-    1. Base package in job uv: Reinstalls base package + ado-core + extra
-    2. Base package in base env only: Just installs the extra
-
-    Args:
-        base_package_name: Name of the base package that defines the extra
-                          (e.g., 'ado-vllm-performance')
-        extra: Name of the extra package to install (e.g., 'vllm', 'guidellm')
-
-    Returns:
-        Runtime environment dict with uv packages list
-
-    Raises:
-        RuntimeError: If base package is not found in either job uv or base environment
+        Dictionary mapping package names to their specifications:
+        {
+            "package-name": {
+                "source": "package-name" or "/path/to/wheel.whl" (no version or extras),
+                "version": "==1.2.3" or None,
+                "extras": "extra1,extra2" or None
+            }
+        }
+        Only includes packages that are found in the job uv environment.
 
     Example:
-        >>> # If job uv has: ["numpy", "pandas", "ado-vllm-performance==1.2.3"]
-        >>> env = inherit_ray_job_env_and_add_extra('ado-vllm-performance', 'vllm')
-        >>> # Returns: {"uv": ["numpy", "pandas", "ado-vllm-performance==1.2.3", "vllm>=0.6.0"]}
-        >>>
-        >>> # If job uv has: ["numpy", "pandas"] (base package in base image)
-        >>> env = inherit_ray_job_env_and_add_extra('ado-vllm-performance', 'vllm')
-        >>> # Returns: {"uv": ["numpy", "pandas", "vllm>=0.6.0"]}
+        >>> # If job uv has: ["numpy>=1.20", "ado-vllm-performance[vllm]==1.2.3", "/path/to/custom.whl"]
+        >>> result = parse_job_uv_packages(['numpy', 'ado-vllm-performance', 'custom'])
+        >>> # Returns: {
+        >>> #     "numpy": {"source": "numpy", "version": ">=1.20", "extras": None},
+        >>> #     "ado-vllm-performance": {"source": "ado-vllm-performance", "version": "==1.2.3", "extras": "vllm"},
+        >>> #     "custom": {"source": "/path/to/custom.whl", "version": None, "extras": None}
+        >>> # }
     """
-    # Get the job's runtime environment to inherit its packages
+    # Get the job's runtime environment
     job_runtime_env = ray.get_runtime_context().runtime_env
     job_uv_config = job_runtime_env.get("uv", {}) if job_runtime_env else {}
-
-    # Extract packages from the uv config
-    # Ray normalizes the uv config to a dict with a "packages" key:
-    # {"packages": ["pkg1", "pkg2"], "uv_check": false, "uv_pip_install_options": [...]}
     job_uv_packages = job_uv_config.get("packages", []) if job_uv_config else []
 
-    logger.debug(f"Job runtime environment uv packages: {job_uv_packages}")
+    logger.debug(f"Parsing job uv packages: {job_uv_packages}")
 
-    # Check if base package is in the job environment
-    base_package_in_job = None
-    other_packages = []
+    result = {}
 
-    # Normalize base package name for comparison (handle both - and _)
-    normalized_base = base_package_name.lower().replace("-", "_")
+    # Iterate over requested package names
+    for requested_name in package_names:
+        # Search for this package in the job uv packages
+        for pkg_spec in job_uv_packages:
+            # Quick check: does the requested package name appear in this spec?
+            # Check the name as-is and with all dashes replaced by underscores
+            pkg_spec_lower = pkg_spec.lower()
+            name_with_underscores = requested_name.replace("-", "_").lower()
+            if (
+                requested_name.lower() not in pkg_spec_lower
+                and name_with_underscores not in pkg_spec_lower
+            ):
+                continue  # Not a match, skip to next package
 
-    for pkg in job_uv_packages:
-        # Check if this is the base package
-        pkg_lower = pkg.lower().replace("-", "_")
-        if normalized_base in pkg_lower:
-            # Keep the package exactly as specified (with version and extras if any)
-            base_package_in_job = pkg
-        else:
-            other_packages.append(pkg)
+            # Found a match - now parse using packaging.requirements.Requirement
+            # Check if it's a wheel file path
+            if pkg_spec.endswith(".whl") or "/" in pkg_spec:
+                # It's a wheel file path - can't use Requirement parser
+                source = pkg_spec.split("[")[0] if "[" in pkg_spec else pkg_spec
+                extras = None
+                if "[" in pkg_spec:
+                    extras = pkg_spec.split("[", 1)[1].split("]")[0]
+                version = None
+            else:
+                # It's a PyPI package - use Requirement parser
+                req = Requirement(pkg_spec)
+                source = req.name
+                extras = ",".join(req.extras) if req.extras else None
+                # Convert specifier to string (e.g., "==1.2.3")
+                version = str(req.specifier) if req.specifier else None
 
-    # Try to extract the dependency specification from the base package
-    extra_dependency = _get_dependency_from_package_metadata(base_package_name, extra)
+            result[requested_name] = {
+                "source": source,
+                "version": version,
+                "extras": extras,
+            }
+            break  # Found the package, move to next requested name
 
-    if not extra_dependency:
-        # If we can't find the dependency in metadata, the base package might not be installed
-        # or the extra doesn't exist
-        raise RuntimeError(
-            f"Base package '{base_package_name}' does not define extra '{extra}'. "
-            f"Ensure the package is installed and the extra is defined in its metadata."
-        )
-
-    logger.debug(
-        f"Extracted dependency for extra '{extra}' from {base_package_name}: {extra_dependency}"
-    )
-
-    # Build the final package list based on whether base package is in job uv
-    if base_package_in_job:
-        # Case 1: Base package is in job uv
-        # Reinstall: other packages + base package (exactly as specified) + extra
-        logger.debug(
-            f"Base package '{base_package_name}' found in job uv as '{base_package_in_job}', "
-            f"reinstalling exactly as specified with extra"
-        )
-        final_packages = [
-            *other_packages,
-            base_package_in_job,  # Keep exact specification (version, extras, etc.)
-            extra_dependency,
-        ]
-    else:
-        # Case 2: Base package is in base env only
-        # Just install: existing packages + extra
-        logger.debug(
-            f"Base package '{base_package_name}' not in job uv (assumed in base env), "
-            f"installing only the extra"
-        )
-        final_packages = [*job_uv_packages, extra_dependency]
-
-    logger.debug(f"Final package list: {final_packages}")
-
-    return {"uv": final_packages}
+    logger.debug(f"Parsed package info: {result}")
+    return result
 
 
 def enable_ray_actor_coverage(identifier: str) -> None:

--- a/orchestrator/utilities/environment.py
+++ b/orchestrator/utilities/environment.py
@@ -2,6 +2,146 @@
 # SPDX-License-Identifier: MIT
 import logging
 import os
+from importlib.metadata import requires
+
+import ray
+
+logger = logging.getLogger(__name__)
+
+
+def _get_dependency_from_package_metadata(
+    package_name: str, extra_name: str
+) -> str | None:
+    """
+    Extract dependency specification from installed package metadata.
+
+    Args:
+        package_name: Name of the package to query (e.g., 'ado-vllm-performance')
+        extra_name: Name of the optional dependency group (e.g., 'vllm', 'guidellm')
+
+    Returns:
+        Dependency specification from the package's optional-dependencies, or None if not found
+    """
+    try:
+        # Get the package requirements
+        # The requires() function returns a list of requirement strings
+        # Format: "package>=version; extra == 'extra_name'"
+        package_requires = requires(package_name) or []
+        for req in package_requires:
+            # Parse requirements that match our extra
+            if f'extra == "{extra_name}"' in req or f"extra == '{extra_name}'" in req:
+                # Extract just the package specification (before the semicolon)
+                dep_spec = req.split(";")[0].strip()
+                logger.debug(
+                    f"Extracted dependency for '{extra_name}' from {package_name} metadata: {dep_spec}"
+                )
+                return dep_spec
+    except Exception as e:
+        logger.debug(f"Could not read metadata for package '{package_name}': {e}")
+
+    return None
+
+
+def inherit_ray_job_env_and_add_extra(base_package_name: str, extra: str) -> dict:
+    """
+    Build a Ray runtime environment that inherits packages from the job's runtime
+    environment and adds an extra dependency by extracting its version from the
+    base package's metadata.
+
+    This is useful for actuators that need to add experiment-specific dependencies
+    (e.g., 'vllm', 'guidellm') that are defined as extras in the base package.
+
+    The function handles two cases:
+    1. Base package in job uv: Reinstalls base package + ado-core + extra
+    2. Base package in base env only: Just installs the extra
+
+    Args:
+        base_package_name: Name of the base package that defines the extra
+                          (e.g., 'ado-vllm-performance')
+        extra: Name of the extra package to install (e.g., 'vllm', 'guidellm')
+
+    Returns:
+        Runtime environment dict with uv packages list
+
+    Raises:
+        RuntimeError: If base package is not found in either job uv or base environment
+
+    Example:
+        >>> # If job uv has: ["numpy", "pandas", "ado-vllm-performance==1.2.3"]
+        >>> env = inherit_ray_job_env_and_add_extra('ado-vllm-performance', 'vllm')
+        >>> # Returns: {"uv": ["numpy", "pandas", "ado-vllm-performance==1.2.3", "vllm>=0.6.0"]}
+        >>>
+        >>> # If job uv has: ["numpy", "pandas"] (base package in base image)
+        >>> env = inherit_ray_job_env_and_add_extra('ado-vllm-performance', 'vllm')
+        >>> # Returns: {"uv": ["numpy", "pandas", "vllm>=0.6.0"]}
+    """
+    # Get the job's runtime environment to inherit its packages
+    job_runtime_env = ray.get_runtime_context().runtime_env
+    job_uv_config = job_runtime_env.get("uv", {}) if job_runtime_env else {}
+
+    # Extract packages from the uv config
+    # Ray normalizes the uv config to a dict with a "packages" key:
+    # {"packages": ["pkg1", "pkg2"], "uv_check": false, "uv_pip_install_options": [...]}
+    job_uv_packages = job_uv_config.get("packages", []) if job_uv_config else []
+
+    logger.debug(f"Job runtime environment uv packages: {job_uv_packages}")
+
+    # Check if base package is in the job environment
+    base_package_in_job = None
+    other_packages = []
+
+    # Normalize base package name for comparison (handle both - and _)
+    normalized_base = base_package_name.lower().replace("-", "_")
+
+    for pkg in job_uv_packages:
+        # Check if this is the base package
+        pkg_lower = pkg.lower().replace("-", "_")
+        if normalized_base in pkg_lower:
+            # Keep the package exactly as specified (with version and extras if any)
+            base_package_in_job = pkg
+        else:
+            other_packages.append(pkg)
+
+    # Try to extract the dependency specification from the base package
+    extra_dependency = _get_dependency_from_package_metadata(base_package_name, extra)
+
+    if not extra_dependency:
+        # If we can't find the dependency in metadata, the base package might not be installed
+        # or the extra doesn't exist
+        raise RuntimeError(
+            f"Base package '{base_package_name}' does not define extra '{extra}'. "
+            f"Ensure the package is installed and the extra is defined in its metadata."
+        )
+
+    logger.debug(
+        f"Extracted dependency for extra '{extra}' from {base_package_name}: {extra_dependency}"
+    )
+
+    # Build the final package list based on whether base package is in job uv
+    if base_package_in_job:
+        # Case 1: Base package is in job uv
+        # Reinstall: other packages + base package (exactly as specified) + extra
+        logger.debug(
+            f"Base package '{base_package_name}' found in job uv as '{base_package_in_job}', "
+            f"reinstalling exactly as specified with extra"
+        )
+        final_packages = [
+            *other_packages,
+            base_package_in_job,  # Keep exact specification (version, extras, etc.)
+            extra_dependency,
+        ]
+    else:
+        # Case 2: Base package is in base env only
+        # Just install: existing packages + extra
+        logger.debug(
+            f"Base package '{base_package_name}' not in job uv (assumed in base env), "
+            f"installing only the extra"
+        )
+        final_packages = [*job_uv_packages, extra_dependency]
+
+    logger.debug(f"Final package list: {final_packages}")
+
+    return {"uv": final_packages}
 
 
 def enable_ray_actor_coverage(identifier: str) -> None:

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/actuator.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/actuator.py
@@ -1,9 +1,12 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
+
 import logging
 import uuid
+from importlib.metadata import version
 from pathlib import Path
+from typing import Any
 
 import ray
 import yaml
@@ -31,9 +34,54 @@ from orchestrator.schema.entity import Entity
 from orchestrator.schema.experiment import Experiment, ParameterizedExperiment
 from orchestrator.schema.reference import ExperimentReference
 from orchestrator.schema.request import MeasurementRequest
-from orchestrator.utilities.environment import inherit_ray_job_env_and_add_extra
+from orchestrator.utilities.environment import extract_package_specs_from_job_env
 
 logger = logging.getLogger(__name__)
+
+
+def _build_ray_runtime_env_with_extra(benchmark_tool: str) -> dict[str, list[Any]]:
+
+    # Check if ado-vllm-performance is in the job venv.
+    worker_deps = []
+    specs_from_job_env = extract_package_specs_from_job_env(
+        ["ado-vllm-performance", "ado-core"]
+    )
+
+    if "ado-core" in specs_from_job_env:
+        ado_source = specs_from_job_env["ado-core"]["source"]
+        ado_version: str | None = specs_from_job_env["ado-core"].get("version") or ""
+        extras = specs_from_job_env["ado-core"].get("extras")
+        ado_extras = f"[{extras}]" if extras else ""
+    else:
+        # If ado-core is not in the job env it means that it comes with the base and we assume
+        # it got installed with pypi.
+        # Just to be sure, we extract the version and make sure we get the same installed
+        # in the Ray task environment.
+        # Say the base image runs on an older version of ado-core, we want to avoid it to
+        # be upgraded to a newer version when starting the Ray task.
+        ado_source = "ado-core"
+        ado_version = f"=={version('ado-core')}"
+        ado_extras = ""
+
+    ado_dep = f"{ado_source}{ado_extras}{ado_version}"
+    worker_deps.append(ado_dep)
+
+    # Here we assume the actuator only has 'vllm' or 'guildellm' as extraw dependencies.
+    if "ado-vllm-performance" in specs_from_job_env:
+        actuator_source = specs_from_job_env["ado-vllm-performance"]["source"]
+        actuator_version: str | None = (
+            specs_from_job_env["ado-vllm-performance"].get("version") or ""
+        )
+    else:
+        # Similarly to what we did with ado-core, we also extract the version of the
+        # actuator package.
+        actuator_source = "ado-vllm-performance"
+        actuator_version = f"=={version('ado-vllm-performance')}"
+
+    actuator_dep = f"{actuator_source}[{benchmark_tool}]{actuator_version}"
+    worker_deps.append(actuator_dep)
+
+    return {"uv": worker_deps}
 
 
 # An Actuator must do three things
@@ -208,9 +256,7 @@ class VLLMPerformanceTest(ActuatorBase):
             required_tool = "guidellm" if "guidellm" in experiment_id_lower else "vllm"
 
             # Build runtime environment that inherits job packages and adds experiment tool
-            experiment_ray_env = inherit_ray_job_env_and_add_extra(
-                "ado-vllm-performance", required_tool
-            )
+            experiment_ray_env = _build_ray_runtime_env_with_extra(required_tool)
             ray_options = {"runtime_env": experiment_ray_env}
             logger.debug(
                 f"Experiment ({experiment.identifier}) - Ray task environment: {experiment_ray_env}"

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/actuator.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/actuator.py
@@ -31,75 +31,9 @@ from orchestrator.schema.entity import Entity
 from orchestrator.schema.experiment import Experiment, ParameterizedExperiment
 from orchestrator.schema.reference import ExperimentReference
 from orchestrator.schema.request import MeasurementRequest
+from orchestrator.utilities.environment import inherit_ray_job_env_and_add_extra
 
 logger = logging.getLogger(__name__)
-
-
-def _build_experiment_runtime_env(required_tool: str) -> dict:
-    """
-    Build a runtime environment for an experiment task that inherits packages
-    from the job's runtime environment and adds the experiment-specific tool.
-
-    Args:
-        required_tool: Name of the tool to install (e.g., 'vllm', 'guidellm')
-
-    Returns:
-        Runtime environment dict with uv packages list
-    """
-    # Get the job's runtime environment to inherit its packages
-    job_runtime_env = ray.get_runtime_context().runtime_env
-    job_uv_config = job_runtime_env.get("uv", {}) if job_runtime_env else {}
-
-    # Extract packages from the uv config
-    # Ray normalizes the uv config to a dict with a "packages" key:
-    # {"packages": ["pkg1", "pkg2"], "uv_check": false, "uv_pip_install_options": [...]}
-    job_uv_packages = job_uv_config.get("packages", []) if job_uv_config else []
-
-    logger.debug(f"Job runtime environment uv packages: {job_uv_packages}")
-
-    # Check if ado-vllm-performance is already in the job packages
-    vllm_perf_package = None
-    other_packages = []
-
-    for pkg in job_uv_packages:
-        # Check if this is the ado-vllm-performance package
-        # Handle various formats: "ado-vllm-performance", "ado-vllm-performance==1.0.0",
-        # "/path/to/ado_vllm_performance-1.2.3.whl", etc.
-        pkg_lower = pkg.lower()
-        if "ado-vllm-performance" in pkg_lower or "ado_vllm_performance" in pkg_lower:
-            vllm_perf_package = pkg
-        else:
-            other_packages.append(pkg)
-
-    # Build the final package list
-    if vllm_perf_package:
-        # ado-vllm-performance is in job env - reinstall with the required tool extra
-        # Extract the base package spec and any existing extras
-        if "[" in vllm_perf_package:
-            base_pkg, extras_part = vllm_perf_package.split("[", 1)
-            # Remove the closing bracket and split by comma to get individual extras
-            existing_extras = extras_part.rstrip("]").split(",")
-            # Add the required tool if not already present
-            if required_tool not in existing_extras:
-                existing_extras.append(required_tool)
-            tool_pkg = f"{base_pkg}[{','.join(existing_extras)}]"
-        else:
-            # No existing extras, just add the required tool
-            tool_pkg = f"{vllm_perf_package}[{required_tool}]"
-
-        logger.debug(
-            f"Found ado-vllm-performance in job env: {vllm_perf_package}, "
-            f"reinstalling with [{required_tool}] extra: {tool_pkg}"
-        )
-        final_packages = [*other_packages, tool_pkg]
-    else:
-        # ado-vllm-performance not in job env - install it with the tool extra
-        # The extra will handle installing the correct version of the tool
-        tool_pkg = f"ado-vllm-performance[{required_tool}]"
-        logger.debug(f"ado-vllm-performance not in job env, installing: {tool_pkg}")
-        final_packages = [*job_uv_packages, "ado-core", tool_pkg]
-
-    return {"uv": final_packages}
 
 
 # An Actuator must do three things
@@ -274,7 +208,9 @@ class VLLMPerformanceTest(ActuatorBase):
             required_tool = "guidellm" if "guidellm" in experiment_id_lower else "vllm"
 
             # Build runtime environment that inherits job packages and adds experiment tool
-            experiment_ray_env = _build_experiment_runtime_env(required_tool)
+            experiment_ray_env = inherit_ray_job_env_and_add_extra(
+                "ado-vllm-performance", required_tool
+            )
             ray_options = {"runtime_env": experiment_ray_env}
             logger.debug(
                 f"Experiment ({experiment.identifier}) - Ray task environment: {experiment_ray_env}"

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/actuator.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/actuator.py
@@ -35,6 +35,73 @@ from orchestrator.schema.request import MeasurementRequest
 logger = logging.getLogger(__name__)
 
 
+def _build_experiment_runtime_env(required_tool: str) -> dict:
+    """
+    Build a runtime environment for an experiment task that inherits packages
+    from the job's runtime environment and adds the experiment-specific tool.
+
+    Args:
+        required_tool: Name of the tool to install (e.g., 'vllm', 'guidellm')
+
+    Returns:
+        Runtime environment dict with uv packages list
+    """
+    # Get the job's runtime environment to inherit its packages
+    job_runtime_env = ray.get_runtime_context().runtime_env
+    job_uv_config = job_runtime_env.get("uv", {}) if job_runtime_env else {}
+
+    # Extract packages from the uv config
+    # Ray normalizes the uv config to a dict with a "packages" key:
+    # {"packages": ["pkg1", "pkg2"], "uv_check": false, "uv_pip_install_options": [...]}
+    job_uv_packages = job_uv_config.get("packages", []) if job_uv_config else []
+
+    logger.debug(f"Job runtime environment uv packages: {job_uv_packages}")
+
+    # Check if ado-vllm-performance is already in the job packages
+    vllm_perf_package = None
+    other_packages = []
+
+    for pkg in job_uv_packages:
+        # Check if this is the ado-vllm-performance package
+        # Handle various formats: "ado-vllm-performance", "ado-vllm-performance==1.0.0",
+        # "/path/to/ado_vllm_performance-1.2.3.whl", etc.
+        pkg_lower = pkg.lower()
+        if "ado-vllm-performance" in pkg_lower or "ado_vllm_performance" in pkg_lower:
+            vllm_perf_package = pkg
+        else:
+            other_packages.append(pkg)
+
+    # Build the final package list
+    if vllm_perf_package:
+        # ado-vllm-performance is in job env - reinstall with the required tool extra
+        # Extract the base package spec and any existing extras
+        if "[" in vllm_perf_package:
+            base_pkg, extras_part = vllm_perf_package.split("[", 1)
+            # Remove the closing bracket and split by comma to get individual extras
+            existing_extras = extras_part.rstrip("]").split(",")
+            # Add the required tool if not already present
+            if required_tool not in existing_extras:
+                existing_extras.append(required_tool)
+            tool_pkg = f"{base_pkg}[{','.join(existing_extras)}]"
+        else:
+            # No existing extras, just add the required tool
+            tool_pkg = f"{vllm_perf_package}[{required_tool}]"
+
+        logger.debug(
+            f"Found ado-vllm-performance in job env: {vllm_perf_package}, "
+            f"reinstalling with [{required_tool}] extra: {tool_pkg}"
+        )
+        final_packages = [*other_packages, tool_pkg]
+    else:
+        # ado-vllm-performance not in job env - install it with the tool extra
+        # The extra will handle installing the correct version of the tool
+        tool_pkg = f"ado-vllm-performance[{required_tool}]"
+        logger.debug(f"ado-vllm-performance not in job env, installing: {tool_pkg}")
+        final_packages = [*job_uv_packages, "ado-core", tool_pkg]
+
+    return {"uv": final_packages}
+
+
 # An Actuator must do three things
 # 1. Provide a catalog of Experiments it can execute - the catalog method
 # 2. Provide a way to run those experiments asynchronously - the submit method
@@ -205,7 +272,9 @@ class VLLMPerformanceTest(ActuatorBase):
         else:
             experiment_id_lower = experiment.identifier.lower()
             required_tool = "guidellm" if "guidellm" in experiment_id_lower else "vllm"
-            experiment_ray_env = {"uv": [f"ado-vllm-performance[{required_tool}]"]}
+
+            # Build runtime environment that inherits job packages and adds experiment tool
+            experiment_ray_env = _build_experiment_runtime_env(required_tool)
             ray_options = {"runtime_env": experiment_ray_env}
             logger.debug(
                 f"Experiment ({experiment.identifier}) - Ray task environment: {experiment_ray_env}"


### PR DESCRIPTION
## High-Level Summary

This PR improves the Ray runtime environment handling for the vLLM Performance actuator by implementing intelligent package inheritance for experiment tasks.

**Key Changes:**

- **Added `_build_experiment_runtime_env()` function**: Constructs experiment-specific runtime environments that inherit packages from the parent job's environment while adding required experiment tools (vllm or guidellm)

- **Smart package management**: Detects if `ado-vllm-performance` is already installed in the job environment and intelligently merges extras (e.g., `[vllm]`, `[guidellm]`) rather than creating conflicting installations

- **Improved isolation**: Ensures experiment tasks have access to both the base job dependencies and their specific tool requirements without package conflicts

This change addresses runtime environment isolation issues when running vLLM performance experiments on Ray clusters, ensuring experiments can access both shared dependencies and their specialized tools.