### PR TITLE
feat(core): record distribution package provenance on resource creation

### DIFF
--- a/orchestrator/cli/resources/actuator_configuration/create.py
+++ b/orchestrator/cli/resources/actuator_configuration/create.py
@@ -46,16 +46,22 @@ def create_actuator_configuration(parameters: AdoCreateCommandParameters) -> str
         console_print(ADO_CREATE_DRY_RUN_CONFIG_VALID, stderr=True)
         return None
 
+    from orchestrator.core.actuatorconfiguration.resource import (
+        ActuatorConfigurationProvenanceInfo,
+    )
     from orchestrator.modules.actuators.registry import ActuatorRegistry
 
     registry = ActuatorRegistry.globalRegistry()
     actuator_provenance = registry.provenance_for_actuator(
         actuatorconfig_configuration.actuatorIdentifier
     )
+    actuators = {}
+    if actuator_provenance is not None:
+        actuators[actuatorconfig_configuration.actuatorIdentifier] = actuator_provenance
 
     resource_to_be_created = ActuatorConfigurationResource(
         config=actuatorconfig_configuration,
-        actuatorProvenance=actuator_provenance,
+        provenance=ActuatorConfigurationProvenanceInfo(actuators=actuators),
     )
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)

--- a/orchestrator/cli/resources/actuator_configuration/create.py
+++ b/orchestrator/cli/resources/actuator_configuration/create.py
@@ -46,8 +46,16 @@ def create_actuator_configuration(parameters: AdoCreateCommandParameters) -> str
         console_print(ADO_CREATE_DRY_RUN_CONFIG_VALID, stderr=True)
         return None
 
+    from orchestrator.modules.actuators.registry import ActuatorRegistry
+
+    registry = ActuatorRegistry.globalRegistry()
+    actuator_provenance = registry.provenance_for_actuator(
+        actuatorconfig_configuration.actuatorIdentifier
+    )
+
     resource_to_be_created = ActuatorConfigurationResource(
-        config=actuatorconfig_configuration
+        config=actuatorconfig_configuration,
+        actuatorProvenance=actuator_provenance,
     )
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)

--- a/orchestrator/core/actuatorconfiguration/resource.py
+++ b/orchestrator/core/actuatorconfiguration/resource.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 import pydantic
 
 from orchestrator.core.actuatorconfiguration.config import ActuatorConfiguration
+from orchestrator.core.metadata import PackageProvenance
 from orchestrator.core.resources import ADOResource, CoreResourceKinds
 from orchestrator.utilities.pydantic import Defaultable
 
@@ -24,5 +25,17 @@ class ActuatorConfigurationResource(ADOResource):
         Defaultable[str],
         pydantic.Field(
             default_factory=_identifier_from_data,
+        ),
+    ]
+    actuatorProvenance: Annotated[
+        PackageProvenance | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Python distribution that provided the actuator at the time this "
+                "configuration was created. None for resources created before "
+                "provenance tracking was introduced, or when the distribution could "
+                "not be resolved."
+            ),
         ),
     ]

--- a/orchestrator/core/actuatorconfiguration/resource.py
+++ b/orchestrator/core/actuatorconfiguration/resource.py
@@ -7,9 +7,24 @@ from typing import Annotated, Any
 import pydantic
 
 from orchestrator.core.actuatorconfiguration.config import ActuatorConfiguration
-from orchestrator.core.metadata import PackageProvenance
+from orchestrator.core.metadata import PackageProvenance, ProvenanceInfo
 from orchestrator.core.resources import ADOResource, CoreResourceKinds
 from orchestrator.utilities.pydantic import Defaultable
+
+
+class ActuatorConfigurationProvenanceInfo(ProvenanceInfo):
+    """Plugin provenance for an actuator configuration resource."""
+
+    actuators: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of actuator identifier to the Python distribution that "
+                "provided it at the time this configuration was created."
+            ),
+        ),
+    ]
 
 
 class ActuatorConfigurationResource(ADOResource):
@@ -27,15 +42,10 @@ class ActuatorConfigurationResource(ADOResource):
             default_factory=_identifier_from_data,
         ),
     ]
-    actuatorProvenance: Annotated[
-        PackageProvenance | None,
+    provenance: Annotated[
+        ActuatorConfigurationProvenanceInfo,
         pydantic.Field(
-            default=None,
-            description=(
-                "Python distribution that provided the actuator at the time this "
-                "configuration was created. None for resources created before "
-                "provenance tracking was introduced, or when the distribution could "
-                "not be resolved."
-            ),
+            default_factory=ActuatorConfigurationProvenanceInfo,
+            description="Plugin package provenance frozen at resource creation time.",
         ),
     ]

--- a/orchestrator/core/discoveryspace/resource.py
+++ b/orchestrator/core/discoveryspace/resource.py
@@ -8,13 +8,38 @@ import pydantic
 import rich.box
 
 from orchestrator.core.discoveryspace.config import DiscoverySpaceConfiguration
-from orchestrator.core.metadata import PackageProvenance
+from orchestrator.core.metadata import PackageProvenance, ProvenanceInfo
 from orchestrator.core.resources import ADOResource, CoreResourceKinds
 from orchestrator.schema.measurementspace import MeasurementSpaceConfiguration
 from orchestrator.utilities.pydantic import Defaultable
 
 if typing.TYPE_CHECKING:
     from rich.console import RenderableType
+
+
+class DiscoverySpaceProvenanceInfo(ProvenanceInfo):
+    """Plugin provenance for a discovery space resource."""
+
+    actuators: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of actuator identifier to the Python distribution that "
+                "provided it at the time this space was created."
+            ),
+        ),
+    ]
+    customExperiments: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of custom experiment identifier to the Python distribution "
+                "that provided it at the time this space was created."
+            ),
+        ),
+    ]
 
 
 class DiscoverySpaceResource(ADOResource):
@@ -29,30 +54,11 @@ class DiscoverySpaceResource(ADOResource):
             default_factory=lambda: f"space-{str(uuid.uuid4())[:8]}",
         ),
     ]
