### PR TITLE
build: ensure uv forks in dependency resolution

### DIFF
--- a/plugins/custom_experiments/autoconf/pyproject.toml
+++ b/plugins/custom_experiments/autoconf/pyproject.toml
@@ -4,7 +4,7 @@ description = "An AutoConf plugin that suggests the minimum number of gpus neces
 requires-python = ">=3.10,<3.14"
 dependencies = [
   "ado-core>=1.2.3",
-  "autogluon.tabular[catboost,xgboost]==1.5.0",
+  "autogluon-tabular[catboost,xgboost]==1.5.0 ; python_full_version < '3.14'",
   "pandas<3.0.0",
   "pydantic",
   "torch",

--- a/plugins/operators/profile_space/pyproject.toml
+++ b/plugins/operators/profile_space/pyproject.toml
@@ -4,7 +4,14 @@ requires-python = ">=3.10,<3.14"
 # fg-data-profiling's latest release (4.19.1)
 # requires numba<0.63 which is incompatible with
 # Python 3.14
-dependencies = ["fg-data-profiling"]
+dependencies = [
+  # AP 02/06/2026:
+  # We help uv perform a forked resolution by adding
+  # a version marker to this dependency. Since this
+  # package is marked as only supporting up to
+  # Python 3.13, this information is redundant.
+  "fg-data-profiling>=4.19.1 ; python_full_version < '3.14'",
+]
 dynamic = ["version"]
 
 [project.entry-points."ado.operators"]

--- a/plugins/operators/ray_tune/pyproject.toml
+++ b/plugins/operators/ray_tune/pyproject.toml
@@ -3,9 +3,17 @@ name = "ado-ray-tune"
 dependencies = [
   "bayesian-optimization>=1.4.0",
   "nevergrad>=1.0.12",
+  # Numba added support for Python 3.14 only in
+  # version 0.63.0. By adding this requirement explicitly
+  # we help uv perform a forked resolution for the lockfile.
+  "numba>=0.63.0 ; python_full_version >= '3.14'",
   "paretoset>=1.2.4",
   "ray[tune]>=2.9",
   "scipy>=1.15.3",
+  # Scipy's first full release that supports Python 3.14
+  # (1.17.0) requires numpy>=1.26.4
+  # ref: https://github.com/scipy/scipy/releases/tag/v1.17.0
+  "scipy>=1.17.0 ; python_full_version >= '3.14'",
 ]
 dynamic = ["version"]
 

--- a/plugins/operators/trim/pyproject.toml
+++ b/plugins/operators/trim/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
   "ado-core",
-  "autogluon-tabular[catboost,xgboost]==1.5",
+  "autogluon-tabular[catboost,xgboost]==1.5.0 ; python_full_version < '3.14'",
   "numpy",
   "pandas>=2.2.0",
   "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,26 +82,18 @@ docs = [
   "pygments>=2.19.1",
   "pymdown-extensions>=10.15",
 ]
-resolution-helpers = [
-  "urllib3>=2.5.0",
-]
-# AP 2025-12-05:
-# ado-sfttrainer is currently incompatible with Python 3.13
-#   due to a dependency on aim/aimrocks
-# ado-vllm-performance is currently incompatible with macOS
-#   due to a new requirement in vllm>=0.11.1 which brings in
-#   cuda dependencies.
+
 test = [
-  "ado-autoconf; python_version < '3.14'",
+  "ado-autoconf ; python_full_version < '3.14'",
   "ado-ray-tune",
-  "ado-sfttrainer; python_version < '3.13'",
-  "ado-trim; python_version < '3.14'",
+  "ado-sfttrainer ; python_full_version < '3.13'",
+  "ado-trim ; python_full_version < '3.14'",
   "ado-vllm-performance",
   "anomalous-series",
   "density-test",
   "optimization-test-functions",
   "pfas-custom-functions",
-  "profile-space; python_version < '3.14'",
+  "profile-space ; python_full_version < '3.14'",
   "robotic-lab",
   "trim-custom-experiments",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ado-core", specifier = ">=1.2.3" },
-    { name = "autogluon-tabular", extras = ["catboost", "xgboost"], specifier = "==1.5.0" },
+    { name = "autogluon-tabular", extras = ["catboost", "xgboost"], marker = "python_full_version < '3.14'", specifier = "==1.5.0" },
     { name = "autogluon-tabular", extras = ["lightgbm"], marker = "extra == 'libomp'" },
     { name = "pandas", specifier = "<3.0.0" },
     { name = "pydantic" },
@@ -105,9 +105,6 @@ docs = [
     { name = "mkdocs-minify-plugin" },
     { name = "pygments" },
     { name = "pymdown-extensions" },
-]
-resolution-helpers = [
-    { name = "urllib3" },
 ]
 test = [
     { name = "ado-autoconf", marker = "python_full_version < '3.14'" },
@@ -171,7 +168,6 @@ docs = [
     { name = "pygments", specifier = ">=2.19.1" },
     { name = "pymdown-extensions", specifier = ">=10.15" },
 ]
-resolution-helpers = [{ name = "urllib3", specifier = ">=2.5.0" }]
 test = [
     { name = "ado-autoconf", marker = "python_full_version < '3.14'", editable = "plugins/custom_experiments/autoconf" },
     { name = "ado-ray-tune", editable = "plugins/operators/ray_tune" },
@@ -193,6 +189,7 @@ source = { editable = "plugins/operators/ray_tune" }
 dependencies = [
     { name = "bayesian-optimization" },
     { name = "nevergrad" },
+    { name = "numba", version = "0.65.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "paretoset" },
     { name = "ray", extra = ["tune"] },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -203,9 +200,11 @@ dependencies = [
 requires-dist = [
     { name = "bayesian-optimization", specifier = ">=1.4.0" },
     { name = "nevergrad", specifier = ">=1.0.12" },
+    { name = "numba", marker = "python_full_version >= '3.14'", specifier = ">=0.63.0" },
     { name = "paretoset", specifier = ">=1.2.4" },
     { name = "ray", extras = ["tune"], specifier = ">=2.9" },
     { name = "scipy", specifier = ">=1.15.3" },
+    { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.17.0" },
 ]
 
 [[package]]
@@ -240,7 +239,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ado-core" },
-    { name = "autogluon-tabular", extras = ["catboost", "xgboost"], specifier = "==1.5" },
+    { name = "autogluon-tabular", extras = ["catboost", "xgboost"], marker = "python_full_version < '3.14'", specifier = "==1.5.0" },
     { name = "numpy" },
     { name = "pandas", specifier = ">=2.2.0" },
     { name = "scikit-learn" },
@@ -5655,7 +5654,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fg-data-profiling" }]
+requires-dist = [{ name = "fg-data-profiling", marker = "python_full_version < '3.14'", specifier = ">=4.19.1" }]
 
 [[package]]
 name = "prometheus-client"


### PR DESCRIPTION
## Context

I was under the (wrong) impression that uv didn't support python version-specific resolution. The docs show that instead it's possible: https://docs.astral.sh/uv/reference/internals/resolver/#forking

We just need to make sure we include the python version markers even in places where they may not be quite as intuitive.

I confirmed this works by running `uv lock -U --dry-run`, which produced split results:
```
Update numba v0.61.2, v0.62.1, v0.65.0 -> v0.61.2, v0.65.0
```

Additionally, running `tox -re py314-locked-macos` works, with the correct version of the packages being installed.

