### PR TITLE
build(hooks): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: detect-secrets # pragma: whitelist secret
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.14
     hooks:
       - id: ruff
         args:
@@ -17,7 +17,7 @@ repos:
           - website,plugins/actuators/vllm_performance/ado_actuators/vllm_performance/vllm_performance_test
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black-jupyter
   - repo: https://github.com/compilerla/conventional-pre-commit
@@ -35,7 +35,7 @@ repos:
         additional_dependencies: ['tomli']
         args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.13
+    rev: 0.11.16
     hooks:
       - id: uv-lock
       - id: uv-export
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.11.1
+    rev: v1.0.0
     hooks:
       - id: tombi-format
         args: ["--offline"]


### PR DESCRIPTION
## Updated pre-commit hooks

| Hook | From | To |
|---|---|---|
| [ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) | 0.15.12 | 0.15.14 |
| [black-pre-commit-mirror](https://github.com/psf/black-pre-commit-mirror) | 26.3.1 | 26.5.1 |
| [uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) | 0.11.13 | 0.11.16 |
| [tombi-pre-commit](https://github.com/tombi-toml/tombi-pre-commit) | 0.11.1 | 1.0.0 |