-
-    actuatorProvenance: Annotated[
-        dict[str, PackageProvenance],
+    provenance: Annotated[
+        DiscoverySpaceProvenanceInfo,
         pydantic.Field(
-            default_factory=dict,
-            description=(
-                "Mapping of actuator identifier to the Python distribution that "
-                "provided it at the time this space was created. Populated automatically "
-                "from the installed environment; empty for resources created before "
-                "provenance tracking was introduced."
-            ),
-        ),
-    ]
-
-    customExperimentProvenance: Annotated[
-        dict[str, PackageProvenance],
-        pydantic.Field(
-            default_factory=dict,
-            description=(
-                "Mapping of custom experiment identifier to the Python distribution "
-                "that provided it at the time this space was created. Only populated "
-                "for experiments registered via the ``ado.custom_experiments`` entry "
-                "point whose source module can be resolved to a distribution."
-            ),
+            default_factory=DiscoverySpaceProvenanceInfo,
+            description="Plugin package provenance frozen at resource creation time.",
         ),
     ]
 

--- a/orchestrator/core/discoveryspace/resource.py
+++ b/orchestrator/core/discoveryspace/resource.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 import typing
 import uuid
+from typing import Annotated
 
 import pydantic
 import rich.box
 
 from orchestrator.core.discoveryspace.config import DiscoverySpaceConfiguration
+from orchestrator.core.metadata import PackageProvenance
 from orchestrator.core.resources import ADOResource, CoreResourceKinds
 from orchestrator.schema.measurementspace import MeasurementSpaceConfiguration
 from orchestrator.utilities.pydantic import Defaultable
@@ -21,10 +23,36 @@ class DiscoverySpaceResource(ADOResource):
     kind: CoreResourceKinds = CoreResourceKinds.DISCOVERYSPACE
     config: DiscoverySpaceConfiguration
 
-    identifier: typing.Annotated[
+    identifier: Annotated[
         Defaultable[str],
         pydantic.Field(
             default_factory=lambda: f"space-{str(uuid.uuid4())[:8]}",
+        ),
+    ]
+
+    actuatorProvenance: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of actuator identifier to the Python distribution that "
+                "provided it at the time this space was created. Populated automatically "
+                "from the installed environment; empty for resources created before "
+                "provenance tracking was introduced."
+            ),
+        ),
+    ]
+
+    customExperimentProvenance: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of custom experiment identifier to the Python distribution "
+                "that provided it at the time this space was created. Only populated "
+                "for experiments registered via the ``ado.custom_experiments`` entry "
+                "point whose source module can be resolved to a distribution."
+            ),
         ),
     ]
 

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -534,36 +534,32 @@ class DiscoverySpace:
 
     def _build_provenance(
         self,
-    ) -> tuple[
-        dict[str, "orchestrator.core.metadata.PackageProvenance"],
-        dict[str, "orchestrator.core.metadata.PackageProvenance"],
-    ]:
+    ) -> "orchestrator.core.discoveryspace.resource.DiscoverySpaceProvenanceInfo":
         """Resolve package provenance for all actuators and custom experiments.
 
         Returns:
-            A tuple of (actuatorProvenance, customExperimentProvenance) where:
-            - *actuatorProvenance* maps each unique actuator identifier used in the
-              measurement space to the distribution that provides it.
-            - *customExperimentProvenance* maps each custom experiment identifier
-              (from the ``custom_experiments`` actuator) to the distribution that
-              provides the experiment function.
+            DiscoverySpaceProvenanceInfo mapping actuators and custom experiments
+            to the distributions that provided them at space creation time.
         """
+        from orchestrator.core.discoveryspace.resource import (
+            DiscoverySpaceProvenanceInfo,
+        )
         from orchestrator.core.metadata import PackageProvenance
         from orchestrator.modules.actuators.registry import ActuatorRegistry
         from orchestrator.utilities.distribution import distribution_from_module
 
         registry = ActuatorRegistry.globalRegistry()
-        actuator_provenance: dict[str, PackageProvenance] = {}
-        custom_experiment_provenance: dict[str, PackageProvenance] = {}
+        actuators: dict[str, PackageProvenance] = {}
+        custom_experiments: dict[str, PackageProvenance] = {}
 
         for experiment in self.measurementSpace.experiments:
             actuator_id = experiment.actuatorIdentifier
 
             # Per-actuator provenance (deduplicated)
-            if actuator_id not in actuator_provenance:
+            if actuator_id not in actuators:
                 provenance = registry.provenance_for_actuator(actuator_id)
                 if provenance is not None:
-                    actuator_provenance[actuator_id] = provenance
+                    actuators[actuator_id] = provenance
 
             # Per-custom-experiment provenance
             if actuator_id == "custom_experiments":
@@ -583,28 +579,29 @@ class DiscoverySpace:
                                 dist = importlib.metadata.distribution(dist_name)
                                 version = dist.metadata.get("Version")
                                 if version is not None:
-                                    custom_experiment_provenance[
-                                        experiment.identifier
-                                    ] = PackageProvenance(
-                                        distributionName=dist_name,
-                                        distributionVersion=version,
+                                    custom_experiments[experiment.identifier] = (
+                                        PackageProvenance(
+                                            distributionName=dist_name,
+                                            distributionVersion=version,
+                                        )
                                     )
                         except Exception:  # noqa: S110
                             pass
 
-        return actuator_provenance, custom_experiment_provenance
+        return DiscoverySpaceProvenanceInfo(
+            actuators=actuators,
+            customExperiments=custom_experiments,
+        )
 
     @property
     def resource(
         self,
     ) -> orchestrator.core.discoveryspace.resource.DiscoverySpaceResource:
 
-        actuator_provenance, custom_experiment_provenance = self._build_provenance()
         return orchestrator.core.discoveryspace.resource.DiscoverySpaceResource(
             identifier=self._identifier,
             config=self.config,
-            actuatorProvenance=actuator_provenance,
-            customExperimentProvenance=custom_experiment_provenance,
+            provenance=self._build_provenance(),
         )
 
     def saveSpace(self) -> None:

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -546,7 +546,6 @@ class DiscoverySpace:
         )
         from orchestrator.core.metadata import PackageProvenance
         from orchestrator.modules.actuators.registry import ActuatorRegistry
-        from orchestrator.utilities.distribution import distribution_from_module
 
         registry = ActuatorRegistry.globalRegistry()
         actuators: dict[str, PackageProvenance] = {}
@@ -565,28 +564,9 @@ class DiscoverySpace:
             if actuator_id == "custom_experiments":
                 module_conf = experiment.metadata.get("module")
                 if module_conf is not None:
