### PR TITLE
build(ray-tune): remove python version-specific dep requirements

### DIFF
--- a/plugins/custom_experiments/autoconf/pyproject.toml
+++ b/plugins/custom_experiments/autoconf/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "ado-autoconf"
 description = "An AutoConf plugin that suggests the minimum number of gpus necessary to execute a Tuning job"
-requires-python = ">=3.10,<3.14"
 dependencies = [
   "ado-core>=1.2.3",
   "autogluon.tabular[catboost,xgboost]==1.5.0",

--- a/plugins/custom_experiments/autoconf/pyproject.toml
+++ b/plugins/custom_experiments/autoconf/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "ado-autoconf"
 description = "An AutoConf plugin that suggests the minimum number of gpus necessary to execute a Tuning job"
+requires-python = ">=3.10,<3.14"
 dependencies = [
   "ado-core>=1.2.3",
   "autogluon.tabular[catboost,xgboost]==1.5.0",

--- a/plugins/operators/ray_tune/pyproject.toml
+++ b/plugins/operators/ray_tune/pyproject.toml
@@ -3,21 +3,21 @@ name = "ado-ray-tune"
 dependencies = [
   "bayesian-optimization>=1.4.0",
   "nevergrad>=1.0.12",
-  "numba>=0.57.0; python_version > '3.10'",
-  "numba>=0.59.0; python_version > '3.11'",
-  "numba>=0.61.0; python_version > '3.12'",
   # A minimum numba version is required to
   # support certain Python versions.
   # ref: https://github.com/numba/numba/releases
-  "numba>=0.63.0; python_version > '3.13'",
+  #  "numba>=0.57.0; python_version > '3.10'",
+  #  "numba>=0.59.0; python_version > '3.11'",
+  #  "numba>=0.61.0; python_version > '3.12'",
+  #  "numba>=0.63.0; python_version > '3.13'",
   # Scipy's first full release that supports Python 3.14
   # (1.17.0) requires numpy>=1.26.4
   # ref: https://github.com/scipy/scipy/releases/tag/v1.17.0
-  "numpy>=1.26.4 ; python_full_version >= '3.14'",
+  #  "numpy>=1.26.4 ; python_full_version >= '3.14'",
   "paretoset>=1.2.4",
   "ray[tune]>=2.9",
   "scipy>=1.15.3",
-  "scipy>=1.17.0 ; python_full_version >= '3.14'",
+  # "scipy>=1.17.0 ; python_full_version >= '3.14'",
 ]
 dynamic = ["version"]
 

--- a/plugins/operators/ray_tune/pyproject.toml
+++ b/plugins/operators/ray_tune/pyproject.toml
@@ -6,14 +6,6 @@ dependencies = [
   "paretoset>=1.2.4",
   "ray[tune]>=2.9",
   "scipy>=1.15.3",
-  # Commenting out requirements for 3.14 due to uv resolution
-  # incompatibilities with autoconf and trim
-  # Scipy's first full release that supports Python 3.14
-  # (1.17.0) requires numpy>=1.26.4
-  # ref: https://github.com/scipy/scipy/releases/tag/v1.17.0
-  # "numba>=0.63.0 ; python_full_version >= '3.14'",
-  # "numpy>=1.26.4 ; python_full_version >= '3.14'",
-  # "scipy>=1.17.0 ; python_full_version >= '3.14'",
 ]
 dynamic = ["version"]
 

--- a/plugins/operators/ray_tune/pyproject.toml
+++ b/plugins/operators/ray_tune/pyproject.toml
@@ -3,20 +3,16 @@ name = "ado-ray-tune"
 dependencies = [
   "bayesian-optimization>=1.4.0",
   "nevergrad>=1.0.12",
-  # A minimum numba version is required to
-  # support certain Python versions.
-  # ref: https://github.com/numba/numba/releases
-  #  "numba>=0.57.0; python_version > '3.10'",
-  #  "numba>=0.59.0; python_version > '3.11'",
-  #  "numba>=0.61.0; python_version > '3.12'",
-  #  "numba>=0.63.0; python_version > '3.13'",
-  # Scipy's first full release that supports Python 3.14
-  # (1.17.0) requires numpy>=1.26.4
-  # ref: https://github.com/scipy/scipy/releases/tag/v1.17.0
-  #  "numpy>=1.26.4 ; python_full_version >= '3.14'",
   "paretoset>=1.2.4",
   "ray[tune]>=2.9",
   "scipy>=1.15.3",
+  # Commenting out requirements for 3.14 due to uv resolution
+  # incompatibilities with autoconf and trim
+  # Scipy's first full release that supports Python 3.14
+  # (1.17.0) requires numpy>=1.26.4
+  # ref: https://github.com/scipy/scipy/releases/tag/v1.17.0
+  # "numba>=0.63.0 ; python_full_version >= '3.14'",
+  # "numpy>=1.26.4 ; python_full_version >= '3.14'",
   # "scipy>=1.17.0 ; python_full_version >= '3.14'",
 ]
 dynamic = ["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -193,10 +193,6 @@ source = { editable = "plugins/operators/ray_tune" }
 dependencies = [
     { name = "bayesian-optimization" },
     { name = "nevergrad" },
-    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin'" },
-    { name = "numba", version = "0.62.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin'" },
-    { name = "numba", version = "0.65.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "numpy", marker = "python_full_version >= '3.14'" },
     { name = "paretoset" },
     { name = "ray", extra = ["tune"] },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -207,15 +203,9 @@ dependencies = [
 requires-dist = [
     { name = "bayesian-optimization", specifier = ">=1.4.0" },
     { name = "nevergrad", specifier = ">=1.0.12" },
-    { name = "numba", marker = "python_full_version >= '3.11'", specifier = ">=0.57.0" },
-    { name = "numba", marker = "python_full_version >= '3.12'", specifier = ">=0.59.0" },
-    { name = "numba", marker = "python_full_version >= '3.13'", specifier = ">=0.61.0" },
-    { name = "numba", marker = "python_full_version >= '3.14'", specifier = ">=0.63.0" },
-    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=1.26.4" },
     { name = "paretoset", specifier = ">=1.2.4" },
     { name = "ray", extras = ["tune"], specifier = ">=2.9" },
     { name = "scipy", specifier = ">=1.15.3" },
-    { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.17.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Earlier we had specific version requirements for `numba` and other packages to make sure certain Python versions weren't installing unsupported versions. This was added because we saw this happening multiple times in the CI.

Manual checks, though, show that this isn't happening anymore. Even specifiers that were added recently (e.g., for SciPy) aren't needed. This has been verified on a clean virtual environment with both `uv pip` and `pip`:

```terminaloutput
(.venv) alessandropomponio@MacBook-Pro-di-Alessandro ~/w/t/ado-3.14> uv pip install /Users/alessandropomponio/Documents/GitHub/public/ado/plugins/operators/ray_tune
Resolved 42 packages in 1.98s
      Built ado-ray-tune @ file:///Users/alessandropomponio/Documents/GitHub/public/ado/plugins/operators/ray_tune
Prepared 5 packages in 1.62s
Installed 42 packages in 412ms
 + ado-ray-tune==1.8.1.dev39+g56cf73b88 (from file:///Users/alessandropomponio/Documents/GitHub/public/ado/plugins/operators/ray_tune)
 + annotated-types==0.7.0
 + attrs==26.1.0
 + bayesian-optimization==1.4.0
 + certifi==2026.5.20
 + charset-normalizer==3.4.7
 + click==8.4.1
 + cma==4.4.4
 + directsearch==1.0.1
 + filelock==3.29.0
 + fsspec==2026.4.0
 + idna==3.17
 + joblib==1.5.3
 + jsonschema==4.26.0
 + jsonschema-specifications==2025.9.1
 + llvmlite==0.47.0
 + msgpack==1.1.2
 + nevergrad==1.0.12
 + numba==0.65.1
 + numpy==2.4.6
 + packaging==26.2
 + pandas==3.0.3
 + paretoset==1.2.5
 + protobuf==7.35.0
 + pyarrow==24.0.0
 + pydantic==2.13.4
 + pydantic-core==2.46.4
 + python-dateutil==2.9.0.post0
 + pyyaml==6.0.3
 + ray==2.55.1
 + referencing==0.37.0
 + requests==2.34.2
 + rpds-py==2026.5.1
 + scikit-learn==1.8.0
 + scipy==1.17.1
 + setuptools==82.0.1
 + six==1.17.0
 + tensorboardx==2.6.5
 + threadpoolctl==3.6.0
 + typing-extensions==4.15.0
 + typing-inspection==0.4.2
 + urllib3==2.7.0
```

```terminaloutput
(.venv) alessandropomponio@MacBook-Pro-di-Alessandro ~/w/t/ado-3.14> pip install /Users/alessandropomponio/Documents/GitHub/public/ado/plugins/operators/ray_tune
[...]
Installing collected packages: urllib3, typing-extensions, threadpoolctl, six, setuptools, rpds-py, pyyaml, pyarrow, protobuf, packaging, numpy, msgpack, llvmlite, joblib, idna, fsspec, filelock, click, charset_normalizer, certifi, attrs, annotated-types, typing-inspection, tensorboardX, scipy, requests, referencing, python-dateutil, pydantic-core, numba, cma, scikit-learn, pydantic, pandas, jsonschema-specifications, directsearch, paretoset, jsonschema, bayesian-optimization, ray, nevergrad, ado-ray-tune
Successfully installed ado-ray-tune-1.8.1.dev39+g56cf73b88 annotated-types-0.7.0 attrs-26.1.0 bayesian-optimization-1.4.0 certifi-2026.5.20 charset_normalizer-3.4.7 click-8.4.1 cma-4.4.4 directsearch-1.0.1 filelock-3.29.0 fsspec-2026.4.0 idna-3.17 joblib-1.5.3 jsonschema-4.26.0 jsonschema-specifications-2025.9.1 llvmlite-0.47.0 msgpack-1.1.2 nevergrad-1.0.12 numba-0.65.1 numpy-2.4.6 packaging-26.2 pandas-3.0.3 paretoset-1.2.5 protobuf-7.35.0 pyarrow-24.0.0 pydantic-2.13.4 pydantic-core-2.46.4 python-dateutil-2.9.0.post0 pyyaml-6.0.3 ray-2.55.1 referencing-0.37.0 requests-2.34.2 rpds-py-2026.5.1 scikit-learn-1.8.0 scipy-1.17.1 setuptools-82.0.1 six-1.17.0 tensorboardX-2.6.5 threadpoolctl-3.6.0 typing-extensions-4.15.0 typing-inspection-0.4.2 urllib3-2.7.0
```