-                    import importlib.metadata
-
-                    module_name = (
-                        module_conf.get("moduleName")
-                        if isinstance(module_conf, dict)
-                        else getattr(module_conf, "moduleName", None)
-                    )
-                    if module_name is not None:
-                        try:
-                            dist_name = distribution_from_module(module_name)
-                            if dist_name is not None:
-                                dist = importlib.metadata.distribution(dist_name)
-                                version = dist.metadata.get("Version")
-                                if version is not None:
-                                    custom_experiments[experiment.identifier] = (
-                                        PackageProvenance(
-                                            distributionName=dist_name,
-                                            distributionVersion=version,
-                                        )
-                                    )
-                        except Exception:  # noqa: S110
-                            pass
+                    provenance = PackageProvenance.from_module_conf(module_conf)
+                    if provenance is not None:
+                        custom_experiments[experiment.identifier] = provenance
 
         return DiscoverySpaceProvenanceInfo(
             actuators=actuators,

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -532,13 +532,79 @@ class DiscoverySpace:
             metadata=metadata,
         )
 
+    def _build_provenance(
+        self,
+    ) -> tuple[
+        dict[str, "orchestrator.core.metadata.PackageProvenance"],
+        dict[str, "orchestrator.core.metadata.PackageProvenance"],
+    ]:
+        """Resolve package provenance for all actuators and custom experiments.
+
+        Returns:
+            A tuple of (actuatorProvenance, customExperimentProvenance) where:
+            - *actuatorProvenance* maps each unique actuator identifier used in the
+              measurement space to the distribution that provides it.
+            - *customExperimentProvenance* maps each custom experiment identifier
+              (from the ``custom_experiments`` actuator) to the distribution that
+              provides the experiment function.
+        """
+        from orchestrator.core.metadata import PackageProvenance
+        from orchestrator.modules.actuators.registry import ActuatorRegistry
+        from orchestrator.utilities.distribution import distribution_from_module
+
+        registry = ActuatorRegistry.globalRegistry()
+        actuator_provenance: dict[str, PackageProvenance] = {}
+        custom_experiment_provenance: dict[str, PackageProvenance] = {}
+
+        for experiment in self.measurementSpace.experiments:
+            actuator_id = experiment.actuatorIdentifier
+
+            # Per-actuator provenance (deduplicated)
+            if actuator_id not in actuator_provenance:
+                provenance = registry.provenance_for_actuator(actuator_id)
+                if provenance is not None:
+                    actuator_provenance[actuator_id] = provenance
+
+            # Per-custom-experiment provenance
+            if actuator_id == "custom_experiments":
+                module_conf = experiment.metadata.get("module")
+                if module_conf is not None:
+                    import importlib.metadata
+
+                    module_name = (
+                        module_conf.get("moduleName")
+                        if isinstance(module_conf, dict)
+                        else getattr(module_conf, "moduleName", None)
+                    )
+                    if module_name is not None:
+                        try:
+                            dist_name = distribution_from_module(module_name)
+                            if dist_name is not None:
+                                dist = importlib.metadata.distribution(dist_name)
+                                version = dist.metadata.get("Version")
+                                if version is not None:
+                                    custom_experiment_provenance[
+                                        experiment.identifier
+                                    ] = PackageProvenance(
+                                        distributionName=dist_name,
+                                        distributionVersion=version,
+                                    )
+                        except Exception:  # noqa: S110
+                            pass
+
+        return actuator_provenance, custom_experiment_provenance
+
     @property
     def resource(
         self,
     ) -> orchestrator.core.discoveryspace.resource.DiscoverySpaceResource:
 
+        actuator_provenance, custom_experiment_provenance = self._build_provenance()
         return orchestrator.core.discoveryspace.resource.DiscoverySpaceResource(
-            identifier=self._identifier, config=self.config
+            identifier=self._identifier,
+            config=self.config,
+            actuatorProvenance=actuator_provenance,
+            customExperimentProvenance=custom_experiment_provenance,
         )
 
     def saveSpace(self) -> None:

--- a/orchestrator/core/metadata.py
+++ b/orchestrator/core/metadata.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 
-from typing import Annotated
+from typing import Annotated, Self
 
 import pydantic
 from pydantic import ConfigDict
@@ -58,3 +58,32 @@ class PackageProvenance(pydantic.BaseModel):
             description="Installed version of the distribution (e.g. '1.7.1')."
         ),
     ]
+
+
+class ProvenanceInfo(pydantic.BaseModel):
+    """Base model for plugin provenance stored on ADO resources.
+
+    Subclasses declare named maps of plugin identifiers to the distribution
+    that provided each plugin at resource creation time. All declared fields
+    must be ``dict[str, PackageProvenance]``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    @pydantic.model_validator(mode="after")
+    def validate_provenance_field_values(self) -> Self:
+        """Ensure every declared field is a dict of PackageProvenance instances."""
+        for field_name in type(self).model_fields:
+            value = getattr(self, field_name)
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"{field_name} must be a dict[str, PackageProvenance], "
+                    f"got {type(value)}"
+                )
+            for key, item in value.items():
+                if not isinstance(item, PackageProvenance):
+                    raise ValueError(
+                        f"{field_name}[{key!r}] must be PackageProvenance, "
+                        f"got {type(item)}"
+                    )
+        return self

--- a/orchestrator/core/metadata.py
+++ b/orchestrator/core/metadata.py
@@ -60,6 +60,81 @@ class PackageProvenance(pydantic.BaseModel):
         ),
     ]
 
+    @classmethod
+    def from_distribution_name(cls, distribution_name: str) -> Self | None:
+        """Look up installed package provenance for a PyPI distribution name.
+
+        Args:
+            distribution_name: The PyPI distribution name (e.g. ``"ado-core"``).
+
+        Returns:
+            Package provenance for the installed distribution, or ``None`` if the
+            distribution is not installed or its version could not be resolved.
+        """
+        import importlib.metadata
+
+        try:
+            dist = importlib.metadata.distribution(distribution_name)
+            version = dist.metadata.get("Version")
+            if version is None:
+                return None
+            return cls(
+                distributionName=distribution_name,
+                distributionVersion=version,
+            )
+        except Exception:
+            return None
+
+    @classmethod
+    def from_module_name(cls, module_name: str) -> Self | None:
+        """Resolve installed package provenance from a fully qualified module name.
+
+        Modules under the ``orchestrator`` namespace package are resolved to
+        ``ado-core``. For all other modules, the containing distribution is
+        resolved via :func:`~orchestrator.utilities.distribution.distribution_from_module`.
+
+        Args:
+            module_name: Fully qualified module name (e.g. ``"ado_ray_tune.operator"``).
+
+        Returns:
+            Package provenance for the installed distribution, or ``None`` if it
+            could not be resolved.
+        """
+        from orchestrator.utilities.distribution import distribution_from_module
+
+        if module_name.startswith("orchestrator.") or module_name == "orchestrator":
+            return cls.from_distribution_name("ado-core")
+
+        try:
+            dist_name = distribution_from_module(module_name)
+        except Exception:
+            return None
+        if dist_name is None:
+            return None
+        return cls.from_distribution_name(dist_name)
+
+    @classmethod
+    def from_module_conf(cls, module_conf: object) -> Self | None:
+        """Resolve provenance from a module configuration object or dict.
+
+        Accepts a :class:`~orchestrator.modules.module.ModuleConf` instance or a
+        dict containing ``moduleName``.
+
+        Args:
+            module_conf: Module configuration carrying ``moduleName``.
+
+        Returns:
+            Package provenance for the installed distribution, or ``None`` if
+            ``moduleName`` is missing or could not be resolved.
+        """
+        if isinstance(module_conf, dict):
+            module_name = module_conf.get("moduleName")
+        else:
+            module_name = getattr(module_conf, "moduleName", None)
+        if not isinstance(module_name, str):
+            return None
+        return cls.from_module_name(module_name)
+
 
 class ProvenanceInfo(pydantic.BaseModel):
     """Base model for plugin provenance stored on ADO resources.

--- a/orchestrator/core/metadata.py
+++ b/orchestrator/core/metadata.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 
-from typing import Annotated, Self
+from typing import Annotated
 
 import pydantic
 from pydantic import ConfigDict
+from typing_extensions import Self
 
 
 class ConfigurationMetadata(pydantic.BaseModel):

--- a/orchestrator/core/metadata.py
+++ b/orchestrator/core/metadata.py
@@ -8,6 +8,8 @@ import pydantic
 from pydantic import ConfigDict
 from typing_extensions import Self
 
+from orchestrator.utilities.pydantic import Pep440VersionStr
+
 
 class ConfigurationMetadata(pydantic.BaseModel):
 
@@ -54,7 +56,7 @@ class PackageProvenance(pydantic.BaseModel):
         ),
     ]
     distributionVersion: Annotated[
-        str,
+        Pep440VersionStr,
         pydantic.Field(
             description="Installed version of the distribution (e.g. '1.7.1')."
         ),

--- a/orchestrator/core/metadata.py
+++ b/orchestrator/core/metadata.py
@@ -30,3 +30,31 @@ class ConfigurationMetadata(pydantic.BaseModel):
             description="Optional labels to allow for quick filtering of this resource"
         ),
     ] = None
+
+
+class PackageProvenance(pydantic.BaseModel):
+    """Records the Python distribution package that provided a plugin at resource creation time.
+
+    Captures the PyPI distribution name and installed version so that the exact
+    package used when a resource was created can be identified later for
+    replication or debugging.
+
+    Attributes:
+        distributionName: The PyPI distribution name (e.g. ``"ado-ray-tune"``).
+        distributionVersion: The installed version of the distribution (e.g. ``"1.7.1"``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    distributionName: Annotated[
+        str,
+        pydantic.Field(
+            description="PyPI distribution name (e.g. 'ado-ray-tune', 'ado-core')."
+        ),
+    ]
+    distributionVersion: Annotated[
+        str,
+        pydantic.Field(
+            description="Installed version of the distribution (e.g. '1.7.1')."
+        ),
+    ]

--- a/orchestrator/core/operation/config.py
+++ b/orchestrator/core/operation/config.py
@@ -23,6 +23,7 @@ from orchestrator.modules.module import (
     load_module_class_or_function,
 )
 from orchestrator.schema.measurementspace import MeasurementSpaceConfiguration
+from orchestrator.utilities.pydantic import Pep440VersionStr
 
 if typing.TYPE_CHECKING:
     import orchestrator.modules.operators.base
@@ -209,7 +210,7 @@ class OperatorMetadata(pydantic.BaseModel):
         ),
     ] = None
     version: Annotated[
-        str,
+        Pep440VersionStr,
         pydantic.Field(
             description=(
                 "PEP 440 version string for the operator (e.g. '0.1.0', "
@@ -264,30 +265,6 @@ class OperatorMetadata(pydantic.BaseModel):
             ),
         ),
     ]
-
-    @pydantic.field_validator("version", mode="after")
-    @classmethod
-    def validate_version_is_pep440(cls, value: str) -> str:
-        """Validate that *version* is a valid PEP 440 version string.
-
-        Args:
-            value: The version string to validate.
-
-        Returns:
-            The original version string unchanged.
-
-        Raises:
-            ValueError: If *value* is not a valid PEP 440 version string.
-        """
-        from packaging.version import InvalidVersion, Version
-
-        try:
-            Version(value)
-        except InvalidVersion as exc:
-            raise ValueError(
-                f"Operator version {value!r} is not a valid PEP 440 version string: {exc}"
-            ) from exc
-        return value
 
     @property
     def operatorIdentifier(self) -> str:

--- a/orchestrator/core/operation/config.py
+++ b/orchestrator/core/operation/config.py
@@ -253,6 +253,16 @@ class OperatorMetadata(pydantic.BaseModel):
             description="The discovery operation type this operator belongs to."
         ),
     ]
+    distributionName: Annotated[
+        str | None,
+        pydantic.Field(
+            description=(
+                "PyPI distribution name that provides this operator "
+                "(e.g. 'ado-ray-tune', 'ado-core'). Resolved at registration time; "
+                "None when the module is not installed as a distribution package."
+            ),
+        ),
+    ] = None
 
     @pydantic.field_validator("version", mode="after")
     @classmethod

--- a/orchestrator/core/operation/config.py
+++ b/orchestrator/core/operation/config.py
@@ -14,7 +14,7 @@ from orchestrator.core.actuatorconfiguration.config import ActuatorConfiguration
 from orchestrator.core.discoveryspace.config import (
     DiscoverySpaceConfiguration,
 )
-from orchestrator.core.metadata import ConfigurationMetadata
+from orchestrator.core.metadata import ConfigurationMetadata, PackageProvenance
 from orchestrator.core.resources import CoreResourceKinds
 from orchestrator.metastore.project import ProjectContext
 from orchestrator.modules.module import (
@@ -253,16 +253,17 @@ class OperatorMetadata(pydantic.BaseModel):
             description="The discovery operation type this operator belongs to."
         ),
     ]
-    distributionName: Annotated[
-        str | None,
+    provenance: Annotated[
+        PackageProvenance | None,
         pydantic.Field(
+            default=None,
             description=(
-                "PyPI distribution name that provides this operator "
-                "(e.g. 'ado-ray-tune', 'ado-core'). Resolved at registration time; "
-                "None when the module is not installed as a distribution package."
+                "Python distribution that provides this operator, resolved from the "
+                "installed environment at registration time. None when the operator "
+                "module is not installed as a distribution package."
             ),
         ),
-    ] = None
+    ]
 
     @pydantic.field_validator("version", mode="after")
     @classmethod

--- a/orchestrator/core/operation/resource.py
+++ b/orchestrator/core/operation/resource.py
@@ -8,6 +8,7 @@ from typing import Annotated
 
 import pydantic
 
+from orchestrator.core.metadata import PackageProvenance
 from orchestrator.core.operation.config import (
     DiscoveryOperationEnum,
     DiscoveryOperationResourceConfiguration,
@@ -84,6 +85,17 @@ class OperationResource(ADOResource):
                 OperationResourceStatus(event=ADOResourceEventEnum.CREATED)
             ],
             description="A list of status objects",
+        ),
+    ]
+    operatorProvenance: Annotated[
+        PackageProvenance | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Python distribution that provided the operator at the time this "
+                "operation was created. None for operations created before provenance "
+                "tracking was introduced, or when the distribution could not be resolved."
+            ),
         ),
     ]
 

--- a/orchestrator/core/operation/resource.py
+++ b/orchestrator/core/operation/resource.py
@@ -8,7 +8,7 @@ from typing import Annotated
 
 import pydantic
 
-from orchestrator.core.metadata import PackageProvenance
+from orchestrator.core.metadata import PackageProvenance, ProvenanceInfo
 from orchestrator.core.operation.config import (
     DiscoveryOperationEnum,
     DiscoveryOperationResourceConfiguration,
@@ -64,6 +64,21 @@ class OperationResourceStatus(ADOResourceStatus):
         return self
 
 
+class OperationProvenanceInfo(ProvenanceInfo):
+    """Plugin provenance for an operation resource."""
+
+    operators: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of operator identifier to the Python distribution that "
+                "provided it at the time this operation was created."
+            ),
+        ),
+    ]
+
+
 class OperationResource(ADOResource):
 
     version: Annotated[str, pydantic.Field()] = "v1"
@@ -87,15 +102,11 @@ class OperationResource(ADOResource):
             description="A list of status objects",
         ),
     ]
-    operatorProvenance: Annotated[
-        PackageProvenance | None,
+    provenance: Annotated[
+        OperationProvenanceInfo,
         pydantic.Field(
-            default=None,
-            description=(
-                "Python distribution that provided the operator at the time this "
-                "operation was created. None for operations created before provenance "
-                "tracking was introduced, or when the distribution could not be resolved."
-            ),
+            default_factory=OperationProvenanceInfo,
+            description="Plugin package provenance frozen at resource creation time.",
         ),
     ]
 

--- a/orchestrator/core/resources.py
+++ b/orchestrator/core/resources.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 import pydantic
 
+from orchestrator.core.metadata import ProvenanceInfo
 from orchestrator.utilities.pydantic import Defaultable
 
 
@@ -98,6 +99,13 @@ class ADOResource(pydantic.BaseModel):
     ]
     metadata: Annotated[
         dict, pydantic.Field(default_factory=dict, description="Metadata dictionary")
+    ]
+    provenance: Annotated[
+        ProvenanceInfo,
+        pydantic.Field(
+            default_factory=ProvenanceInfo,
+            description="Plugin package provenance frozen at resource creation time.",
+        ),
     ]
 
     model_config = pydantic.ConfigDict(extra="forbid")

--- a/orchestrator/modules/actuators/registry.py
+++ b/orchestrator/modules/actuators/registry.py
@@ -10,6 +10,7 @@ import orchestrator.schema
 from orchestrator.core.actuatorconfiguration.config import (
     GenericActuatorParameters,
 )
+from orchestrator.core.metadata import PackageProvenance
 from orchestrator.modules.actuators.base import (
     ActuatorBase,
 )
@@ -87,7 +88,7 @@ class ActuatorRegistry:
         self.actuatorIdentifierMap: dict[str, type[ActuatorBase]] = {}
         # Maps actuator ids to ExperimentCatalog instances
         self.catalogIdentifierMap: dict[str, ExperimentCatalog] = {}
-        # Maps actuator ids to metadata (version and description)
+        # Maps actuator ids to metadata (version, description, and distributionName)
         self.actuatorMetadataMap: dict[str, dict[str, str | None]] = {}
         self.log = logging.getLogger("registry")
         self.id = uuid.uuid4()
@@ -186,7 +187,11 @@ class ActuatorRegistry:
         except (AttributeError, IndexError):
             pass
 
-        return {"version": version, "description": description}
+        return {
+            "version": version,
+            "description": description,
+            "distributionName": "ado-core",
+        }
 
     def _get_plugin_actuator_metadata(
         self, actuator_class: "type[ActuatorBase]"
@@ -203,6 +208,7 @@ class ActuatorRegistry:
 
         version = None
         description = None
+        distribution_name = None
 
         try:
             # Get the module name from the actuator class
@@ -216,12 +222,17 @@ class ActuatorRegistry:
                 dist = importlib.metadata.distribution(dist_name)
                 version = dist.metadata.get("Version", None)
                 description = dist.metadata.get("Summary", None)
+                distribution_name = dist_name
         except Exception as e:
             self.log.debug(
                 f"Could not extract metadata for plugin actuator {actuator_class}: {e}"
             )
 
-        return {"version": version, "description": description}
+        return {
+            "version": version,
+            "description": description,
+            "distributionName": distribution_name,
+        }
 
     def registerActuator(
         self,
@@ -249,6 +260,31 @@ class ActuatorRegistry:
                 metadata = self._get_plugin_actuator_metadata(actuatorClass)
 
             self.actuatorMetadataMap[actuatorid] = metadata
+
+    def provenance_for_actuator(self, identifier: str) -> PackageProvenance | None:
+        """Return the package provenance for a registered actuator.
+
+        Returns ``None`` if the actuator is not registered or its distribution
+        could not be resolved (e.g. the actuator was loaded from an unpackaged
+        local path).
+
+        Args:
+            identifier: The actuator identifier.
+
+        Returns:
+            A :class:`~orchestrator.core.metadata.PackageProvenance` instance,
+            or ``None`` if provenance is unavailable.
+        """
+        metadata = self.actuatorMetadataMap.get(identifier)
+        if metadata is None:
+            return None
+        dist_name = metadata.get("distributionName")
+        version = metadata.get("version")
+        if dist_name is None or version is None:
+            return None
+        return PackageProvenance(
+            distributionName=dist_name, distributionVersion=version
+        )
 
     def catalogForActuatorIdentifier(self, actuatorid: str) -> ExperimentCatalog:
         """Returns the catalog for a given actuator via its identifier

--- a/orchestrator/modules/actuators/registry.py
+++ b/orchestrator/modules/actuators/registry.py
@@ -19,7 +19,6 @@ from orchestrator.modules.actuators.catalog import (
 )
 from orchestrator.schema.measurementspace import MeasurementSpace
 from orchestrator.schema.reference import ExperimentReference
-from orchestrator.utilities.distribution import distribution_from_module
 from orchestrator.utilities.logging import configure_logging
 
 if typing.TYPE_CHECKING:
@@ -204,34 +203,31 @@ class ActuatorRegistry:
         Returns:
             Dictionary with 'version' and 'description' keys
         """
-        import importlib.metadata
+        from orchestrator.core.metadata import PackageProvenance
 
-        version = None
         description = None
-        distribution_name = None
+        provenance = PackageProvenance.from_module_name(actuator_class.__module__)
+        if provenance is not None:
+            try:
+                import importlib.metadata
 
-        try:
-            # Get the module name from the actuator class
-            module_name = actuator_class.__module__
-
-            # Find the distribution that contains this module
-            dist_name = distribution_from_module(module_name)
-
-            if dist_name:
-                # Get distribution metadata
-                dist = importlib.metadata.distribution(dist_name)
-                version = dist.metadata.get("Version", None)
+                dist = importlib.metadata.distribution(provenance.distributionName)
                 description = dist.metadata.get("Summary", None)
-                distribution_name = dist_name
-        except Exception as e:
-            self.log.debug(
-                f"Could not extract metadata for plugin actuator {actuator_class}: {e}"
-            )
+            except Exception as e:
+                self.log.debug(
+                    f"Could not extract description for plugin actuator "
+                    f"{actuator_class}: {e}"
+                )
+            return {
+                "version": provenance.distributionVersion,
+                "description": description,
+                "distributionName": provenance.distributionName,
+            }
 
         return {
-            "version": version,
-            "description": description,
-            "distributionName": distribution_name,
+            "version": None,
+            "description": None,
+            "distributionName": None,
         }
 
     def registerActuator(

--- a/orchestrator/modules/operators/base.py
+++ b/orchestrator/modules/operators/base.py
@@ -403,12 +403,21 @@ def add_operation_and_output_to_metastore(
     metastore: SQLStore,
 ) -> OperationResource:
     """Creates an operation resource from the given configuration and adds it and its outputs to the resource store"""
+    from orchestrator.modules.operators.collections import provenance_for_operator
+
+    operator_module = operation_resource_configuration.operation.module
+    operator_provenance = None
+    if isinstance(operator_module, OperatorReference):
+        operator_provenance = provenance_for_operator(
+            operator_module.operatorName, operator_module.operationType
+        )
 
     operation = OperationResource(
-        operationType=operation_resource_configuration.operation.module.operationType,
-        operatorIdentifier=operation_resource_configuration.operation.module.operatorIdentifier,
+        operationType=operator_module.operationType,
+        operatorIdentifier=operator_module.operatorIdentifier,
         config=operation_resource_configuration,
         status=[output.exitStatus],
+        operatorProvenance=operator_provenance,
     )
 
     # ValueError means the resource has already been added
@@ -452,6 +461,7 @@ def create_operation_and_add_to_metastore(
     """
 
     from orchestrator.core.operation.config import DiscoveryOperationConfiguration
+    from orchestrator.modules.operators.collections import provenance_for_operator
 
     operation_resource_configuration = DiscoveryOperationResourceConfiguration(
         operation=DiscoveryOperationConfiguration(
@@ -463,11 +473,19 @@ def create_operation_and_add_to_metastore(
         spaces=[discovery_space.resource.identifier],
     )
 
+    op_module = operation_resource_configuration.operation.module
+    operator_provenance = None
+    if isinstance(op_module, OperatorReference):
+        operator_provenance = provenance_for_operator(
+            op_module.operatorName, op_module.operationType
+        )
+
     operation = OperationResource(
         identifier=operation_identifier,
-        operationType=operation_resource_configuration.operation.module.operationType,
-        operatorIdentifier=operation_resource_configuration.operation.module.operatorIdentifier,
+        operationType=op_module.operationType,
+        operatorIdentifier=op_module.operatorIdentifier,
         config=operation_resource_configuration,
+        operatorProvenance=operator_provenance,
     )
 
     related_identifiers = [

--- a/orchestrator/modules/operators/base.py
+++ b/orchestrator/modules/operators/base.py
@@ -403,21 +403,24 @@ def add_operation_and_output_to_metastore(
     metastore: SQLStore,
 ) -> OperationResource:
     """Creates an operation resource from the given configuration and adds it and its outputs to the resource store"""
+    from orchestrator.core.operation.resource import OperationProvenanceInfo
     from orchestrator.modules.operators.collections import provenance_for_operator
 
     operator_module = operation_resource_configuration.operation.module
-    operator_provenance = None
+    operators = {}
     if isinstance(operator_module, OperatorReference):
         operator_provenance = provenance_for_operator(
             operator_module.operatorName, operator_module.operationType
         )
+        if operator_provenance is not None:
+            operators[operator_module.operatorIdentifier] = operator_provenance
 
     operation = OperationResource(
         operationType=operator_module.operationType,
         operatorIdentifier=operator_module.operatorIdentifier,
         config=operation_resource_configuration,
         status=[output.exitStatus],
-        operatorProvenance=operator_provenance,
+        provenance=OperationProvenanceInfo(operators=operators),
     )
 
     # ValueError means the resource has already been added
@@ -461,6 +464,7 @@ def create_operation_and_add_to_metastore(
     """
 
     from orchestrator.core.operation.config import DiscoveryOperationConfiguration
+    from orchestrator.core.operation.resource import OperationProvenanceInfo
     from orchestrator.modules.operators.collections import provenance_for_operator
 
     operation_resource_configuration = DiscoveryOperationResourceConfiguration(
@@ -474,18 +478,20 @@ def create_operation_and_add_to_metastore(
     )
 
     op_module = operation_resource_configuration.operation.module
-    operator_provenance = None
+    operators = {}
     if isinstance(op_module, OperatorReference):
         operator_provenance = provenance_for_operator(
             op_module.operatorName, op_module.operationType
         )
+        if operator_provenance is not None:
+            operators[op_module.operatorIdentifier] = operator_provenance
 
     operation = OperationResource(
         identifier=operation_identifier,
         operationType=op_module.operationType,
         operatorIdentifier=op_module.operatorIdentifier,
         config=operation_resource_configuration,
-        operatorProvenance=operator_provenance,
+        provenance=OperationProvenanceInfo(operators=operators),
     )
 
     related_identifiers = [

--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -10,6 +10,7 @@ import pydantic
 
 import orchestrator.core.operation.config
 from orchestrator.core.discoveryspace.space import DiscoverySpace
+from orchestrator.core.metadata import PackageProvenance
 from orchestrator.core.operation.config import (
     DiscoveryOperationEnum,
     FunctionOperationInfo,
@@ -26,8 +27,30 @@ from orchestrator.modules.operators.orchestrate import (
     orchestrate_explore_operation,
     orchestrate_general_operation,
 )
+from orchestrator.utilities.distribution import distribution_from_module
 
 moduleLog = logging.getLogger("operation_collections")
+
+
+def _resolve_distribution_name(module_name: str) -> str | None:
+    """Resolve the PyPI distribution name for a Python module.
+
+    Modules under the ``orchestrator`` namespace package are always resolved to
+    ``ado-core``.  For all other modules, :func:`distribution_from_module` is
+    used.
+
+    Args:
+        module_name: Fully qualified module name (e.g. ``"ado_ray_tune.operator"``).
+
+    Returns:
+        The distribution name, or ``None`` if it could not be resolved.
+    """
+    if module_name.startswith("orchestrator.") or module_name == "orchestrator":
+        return "ado-core"
+    try:
+        return distribution_from_module(module_name)
+    except Exception:
+        return None
 
 
 def _warn_if_operator_name_reused(
@@ -168,6 +191,7 @@ def characterize_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.CHARACTERIZE,
+            distributionName=_resolve_distribution_name(func.__module__),
         )
         return wrapper
 
@@ -266,6 +290,7 @@ def explore_operation(
         update={
             "function": _generated,
             "cls": cls,
+            "distributionName": _resolve_distribution_name(cls.__module__),
         }
     )
     return cls
@@ -316,6 +341,7 @@ def modify_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.MODIFY,
+            distributionName=_resolve_distribution_name(func.__module__),
         )
         return wrapper
 
@@ -367,13 +393,46 @@ def export_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.EXPORT,
+            distributionName=_resolve_distribution_name(func.__module__),
         )
         return wrapper
 
     return _register
 
 
+def provenance_for_operator(
+    name: str, op_type: DiscoveryOperationEnum
+) -> PackageProvenance | None:
+    """Return the package provenance for a registered operator.
+
+    Looks up the operator in the collection for ``op_type`` and constructs a
+    :class:`~orchestrator.core.metadata.PackageProvenance` from its
+    ``distributionName`` and ``version``.  Returns ``None`` when the operator
+    is not registered, its distribution could not be resolved, or either field
+    is missing.
+
+    Args:
+        name: Canonical operator name.
+        op_type: The discovery operation type the operator belongs to.
+
+    Returns:
+        A :class:`~orchestrator.core.metadata.PackageProvenance` instance,
+        or ``None`` if provenance is unavailable.
+    """
+    collection = operationCollectionMap.get(op_type)
+    if collection is None:
+        return None
+    metadata = collection.operators.get(name)
+    if metadata is None or metadata.distributionName is None:
+        return None
+    return PackageProvenance(
+        distributionName=metadata.distributionName,
+        distributionVersion=metadata.version,
+    )
+
+
 def load_operators() -> None:
+    """Load all operator plugins via ``ado.operators`` entry points."""
     from importlib.metadata import entry_points
 
     for operator_plugin in entry_points(group="ado.operators"):

--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -32,23 +32,41 @@ from orchestrator.utilities.distribution import distribution_from_module
 moduleLog = logging.getLogger("operation_collections")
 
 
-def _resolve_distribution_name(module_name: str) -> str | None:
-    """Resolve the PyPI distribution name for a Python module.
+def _resolve_package_provenance(module_name: str) -> PackageProvenance | None:
+    """Resolve installed package provenance for a Python module.
 
     Modules under the ``orchestrator`` namespace package are always resolved to
     ``ado-core``.  For all other modules, :func:`distribution_from_module` is
-    used.
+    used to find the containing distribution.
 
     Args:
         module_name: Fully qualified module name (e.g. ``"ado_ray_tune.operator"``).
 
     Returns:
-        The distribution name, or ``None`` if it could not be resolved.
+        Package provenance for the installed distribution, or ``None`` if it
+        could not be resolved.
     """
+    import importlib.metadata
+
     if module_name.startswith("orchestrator.") or module_name == "orchestrator":
-        return "ado-core"
+        dist_name = "ado-core"
+    else:
+        try:
+            dist_name = distribution_from_module(module_name)
+        except Exception:
+            return None
+        if dist_name is None:
+            return None
+
     try:
-        return distribution_from_module(module_name)
+        dist = importlib.metadata.distribution(dist_name)
+        version = dist.metadata.get("Version")
+        if version is None:
+            return None
+        return PackageProvenance(
+            distributionName=dist_name,
+            distributionVersion=version,
+        )
     except Exception:
         return None
 
@@ -191,7 +209,7 @@ def characterize_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.CHARACTERIZE,
-            distributionName=_resolve_distribution_name(func.__module__),
+            provenance=_resolve_package_provenance(func.__module__),
         )
         return wrapper
 
@@ -290,7 +308,7 @@ def explore_operation(
         update={
             "function": _generated,
             "cls": cls,
-            "distributionName": _resolve_distribution_name(cls.__module__),
+            "provenance": _resolve_package_provenance(cls.__module__),
         }
     )
     return cls
@@ -341,7 +359,7 @@ def modify_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.MODIFY,
-            distributionName=_resolve_distribution_name(func.__module__),
+            provenance=_resolve_package_provenance(func.__module__),
         )
         return wrapper
 
@@ -393,7 +411,7 @@ def export_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.EXPORT,
-            distributionName=_resolve_distribution_name(func.__module__),
+            provenance=_resolve_package_provenance(func.__module__),
         )
         return wrapper
 
@@ -405,11 +423,9 @@ def provenance_for_operator(
 ) -> PackageProvenance | None:
     """Return the package provenance for a registered operator.
 
-    Looks up the operator in the collection for ``op_type`` and constructs a
-    :class:`~orchestrator.core.metadata.PackageProvenance` from its
-    ``distributionName`` and ``version``.  Returns ``None`` when the operator
-    is not registered, its distribution could not be resolved, or either field
-    is missing.
+    Looks up the operator in the collection for ``op_type`` and returns the
+    :class:`~orchestrator.core.metadata.PackageProvenance` recorded on its
+    registry metadata at registration time.
 
     Args:
         name: Canonical operator name.
@@ -423,12 +439,9 @@ def provenance_for_operator(
     if collection is None:
         return None
     metadata = collection.operators.get(name)
-    if metadata is None or metadata.distributionName is None:
+    if metadata is None:
         return None
-    return PackageProvenance(
-        distributionName=metadata.distributionName,
-        distributionVersion=metadata.version,
-    )
+    return metadata.provenance
 
 
 def load_operators() -> None:

--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -27,48 +27,8 @@ from orchestrator.modules.operators.orchestrate import (
     orchestrate_explore_operation,
     orchestrate_general_operation,
 )
-from orchestrator.utilities.distribution import distribution_from_module
 
 moduleLog = logging.getLogger("operation_collections")
-
-
-def _resolve_package_provenance(module_name: str) -> PackageProvenance | None:
-    """Resolve installed package provenance for a Python module.
-
-    Modules under the ``orchestrator`` namespace package are always resolved to
-    ``ado-core``.  For all other modules, :func:`distribution_from_module` is
-    used to find the containing distribution.
-
-    Args:
-        module_name: Fully qualified module name (e.g. ``"ado_ray_tune.operator"``).
-
-    Returns:
-        Package provenance for the installed distribution, or ``None`` if it
-        could not be resolved.
-    """
-    import importlib.metadata
-
-    if module_name.startswith("orchestrator.") or module_name == "orchestrator":
-        dist_name = "ado-core"
-    else:
-        try:
-            dist_name = distribution_from_module(module_name)
-        except Exception:
-            return None
-        if dist_name is None:
-            return None
-
-    try:
-        dist = importlib.metadata.distribution(dist_name)
-        version = dist.metadata.get("Version")
-        if version is None:
-            return None
-        return PackageProvenance(
-            distributionName=dist_name,
-            distributionVersion=version,
-        )
-    except Exception:
-        return None
 
 
 def _warn_if_operator_name_reused(
@@ -209,7 +169,7 @@ def characterize_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.CHARACTERIZE,
-            provenance=_resolve_package_provenance(func.__module__),
+            provenance=PackageProvenance.from_module_name(func.__module__),
         )
         return wrapper
 
@@ -308,7 +268,7 @@ def explore_operation(
         update={
             "function": _generated,
             "cls": cls,
-            "provenance": _resolve_package_provenance(cls.__module__),
+            "provenance": PackageProvenance.from_module_name(cls.__module__),
         }
     )
     return cls
@@ -359,7 +319,7 @@ def modify_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.MODIFY,
-            provenance=_resolve_package_provenance(func.__module__),
+            provenance=PackageProvenance.from_module_name(func.__module__),
         )
         return wrapper
 
@@ -411,7 +371,7 @@ def export_operation(
             configuration_model=configuration_model,
             example_configuration=example_configuration,
             type=DiscoveryOperationEnum.EXPORT,
-            provenance=_resolve_package_provenance(func.__module__),
+            provenance=PackageProvenance.from_module_name(func.__module__),
         )
         return wrapper
 

--- a/orchestrator/utilities/pydantic.py
+++ b/orchestrator/utilities/pydantic.py
@@ -5,7 +5,7 @@ import typing
 from typing import Annotated, TypeVar
 
 import pydantic
-from pydantic import BeforeValidator
+from pydantic import AfterValidator, BeforeValidator
 from pydantic_core import PydanticUseDefault
 
 
@@ -78,3 +78,29 @@ def validate_rfc_1123(value: str | None) -> str | None:
         )
 
     return value
+
+
+def validate_pep440_version(value: str) -> str:
+    """Validate that *value* is a valid PEP 440 version string.
+
+    Args:
+        value: The version string to validate.
+
+    Returns:
+        The original version string unchanged.
+
+    Raises:
+        ValueError: If *value* is not a valid PEP 440 version string.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        Version(value)
+    except InvalidVersion as exc:
+        raise ValueError(
+            f"Version {value!r} is not a valid PEP 440 version string: {exc}"
+        ) from exc
+    return value
+
+
+Pep440VersionStr = Annotated[str, AfterValidator(validate_pep440_version)]


### PR DESCRIPTION
When a DiscoverySpaceResource, OperationResource, or ActuatorConfigurationResource is written to the metastore, the exact PyPI distribution name and version of every plugin involved is now captured and stored alongside it. This makes it straightforward to identify — after the fact — which package versions were used to create a given resource, supporting both replication and debugging.

Previously this was somewhat deducible for some operators as long as the operator name and package name were similar as the identifier contained the operator plugin version. However this breaks down if a package provides multiple operators. For experiments or actuator configurations there was no record.

Changes
- Add model for package provenance
- Add model for collection of package provenance instances (ProvenanceInfo)
- Add field `provenance` to ADOResource - type `ProvenancenInfo` (empty by default)
- Add subclasses of ProvenanceInfo for specific resource type (DiscoverySpaceResourceProvenanceInfo)
- Add functions to plugin catalogs (actuator registry, operator collections) to get relevant data
- Before creation of resource of each type get package data and add it

All fields in ProvenanceInfo subclass are expected to have type dict[str, PackageProvenance]. 

Examples: 

space - dictionaries of `customExperiment` packages and `actuator packages`

```yaml
...
created: '2026-06-04T18:17:16.323098Z'
provenance:
  customExperiments:
    nevergrad_opt_3d_test_func:
      distributionName: optimization_test_functions
       distributionVersion: 1.8.1.dev46+437b3291.dirty
   actuators:
      ....
identifier: space-7b7ae1-default
status:
- event: created
  recorded_at: '2026-06-04T18:17:16.323104Z'
- event: added
  recorded_at: '2026-06-04T18:17:16.324510Z'
 ```
 
 operation - dict of operators. 
 
 ```yaml
 ...
 kind: operation
metadata:
  entities_submitted: 40
  experiments_requested: 40
operationType: search
operatorIdentifier: ray_tune-1.8.1.dev43+g08402ddd3.d20260603144611
provenance: 
    operators:
         ray_tune:
           distributionName: ado-ray-tune
           distributionVersion: 1.8.1.dev43+g08402ddd3.d20260603144611
  ...
 ```
 
 ## Notes
 
 We use `dict[str, PackageProveancen]` for collecting packages even in cases there can be only one (like one operator per operation) to keep the same structure across all resources. 