### PR TITLE
refactor(cli)!: rename ado show entities to ado show measurements

### DIFF
--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -71,9 +71,9 @@ re-fetching.
 
 ### Large output files
 
-The output for a chosen `-o`/`--output` **format** can be very large (for example
-from `show entities`, `show requests`, or `show results`). Use `--output-file`
-with the destination path and, when inspecting these files:
+The output for a chosen `-o`/`--output` **format** can be very large (for
+example from `show measurements`, `show requests`, or `show results`). Use
+`--output-file` with the destination path and, when inspecting these files:
 
 - Use wc to count the file size first before using head/tail/cat etc. on it.
 - Use head -n1 to get column headers, this will not be large
@@ -268,7 +268,7 @@ To get the data on measurements execute (noting the
 [guidelines on large files](#large-output-files)):
 
 ```bash
-uv run ado show entities operation OPERATION_ID \
+uv run ado show measurements operation OPERATION_ID \
   -o csv --output-file OPERATION_ID_entities.csv
 ```
 

--- a/.cursor/skills/examining-discovery-spaces/SKILL.md
+++ b/.cursor/skills/examining-discovery-spaces/SKILL.md
@@ -15,10 +15,10 @@ Structured workflow for understanding what a discoveryspace contains, how
 covered its entity space is, and what data has been collected.
 
 - Run all commands from the **repository root** with `uv run`.
-- Write the report to `reports/<ado_context_name>/` (create the
-directory if needed)
-  - where `ado_context_name` is the
-    **active ado metastore context** (`uv run ado context`)
+- Write the report to `reports/<ado_context_name>/` (create the directory if
+  needed)
+  - where `ado_context_name` is the **active ado metastore context**
+    (`uv run ado context`)
 - Write the report as `<SPACEID>_<YYYY-MM-DD>_report.md`
 
 **Related skills**:
@@ -62,9 +62,9 @@ Why is it useful to work with matching data?
 
 1. Allows using the discoveryspace as a view to fetch particular data without
    having to perform operations on it
-   - Concrete example: You create a discoveryspace that is a subspace of
-     another sampled spaced to analyze it. You can perform analysis on existing
-     data even though no operation has been run on the new discoveryspace.
+   - Concrete example: You create a discoveryspace that is a subspace of another
+     sampled spaced to analyze it. You can perform analysis on existing data
+     even though no operation has been run on the new discoveryspace.
 2. Memoization: You can understand if there are
    [memoization opportunities](website/docs/core-concepts/data-sharing.md) that
    would speed up a operation on the space.
@@ -85,15 +85,15 @@ uv run ado show related space --use-latest
 
 ### Avoiding refetching YAML
 
-`ado get … -o yaml` writes YAML to stdout by default. Prefer `--output-file
-PATH` (with the same `-o yaml`) to save it once and reuse the file instead of
-calling `ado get` repeatedly for the same resource.
+`ado get … -o yaml` writes YAML to stdout by default. Prefer
+`--output-file PATH` (with the same `-o yaml`) to save it once and reuse the
+file instead of calling `ado get` repeatedly for the same resource.
 
 ### Large output files
 
 The output produced for a given `-o`/`--output` **format** can be very large
-(for example from `show entities`). Use `--output-file` with the path where the
-output should be saved, and when inspecting these files:
+(for example from `show measurements`). Use `--output-file` with the path where
+the output should be saved, and when inspecting these files:
 
 - Use wc to count the file size first before using head/tail/cat etc. on it.
 - Use head -n1 to get column headers, this will not be large
@@ -104,8 +104,7 @@ output should be saved, and when inspecting these files:
 
 ## Workflow
 
-Run Step 2 and 3 first.
-Then steps 4,5 and 6 can be run in parallel.
+Run Step 2 and 3 first. Then steps 4,5 and 6 can be run in parallel.
 
 ### Step 1: Get Space YAML
 
@@ -156,8 +155,8 @@ overlapping spaces exist.
 - If yes, check if either of the following are true:
   - New operations have been run on space since report
   - The number of measured entities has increased
-- If neither of above are true, ask the user if they want to write a
-  new report or use existing
+- If neither of above are true, ask the user if they want to write a new report
+  or use existing
   - As nothing has changed, the only purpose of creating a new report is if a
     different agent is being used
 
@@ -177,22 +176,21 @@ Note: Keep in mind the [guidelines on large output files](#large-output-files)
 for the following.
 
 ```bash
-uv run ado show entities space SPACE_ID \
+uv run ado show measurements space SPACE_ID \
   --include measured \
   --property-format target \
   -o csv --output-file SPACE_ID_entities.csv
 ```
 
-This writes the data to `SPACE_ID_entities.csv`. If you find `SPACE_ID_entities.csv`
-already exists do not use it, as data may be stale
+This writes the data to `SPACE_ID_entities.csv`. If you find
+`SPACE_ID_entities.csv` already exists do not use it, as data may be stale
 
 You can also get lists of all unmeasured or missing entities, though this is not
 typically required unless you want to analyse the unsampled portion.
 
-Perform an analysis of the measurements, checking e.g. distributions of
-metrics, metric outliers, correlations between metrics.
-Take into account the domain of the experiment and meaning of metrics
-when looking for patterns.
+Perform an analysis of the measurements, checking e.g. distributions of metrics,
+metric outliers, correlations between metrics. Take into account the domain of
+the experiment and meaning of metrics when looking for patterns.
 
 ### Step 6: Examine Related Operations
 

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -46,8 +46,8 @@ DOs:
 DONTs
 
 - Do not fetch discoveryspace or operation data for summary queries
-  - Do not use: ado show entities, ado show requests, ado show results, ado show
-    details)
+  - Do not use: ado show measurements, ado show requests, ado show results, ado
+    show details)
   - Do not instantiating DiscoverySpace instances or SQLStore instance
 - Only use these commands or classes when drilling down on a narrow set of
   resources
@@ -176,7 +176,7 @@ uv run ado show details $RESOURCETYPE [RESOURCE_ID] [--use-latest]
 Get entities and their measurements from a space or operation:
 
 ```bash
-uv run ado show entities RESOURCE_TYPE [RESOURCE_ID] \
+uv run ado show measurements RESOURCE_TYPE [RESOURCE_ID] \
                   [--use-latest] [--file | -f <file.yaml>]\
                   [--property-format {observed | target}] \
                   [--output | -o {csv | json | table}] \
@@ -203,12 +203,12 @@ uv run ado show entities RESOURCE_TYPE [RESOURCE_ID] \
 
 ```bash
 # Show matching entities in a space as CSV
-uv run ado show entities space space-abc123-456def --include matching \
+uv run ado show measurements space space-abc123-456def --include matching \
                                              --property-format target \
                                              -o csv --output-file space-abc123-456def-entities.csv
 
 # Show entities from an operation with specific properties
-uv run ado show entities operation randomwalk-0.5.0-123abc \
+uv run ado show measurements operation randomwalk-0.5.0-123abc \
                   --property my-property-1 \
                   --property my-property-2 \
                   -o csv --output-file randomwalk-0.5.0-123abc.csv
@@ -288,7 +288,7 @@ uv run ado get spaces -q 'config.entitySpace={"propertyDomain":{"values":["mistr
 ### Export operation entities to CSV
 
 ```bash
-uv run ado show entities operation OPERATION_ID -o csv --output-file OPERATION_ID_entities.csv
+uv run ado show measurements operation OPERATION_ID -o csv --output-file OPERATION_ID_entities.csv
 ```
 
 ### Get all resources related to a space

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -149,8 +149,8 @@ uv run ado show details space SPACE_ID
 uv run ado show results operation OPERATION_ID
 
 # Get entities and measurements
-uv run ado show entities space SPACE_ID
-uv run ado show entities operation OPERATION_ID
+uv run ado show measurements space SPACE_ID
+uv run ado show measurements operation OPERATION_ID
 ```
 
 ### ado describe
@@ -175,7 +175,7 @@ redirect (`>`) or with the `--output-file PATH` flag. In many cases a redirect
 
 ```bash
 uv run ado get space SPACE_ID -o yaml > space.yaml
-uv run ado show entities operation OPERATION_ID -o csv > entities.csv
+uv run ado show measurements operation OPERATION_ID -o csv > entities.csv
 ```
 
 Prefer `--output-file` in the following situations:
@@ -191,7 +191,7 @@ Prefer `--output-file` in the following situations:
   not removed when the output is redirected, but is if --output-file specified
 
 ```bash
-uv run ado show entities operation OPERATION_ID -o csv --output-file entities.csv
+uv run ado show measurements operation OPERATION_ID -o csv --output-file entities.csv
 ```
 
 ## Debugging
@@ -218,11 +218,11 @@ Entities represent points in the discovery space with:
 
 <!-- markdownlint-disable line-length -->
 
-| Command                   | What It Shows                                                            |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `show entities operation` | Entities (inputs) and their measurements (outputs) from this operation   |
-| `show entities space`     | All entities and measurements collected in this space                    |
-| `show results operation`  | Results **metadata** from this operation (not the full measurement data) |
+| Command                       | What It Shows                                                            |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `show measurements operation` | Entities (inputs) and their measurements (outputs) from this operation   |
+| `show measurements space`     | All entities and measurements collected in this space                    |
+| `show results operation`      | Results **metadata** from this operation (not the full measurement data) |
 
 <!-- markdownlint-enable line-length -->
 
@@ -230,7 +230,7 @@ Entities represent points in the discovery space with:
 
 ```bash
 # Get the actual measurement data for entities
-uv run ado show entities operation op-123
+uv run ado show measurements operation op-123
 
 # Get metadata about the operation's results
 uv run ado show results operation op-123
@@ -335,7 +335,7 @@ created:
 
 View the entities (inputs) and their measurements (outputs):
 
-\`\`\`bash ado show entities operation --use-latest \`\`\`
+\`\`\`bash ado show measurements operation --use-latest \`\`\`
 ```
 
 ## Common Patterns
@@ -350,7 +350,7 @@ uv run ado get operations
 uv run ado get operation op-123 -o yaml --output-file op-123.yaml
 
 # Get the entities and measurements
-uv run ado show entities operation op-123
+uv run ado show measurements operation op-123
 ```
 
 ### Create with dependencies

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "requirements.txt|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-27T11:58:51Z",
+  "generated_at": "2026-06-09T10:52:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -466,7 +466,7 @@
         "hashed_secret": "2db6d21d365f544f7ca3bcfb443ac96898a7a069",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/ml-multi-cloud/EXAMPLE_OBJECTIVE.md
+++ b/examples/ml-multi-cloud/EXAMPLE_OBJECTIVE.md
@@ -271,7 +271,7 @@ additional information related to the dependent experiment.
 When it completes, you can get a table of the points visited with:
 
 ```commandline
-ado show entities operation --use-latest
+ado show measurements operation --use-latest
 ```
 
 You will see a table similar to the following - note the extra column for the

--- a/examples/ml-multi-cloud/EXAMPLE_SIMPLE.md
+++ b/examples/ml-multi-cloud/EXAMPLE_SIMPLE.md
@@ -306,7 +306,7 @@ above, it is `randomwalk-0.9.4.dev30+564196d4.dirty-b8a233`.
 The command
 
 ```commandline
-ado show entities operation --use-latest
+ado show measurements operation --use-latest
 ```
 
 displays the results of the operation i.e. the entities sampled and the
@@ -519,10 +519,10 @@ Here are a variety of commands you can try after executing the example above:
 There are multiple ways to view the entities related to a `discoveryspace`. Try:
 
 ```commandline
-ado show entities space --use-latest
-ado show entities space --use-latest --aggregate mean
-ado show entities space --use-latest --include unmeasured
-ado show entities space --use-latest --property-format target
+ado show measurements space --use-latest
+ado show measurements space --use-latest --aggregate mean
+ado show measurements space --use-latest --include unmeasured
+ado show measurements space --use-latest --property-format target
 ```
 
 Also,
@@ -567,7 +567,8 @@ ado template operation --include-schema --operator-name random_walk
 ### Rerun
 
 An interesting thing to try is to run the operation again and compare the output
-of `show entities operation` for the two operations, and `show entities space`.
+of `show measurements operation` for the two operations, and
+`show measurements space`.
 
 ## Takeaways
 
@@ -583,10 +584,10 @@ of `show entities operation` for the two operations, and `show entities space`.
   been completed on an entity and reuse it
 - **provenance**: `ado` stores the relationship between the resources it
   creates.
-- **results viewing**: `ado show entities` outputs the data in a
+- **results viewing**: `ado show measurements` outputs the data in a
   `discoveryspace` or measured in an `operation`.
 - **measurement timeseries**: The sequence (timeseries) of measurements,
   successful or not, of each `operation` is preserved.
-- **`discoveryspace` views**: By default `ado show entities space` only shows
-  successfully measured entities, but you can see what has not been measured if
-  you want.
+- **`discoveryspace` views**: By default `ado show measurements space` only
+  shows successfully measured entities, but you can see what has not been
+  measured if you want.

--- a/examples/optimization_test_functions/README.md
+++ b/examples/optimization_test_functions/README.md
@@ -9,7 +9,9 @@
 > 2. Performing optimizations with `ray_tune`
 >
 > 3. Parameterizable and parameterized experiments
+
 <!-- markdownlint-disable-next-line no-blanks-blockquote -->
+
 > [!NOTE]
 >
 > We recommend trying the
@@ -79,6 +81,7 @@ pip install custom_experiments/
 after this running `ado get experiments` should show the following line:
 
 <!-- markdownlint-disable line-length -->
+
 ```commandline
 ┌────────────────────┬────────────────────────────┐
 │ ACTUATOR ID        │ EXPERIMENT ID              │
@@ -88,6 +91,7 @@ after this running `ado get experiments` should show the following line:
 │ mock               │ test-experiment-two        │
 └────────────────────┴────────────────────────────┘
 ```
+
 <!-- markdownlint-enable line-length -->
 
 and `ado describe experiment nevergrad_opt_3d_test_func` should output
@@ -96,62 +100,62 @@ and `ado describe experiment nevergrad_opt_3d_test_func` should output
 Identifier: custom_experiments.nevergrad_opt_3d_test_func
 
 Required Inputs:
-                                                                             
-   Constitutive Properties:                                                  
-    ─────────────────────────────────────────────────────────────────────    
-     Identifier: x0                                                          
-     Domain:                                                                 
-                                                                             
-        Type: CONTINUOUS_VARIABLE_TYPE                                       
-                                                                             
-    ─────────────────────────────────────────────────────────────────────    
-    ─────────────────────────────────────────────────────────────────────    
-     Identifier: x1                                                          
-     Domain:                                                                 
-                                                                             
-        Type: CONTINUOUS_VARIABLE_TYPE                                       
-                                                                             
-    ─────────────────────────────────────────────────────────────────────    
-    ─────────────────────────────────────────────────────────────────────    
-     Identifier: x2                                                          
-     Domain:                                                                 
-                                                                             
-        Type: CONTINUOUS_VARIABLE_TYPE                                       
-                                                                             
-    ─────────────────────────────────────────────────────────────────────    
-                                                                             
+
+   Constitutive Properties:
+    ─────────────────────────────────────────────────────────────────────
+     Identifier: x0
+     Domain:
+
+        Type: CONTINUOUS_VARIABLE_TYPE
+
+    ─────────────────────────────────────────────────────────────────────
+    ─────────────────────────────────────────────────────────────────────
+     Identifier: x1
+     Domain:
+
+        Type: CONTINUOUS_VARIABLE_TYPE
+
+    ─────────────────────────────────────────────────────────────────────
+    ─────────────────────────────────────────────────────────────────────
+     Identifier: x2
+     Domain:
+
+        Type: CONTINUOUS_VARIABLE_TYPE
+
+    ─────────────────────────────────────────────────────────────────────
+
 Optional Inputs and Default Values:
-                                                                             
-    ─────────────────────────────────────────────────────────────────────    
-     Identifier: num_blocks                                                  
-     Domain:                                                                 
-                                                                             
-        Type: DISCRETE_VARIABLE_TYPE                                         
-        Interval: 1                                                          
-        Range: [1, 10]                                                       
-                                                                             
-     Default value: 1                                                        
-    ─────────────────────────────────────────────────────────────────────    
-    ─────────────────────────────────────────────────────────────────────    
-     Identifier: name                                                        
-     Domain:                                                                 
-                                                                             
-        Type: CATEGORICAL_VARIABLE_TYPE                                      
-        Values: [                                                            
-            'discus',                                                        
-            'sphere',                                                        
-            'cigar',                                                         
-            'griewank',                                                      
-            'rosenbrock',                                                    
-            'st1'                                                            
-        ]                                                                    
-                                                                             
-     Default value: 'rosenbrock'                                             
-    ─────────────────────────────────────────────────────────────────────    
-                                                                             
+
+    ─────────────────────────────────────────────────────────────────────
+     Identifier: num_blocks
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 10]
+
+     Default value: 1
+    ─────────────────────────────────────────────────────────────────────
+    ─────────────────────────────────────────────────────────────────────
+     Identifier: name
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            'discus',
+            'sphere',
+            'cigar',
+            'griewank',
+            'rosenbrock',
+            'st1'
+        ]
+
+     Default value: 'rosenbrock'
+    ─────────────────────────────────────────────────────────────────────
+
 Outputs:
- ─────────────────────────────────────────────────────────────────────────── 
-   nevergrad_opt_3d_test_func-function_value                                 
+ ───────────────────────────────────────────────────────────────────────────
+   nevergrad_opt_3d_test_func-function_value
  ───────────────────────────────────────────────────────────────────────────
 ```
 
@@ -190,46 +194,46 @@ be different):
 Identifier: 'space-5420a8-default'
 
 Entity Space:
-                                                                             
-   Space with non-discrete dimensions. Cannot count entities                 
-                                                                             
-   Continuous properties:                                                    
-                                                                             
-      name   range                                                           
-     ──────────────────                                                      
-      x2     [-10, 10]                                                       
-      x1     [-10, 10]                                                       
-      x0     [-10, 10]                                                       
-                                                                             
-                                                                             
+
+   Space with non-discrete dimensions. Cannot count entities
+
+   Continuous properties:
+
+      name   range
+     ──────────────────
+      x2     [-10, 10]
+      x1     [-10, 10]
+      x0     [-10, 10]
+
+
 Measurement Space:
-                                                                             
-   Experiments:                                                              
-                                                                             
-      experiment                                      supported              
-     ───────────────────────────────────────────────────────────             
-      custom_experiments.nevergrad_opt_3d_test_func   True                   
-                                                                             
-    ─────────── custom_experiments.nevergrad_opt_3d_test_func ───────────    
-     Inputs:                                                                 
-                                                                             
-        parameter    type       value        parameterized                   
-       ────────────────────────────────────────────────────                  
-        x0           required   None         na                              
-        x1           required   None         na                              
-        x2           required   None         na                              
-        num_blocks   optional   1            False                           
-        name         optional   rosenbrock   False                           
-                                                                             
-     Outputs:                                                                
-                                                                             
-        target property                                                      
-       ─────────────────                                                     
-        function_value                                                       
-                                                                             
-    ─────────────────────────────────────────────────────────────────────    
-                                                                             
-                                                                             
+
+   Experiments:
+
+      experiment                                      supported
+     ───────────────────────────────────────────────────────────
+      custom_experiments.nevergrad_opt_3d_test_func   True
+
+    ─────────── custom_experiments.nevergrad_opt_3d_test_func ───────────
+     Inputs:
+
+        parameter    type       value        parameterized
+       ────────────────────────────────────────────────────
+        x0           required   None         na
+        x1           required   None         na
+        x2           required   None         na
+        num_blocks   optional   1            False
+        name         optional   rosenbrock   False
+
+     Outputs:
+
+        target property
+       ─────────────────
+        function_value
+
+    ─────────────────────────────────────────────────────────────────────
+
+
 Sample Store identifier: default
 ```
 
@@ -253,9 +257,9 @@ Also try:
 ado get spaces
 ```
 
-This will output a list of the spaces created. If this is the first time you
-are following this example it will contain one entry, the identifier of the
-space you just created above.
+This will output a list of the spaces created. If this is the first time you are
+following this example it will contain one entry, the identifier of the space
+you just created above.
 
 ### Run an optimization
 
@@ -273,26 +277,26 @@ of the operation like below:
 
 ```yaml
 Space ID: space-5420a8-default
-Sample Store ID:  default
+Sample Store ID: default
 Operation:
- config:
-  actuatorConfigurationIdentifiers: []
-  metadata: {}
-  operation:
-    module:
-      operatorName: ray_tune
-      operationType: search
-    parameters:
-      tuneConfig:
-        max_concurrent_trials: 2
-        metric: function_value
-        mode: min
-        num_samples: 40
-        search_alg:
-          name: bayesopt
-  spaces:
-  - space-5420a8-default
-created: '2026-01-29T09:52:50.562791Z'
+  config:
+    actuatorConfigurationIdentifiers: []
+    metadata: {}
+    operation:
+      module:
+        operatorName: ray_tune
+        operationType: search
+      parameters:
+        tuneConfig:
+          max_concurrent_trials: 2
+          metric: function_value
+          mode: min
+          num_samples: 40
+          search_alg:
+            name: bayesopt
+    spaces:
+      - space-5420a8-default
+created: "2026-01-29T09:52:50.562791Z"
 identifier: raytune-1.4.1.dev6+b30c6f74-bayesopt-a605a7
 kind: operation
 metadata:
@@ -301,20 +305,20 @@ metadata:
 operationType: search
 operatorIdentifier: raytune-1.4.1.dev6+b30c6f74
 status:
-- event: created
-  recorded_at: '2026-01-29T09:52:50.562796Z'
-- event: added
-  recorded_at: '2026-01-29T09:52:50.576672Z'
-- event: started
-  recorded_at: '2026-01-29T09:52:50.594038Z'
-- event: updated
-  recorded_at: '2026-01-29T09:52:50.594069Z'
-- event: finished
-  exit_state: success
-  message: Ray Tune operation completed successfully
-  recorded_at: '2026-01-29T09:53:55.100673Z'
-- event: updated
-  recorded_at: '2026-01-29T09:53:56.202542Z'
+  - event: created
+    recorded_at: "2026-01-29T09:52:50.562796Z"
+  - event: added
+    recorded_at: "2026-01-29T09:52:50.576672Z"
+  - event: started
+    recorded_at: "2026-01-29T09:52:50.594038Z"
+  - event: updated
+    recorded_at: "2026-01-29T09:52:50.594069Z"
+  - event: finished
+    exit_state: success
+    message: Ray Tune operation completed successfully
+    recorded_at: "2026-01-29T09:53:55.100673Z"
+  - event: updated
+    recorded_at: "2026-01-29T09:53:56.202542Z"
 version: v1
 ```
 
@@ -329,6 +333,7 @@ The target property to optimize against is set by the `metric` field, under the
 operations `parameters` field.
 
 <!-- markdownlint-disable line-length -->
+
 ```yaml
 parameters:
   tuneConfig:
@@ -341,6 +346,7 @@ parameters:
       params:
         optimizer: "CMA"
 ```
+
 <!-- markdownlint-enable line-length -->
 
 ## See the optimization results
@@ -376,42 +382,42 @@ In this case the output will be something like:
 
 ```terminaloutput
 Identifier: datacontainer-a5a33316
-                                                                             
- ─────────────────────────────── Basic Data ──────────────────────────────── 
-                                                                             
-    Label: 'best_result'                                                     
-    {                                                                        
-        'config': {                                                          
-            'x2': -0.6739656478980461,                                       
-            'x1': 0.8532760228340539,                                        
-            'x0': -2.5705928842344696                                        
-        },                                                                   
-        'metrics': {                                                         
-            'function_value': 1106.8717468085306,                            
-            'timestamp': 1769680394,                                         
-            'checkpoint_dir_name': None,                                     
-            'done': True,                                                    
-            'training_iteration': 1,                                         
-            'trial_id': 'e07dd2f6',                                          
-            'date': '2026-01-29_09-53-14',                                   
-            'time_this_iter_s': 1.0830578804016113,                          
-            'time_total_s': 1.0830578804016113,                              
-            'pid': 34110,                                                    
-            'hostname': 'MacBook-Pro-di-Alessandro.local',                   
-            'node_ip': '127.0.0.1',                                          
-            'config': {                                                      
-                'x2': -0.6739656478980461,                                   
-                'x1': 0.8532760228340539,                                    
-                'x0': -2.5705928842344696                                    
-            },                                                               
-            'time_since_restore': 1.0830578804016113,                        
-            'iterations_since_restore': 1,                                   
-            'experiment_tag': '11_x0=-2.5706,x1=0.8533,x2=-0.6740'           
-        },                                                                   
-        'error': None                                                        
-    }                                                                        
-                                                                             
- ─────────────────────────────────────────────────────────────────────────── 
+
+ ─────────────────────────────── Basic Data ────────────────────────────────
+
+    Label: 'best_result'
+    {
+        'config': {
+            'x2': -0.6739656478980461,
+            'x1': 0.8532760228340539,
+            'x0': -2.5705928842344696
+        },
+        'metrics': {
+            'function_value': 1106.8717468085306,
+            'timestamp': 1769680394,
+            'checkpoint_dir_name': None,
+            'done': True,
+            'training_iteration': 1,
+            'trial_id': 'e07dd2f6',
+            'date': '2026-01-29_09-53-14',
+            'time_this_iter_s': 1.0830578804016113,
+            'time_total_s': 1.0830578804016113,
+            'pid': 34110,
+            'hostname': 'MacBook-Pro-di-Alessandro.local',
+            'node_ip': '127.0.0.1',
+            'config': {
+                'x2': -0.6739656478980461,
+                'x1': 0.8532760228340539,
+                'x0': -2.5705928842344696
+            },
+            'time_since_restore': 1.0830578804016113,
+            'iterations_since_restore': 1,
+            'experiment_tag': '11_x0=-2.5706,x1=0.8533,x2=-0.6740'
+        },
+        'error': None
+    }
+
+ ───────────────────────────────────────────────────────────────────────────
 ```
 
 We can see here that the point found is
@@ -431,7 +437,7 @@ where `function_value` was ~1106.87.
 To see the configurations visited during the optimization you just ran, execute:
 
 ```commandline
-ado show entities operation --use-latest
+ado show measurements operation --use-latest
 ```
 
 This will output a dataframe containing the results of that operation.
@@ -452,6 +458,7 @@ same YAML as shown in the previous section.
 ## Parameterizable experiments
 
 <!-- markdownlint-disable descriptive-link-text -->
+
 The `nevergrad_opt_3d_test_func` is an example of a **parameterizable
 experiment**. A parameterizable experiment has optional inputs that have default
 values. In this case the optional inputs are `name` and `num_blocks` which you
@@ -459,6 +466,7 @@ can see are listed in the output of `ado describe experiment`
 [here](#install-the-custom-nevergrad_opt_3d_test_func-experiment). In particular
 the "name" parameter defines the optimization test function the experiment will
 use and its default value is 'rosenbrock'.
+
 <!-- markdownlint-enable descriptive-link-text -->
 
 If you want to set a different value for an optional parameter of an experiment
@@ -490,19 +498,18 @@ Try the following:
 
 - _change optimizer_: The file `optimization_nevergrad.yaml` shows using the CMA
   optimizer from nevergrad. Modify and run in the same way as the Ax example
-- _different results views_: Use `ado show entities space $SPACE_ID` where
+- _different results views_: Use `ado show measurements space $SPACE_ID` where
   `SPACE_ID` is the identifier of the space the operations run on. Compare to
-  the output of `ado show entities operation`
+  the output of `ado show measurements operation`
 - _modify the entity space_: Extending or limiting the dimensions of the entity
   space considered
 - _change optimizer options_: Change the optimization options and run another
   optimization. See
   [the ray tune operator documentation](/ado/operators/optimisation-with-ray-tune/)
   for details and further examples on what can be configured.
-<!-- markdownlint-disable-next-line line-length -->
-- _parameterize the experiment_: Perform an optimization on the `discus` <!-- codespell:ignore discus -->
-  function - this involves parameterizing the
-  `nevergrad_opt_3d_test_func`.
+  <!-- codespell:ignore discus -->
+- _parameterize the experiment_: Perform an optimization on the `discus`
+  function - this involves parameterizing the `nevergrad_opt_3d_test_func`.
   - See how this changes the description of `discoveryspace`.
 - _discretize the space_: Run the optimization on a discretized version of one
   of the functions and see if memoization works. **Hint**: change the entity

--- a/examples/pfas-generative-models/README.md
+++ b/examples/pfas-generative-models/README.md
@@ -103,7 +103,7 @@ ado create operation -f operation_random_walk_test.yaml --use-latest space
 To see the fingerprints of the ten sampled entities (molecules) run:
 
 ```commandline
-ado show entities space --use-latest
+ado show measurements space --use-latest
 ```
 
 Try as well:
@@ -123,7 +123,7 @@ ado show details space --use-latest
 2. Have someone with distributed access the same project and retrieve the
    results.
 3. Have them run another operation and observe how you can retrieve the results
-4. If you run multiple operations, try using `ado show entities operation` to
+4. If you run multiple operations, try using `ado show measurements operation` to
    get the output from a particular operation
 
 <!-- prettier-ignore-end -->

--- a/examples/trim/README.md
+++ b/examples/trim/README.md
@@ -252,7 +252,7 @@ the entities of the space that have been measured, you can run:
 <!-- markdownlint-disable line-length -->
 
 ```commandline
-ado show entities space --use-latest
+ado show measurements space --use-latest
 ```
 
 <!-- markdownlint-enable line-length -->

--- a/orchestrator/cli/commands/show.py
+++ b/orchestrator/cli/commands/show.py
@@ -6,8 +6,8 @@ import typer
 from orchestrator.cli.commands.show_details import (
     register_show_details_command,
 )
-from orchestrator.cli.commands.show_entities import (
-    register_show_entities_command,
+from orchestrator.cli.commands.show_measurements import (
+    register_show_measurements_command,
 )
 from orchestrator.cli.commands.show_related import (
     register_show_related_command,
@@ -34,7 +34,7 @@ show_command = typer.Typer(
 )
 
 register_show_details_command(show_command)
-register_show_entities_command(show_command)
+register_show_measurements_command(show_command)
 register_show_related_command(show_command)
 register_show_requests_command(show_command)
 register_show_results_command(show_command)

--- a/orchestrator/cli/commands/show_measurements.py
+++ b/orchestrator/cli/commands/show_measurements.py
@@ -11,17 +11,19 @@ from orchestrator.cli.exceptions.handlers import (
     handle_no_related_resource,
     handle_resource_does_not_exist,
 )
-from orchestrator.cli.models.parameters import AdoShowEntitiesCommandParameters
+from orchestrator.cli.models.parameters import AdoShowMeasurementsCommandParameters
 from orchestrator.cli.models.types import (
-    AdoShowEntitiesSupportedEntityTypes,
-    AdoShowEntitiesSupportedOutputFormats,
-    AdoShowEntitiesSupportedPropertyFormats,
-    AdoShowEntitiesSupportedResourceTypes,
+    AdoShowMeasurementsSupportedEntityTypes,
+    AdoShowMeasurementsSupportedOutputFormats,
+    AdoShowMeasurementsSupportedPropertyFormats,
+    AdoShowMeasurementsSupportedResourceTypes,
 )
-from orchestrator.cli.resources.discovery_space.show_entities import (
-    show_discovery_space_entities,
+from orchestrator.cli.resources.discovery_space.show_measurements import (
+    show_discovery_space_measurements,
 )
-from orchestrator.cli.resources.operation.show_entities import show_operation_entities
+from orchestrator.cli.resources.operation.show_measurements import (
+    show_operation_measurements,
+)
 from orchestrator.cli.utils.generic.common import get_effective_resource_id
 from orchestrator.cli.utils.input.parsers import enum_choice_with_plural_parser
 from orchestrator.cli.utils.output.prints import (
@@ -44,25 +46,25 @@ if typing.TYPE_CHECKING:
 SPACE_PANEL_NAME = "Space-only options"
 
 
-def show_entities_for_resources(
+def show_measurements_for_resources(
     ctx: typer.Context,
     resource_type: Annotated[
-        AdoShowEntitiesSupportedResourceTypes,
+        AdoShowMeasurementsSupportedResourceTypes,
         typer.Argument(
             ...,
-            help="The kind of the resource to show entities for.",
+            help="The kind of the resource to show measurements for.",
             show_default=False,
             parser=enum_choice_with_plural_parser(
-                AdoShowEntitiesSupportedResourceTypes
+                AdoShowMeasurementsSupportedResourceTypes
             ),
-            metavar=f"[{'|'.join(m.value for m in AdoShowEntitiesSupportedResourceTypes)}]",
+            metavar=f"[{'|'.join(m.value for m in AdoShowMeasurementsSupportedResourceTypes)}]",
         ),
     ],
     resource_id: Annotated[
         str | None,
         typer.Argument(
             ...,
-            help="The id of the resource to show entities for.",
+            help="The id of the resource to show measurements for.",
             show_default=False,
         ),
     ] = None,
@@ -70,7 +72,7 @@ def show_entities_for_resources(
         bool,
         typer.Option(
             "--use-latest",
-            help="Show entities for the latest identifier of the selected resource type. "
+            help="Show measurements for the latest identifier of the selected resource type. "
             "Ignored if a resource identifier is also specified.",
             show_default=False,
         ),
@@ -89,27 +91,27 @@ def show_entities_for_resources(
         ),
     ] = None,
     entity_type: Annotated[
-        AdoShowEntitiesSupportedEntityTypes | None,
+        AdoShowMeasurementsSupportedEntityTypes | None,
         typer.Option(
             "--include",
             help="The type of entities to include. Ignored for operations.",
             rich_help_panel=SPACE_PANEL_NAME,
         ),
-    ] = AdoShowEntitiesSupportedEntityTypes.MEASURED.value,
+    ] = AdoShowMeasurementsSupportedEntityTypes.MEASURED.value,
     property_format: Annotated[
-        AdoShowEntitiesSupportedPropertyFormats,
+        AdoShowMeasurementsSupportedPropertyFormats,
         typer.Option(
             help="The naming format to be used when displaying measured properties."
         ),
-    ] = AdoShowEntitiesSupportedPropertyFormats.TARGET.value,
+    ] = AdoShowMeasurementsSupportedPropertyFormats.TARGET.value,
     output_format: Annotated[
-        AdoShowEntitiesSupportedOutputFormats,
+        AdoShowMeasurementsSupportedOutputFormats,
         typer.Option(
             "--output",
             "-o",
-            help="The format in which to output the entities.",
+            help="The format in which to output the measurements.",
         ),
-    ] = AdoShowEntitiesSupportedOutputFormats.TABLE.value,
+    ] = AdoShowMeasurementsSupportedOutputFormats.TABLE.value,
     output_file: Annotated[
         pathlib.Path | None,
         typer.Option(
@@ -152,21 +154,21 @@ def show_entities_for_resources(
     ] = False,
 ) -> None:
     """
-    Show entities related to a space or an operation and their measurements.
+    Show measurements related to a space or an operation.
 
-    See https://ibm.github.io/ado/getting-started/ado/#ado-show-entities
+    See https://ibm.github.io/ado/getting-started/ado/#ado-show-measurements
     for detailed documentation and examples.
 
     Examples:
 
-    # Show the entities that have been sampled in a space
-    ado show entities space <space-id> --include sampled
+    # Show the measurements for entities that have been sampled in a space
+    ado show measurements space <space-id> --include sampled
 
-    # Show the entities that have been sampled in the latest space
-    ado show entities space --use-latest
+    # Show the measurements for entities in the latest space
+    ado show measurements space --use-latest
 
-    # Show the entities measured in an operation, one row per entity
-    ado show entities operation <operation-id> --property-format target
+    # Show the measurements for an operation, one row per entity
+    ado show measurements operation <operation-id> --property-format target
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
@@ -187,21 +189,21 @@ def show_entities_for_resources(
         raise typer.Exit(1)
 
     if (
-        resource_type != AdoShowEntitiesSupportedResourceTypes.DISCOVERY_SPACE
+        resource_type != AdoShowMeasurementsSupportedResourceTypes.DISCOVERY_SPACE
         and not resource_id
     ):
         console_print(
-            f"{ERROR}You must specify a resource id when showing entities for {resource_type.value}",
+            f"{ERROR}You must specify a resource id when showing measurements for {resource_type.value}",
             stderr=True,
         )
         raise typer.Exit(1)
 
-    parameters = AdoShowEntitiesCommandParameters(
+    parameters = AdoShowMeasurementsCommandParameters(
         ado_configuration=ado_configuration,
         aggregation_method=aggregation_method,
-        entities_output_format=output_format,
-        entities_property_format=property_format,
-        entities_type=entity_type,
+        measurements_output_format=output_format,
+        measurements_property_format=property_format,
+        measurements_type=entity_type,
         no_trunc=no_trunc,
         output_file=output_file,
         properties=properties,
@@ -210,8 +212,8 @@ def show_entities_for_resources(
     )
 
     method_mapping = {
-        AdoShowEntitiesSupportedResourceTypes.DISCOVERY_SPACE: show_discovery_space_entities,
-        AdoShowEntitiesSupportedResourceTypes.OPERATION: show_operation_entities,
+        AdoShowMeasurementsSupportedResourceTypes.DISCOVERY_SPACE: show_discovery_space_measurements,
+        AdoShowMeasurementsSupportedResourceTypes.OPERATION: show_operation_measurements,
     }
 
     try:
@@ -232,8 +234,8 @@ def show_entities_for_resources(
         raise typer.Exit(1) from e
 
 
-def register_show_entities_command(app: typer.Typer) -> None:
+def register_show_measurements_command(app: typer.Typer) -> None:
     app.command(
-        name="entities",
+        name="measurements",
         no_args_is_help=True,
-    )(show_entities_for_resources)
+    )(show_measurements_for_resources)

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -12,9 +12,9 @@ from orchestrator.cli.models.types import (
     AdoEditSupportedEditors,
     AdoGetSupportedOutputFormats,
     AdoGetSupportedResourceTypes,
-    AdoShowEntitiesSupportedEntityTypes,
-    AdoShowEntitiesSupportedOutputFormats,
-    AdoShowEntitiesSupportedPropertyFormats,
+    AdoShowMeasurementsSupportedEntityTypes,
+    AdoShowMeasurementsSupportedOutputFormats,
+    AdoShowMeasurementsSupportedPropertyFormats,
     AdoShowRequestsSupportedOutputFormats,
     AdoShowResultsSupportedOutputFormats,
     AdoShowSummarySupportedOutputFormats,
@@ -93,12 +93,12 @@ class AdoShowDetailsCommandParameters(pydantic.BaseModel):
     resource_id: str
 
 
-class AdoShowEntitiesCommandParameters(pydantic.BaseModel):
+class AdoShowMeasurementsCommandParameters(pydantic.BaseModel):
     ado_configuration: AdoConfiguration
     aggregation_method: PropertyAggregationMethodEnum | None
-    entities_output_format: AdoShowEntitiesSupportedOutputFormats
-    entities_property_format: AdoShowEntitiesSupportedPropertyFormats
-    entities_type: AdoShowEntitiesSupportedEntityTypes
+    measurements_output_format: AdoShowMeasurementsSupportedOutputFormats
+    measurements_property_format: AdoShowMeasurementsSupportedPropertyFormats
+    measurements_type: AdoShowMeasurementsSupportedEntityTypes
     no_trunc: bool
     output_file: Path | None
     properties: list[str] | None

--- a/orchestrator/cli/models/types.py
+++ b/orchestrator/cli/models/types.py
@@ -119,26 +119,26 @@ class AdoShowDetailsSupportedResourceTypes(Enum):
     OPERATION = _OPERATION_SINGULAR
 
 
-#################### ado show entities ####################
-class AdoShowEntitiesSupportedEntityTypes(Enum):
+#################### ado show measurements ####################
+class AdoShowMeasurementsSupportedEntityTypes(Enum):
     MEASURED = "measured"
     MATCHING = "matching"
     MISSING = "missing"
     UNMEASURED = "unmeasured"
 
 
-class AdoShowEntitiesSupportedOutputFormats(Enum):
+class AdoShowMeasurementsSupportedOutputFormats(Enum):
     CSV = _CSV
     JSON = _JSON
     TABLE = _TABLE
 
 
-class AdoShowEntitiesSupportedPropertyFormats(Enum):
+class AdoShowMeasurementsSupportedPropertyFormats(Enum):
     OBSERVED = "observed"
     TARGET = "target"
 
 
-class AdoShowEntitiesSupportedResourceTypes(Enum):
+class AdoShowMeasurementsSupportedResourceTypes(Enum):
     DISCOVERY_SPACE = _DISCOVERY_SPACE_SINGULAR
     OPERATION = _OPERATION_SINGULAR
 

--- a/orchestrator/cli/resources/discovery_space/show_measurements.py
+++ b/orchestrator/cli/resources/discovery_space/show_measurements.py
@@ -7,10 +7,10 @@ import typer
 import yaml
 from rich.status import Status
 
-from orchestrator.cli.models.parameters import AdoShowEntitiesCommandParameters
+from orchestrator.cli.models.parameters import AdoShowMeasurementsCommandParameters
 from orchestrator.cli.models.types import (
-    AdoShowEntitiesSupportedEntityTypes,
-    AdoShowEntitiesSupportedPropertyFormats,
+    AdoShowMeasurementsSupportedEntityTypes,
+    AdoShowMeasurementsSupportedPropertyFormats,
 )
 from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.output.dataframes import df_to_output
@@ -40,21 +40,23 @@ if typing.TYPE_CHECKING:
     from orchestrator.schema.entity import Entity
 
 
-def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) -> None:
+def show_discovery_space_measurements(
+    parameters: AdoShowMeasurementsCommandParameters,
+) -> None:
 
     import pandas as pd
 
     supported_entity_types = [
-        AdoShowEntitiesSupportedEntityTypes.MATCHING,
-        AdoShowEntitiesSupportedEntityTypes.MEASURED,
-        AdoShowEntitiesSupportedEntityTypes.MISSING,
-        AdoShowEntitiesSupportedEntityTypes.UNMEASURED,
+        AdoShowMeasurementsSupportedEntityTypes.MATCHING,
+        AdoShowMeasurementsSupportedEntityTypes.MEASURED,
+        AdoShowMeasurementsSupportedEntityTypes.MISSING,
+        AdoShowMeasurementsSupportedEntityTypes.UNMEASURED,
     ]
 
-    if parameters.entities_type not in supported_entity_types:
+    if parameters.measurements_type not in supported_entity_types:
         supported_types_str = [t.value for t in supported_entity_types]
         raise typer.BadParameter(
-            f"type must be one of {supported_types_str} for ado show entities space",
+            f"type must be one of {supported_types_str} for ado show measurements space",
         )
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
@@ -94,15 +96,20 @@ def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) 
             )
             raise typer.Exit(1) from e
 
-        if parameters.entities_type != AdoShowEntitiesSupportedEntityTypes.MATCHING:
+        if (
+            parameters.measurements_type
+            != AdoShowMeasurementsSupportedEntityTypes.MATCHING
+        ):
             console_print(
-                f"{WARN}The {cyan(f'--include {parameters.entities_type.value}')} option is not supported when "
+                f"{WARN}The {cyan(f'--include {parameters.measurements_type.value}')} option is not supported when "
                 "passing a resource configuration file.\n\tThe only supported option is "
-                f"is {cyan(f'--include {AdoShowEntitiesSupportedEntityTypes.MATCHING.value}')}.\n"
-                f"{INFO}The {cyan(AdoShowEntitiesSupportedEntityTypes.MATCHING.value)} option will be used.",
+                f"is {cyan(f'--include {AdoShowMeasurementsSupportedEntityTypes.MATCHING.value}')}.\n"
+                f"{INFO}The {cyan(AdoShowMeasurementsSupportedEntityTypes.MATCHING.value)} option will be used.",
                 stderr=True,
             )
-            parameters.entities_type = AdoShowEntitiesSupportedEntityTypes.MATCHING
+            parameters.measurements_type = (
+                AdoShowMeasurementsSupportedEntityTypes.MATCHING
+            )
 
         # AP: we set the resource ID to the file name to make it easier
         # for the prints
@@ -117,7 +124,7 @@ def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) 
         )
 
         output_df: pd.DataFrame = pd.DataFrame()
-        status.update(f"Finding {parameters.entities_type.value} entities")
+        status.update(f"Finding {parameters.measurements_type.value} entities")
 
         virtual_property_ids: list[str] | None = None
         if parameters.properties:
@@ -127,30 +134,42 @@ def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) 
                 if VirtualObservedProperty.isVirtualPropertyIdentifier(p)
             ] or None
 
-        if parameters.entities_type == AdoShowEntitiesSupportedEntityTypes.MATCHING:
+        if (
+            parameters.measurements_type
+            == AdoShowMeasurementsSupportedEntityTypes.MATCHING
+        ):
             output_df = space.matchingEntitiesTable(
-                property_type=parameters.entities_property_format.value,
+                property_type=parameters.measurements_property_format.value,
                 aggregationMethod=parameters.aggregation_method,
                 virtualPropertyIdentifiers=virtual_property_ids,
             )
-        elif parameters.entities_type == AdoShowEntitiesSupportedEntityTypes.MEASURED:
+        elif (
+            parameters.measurements_type
+            == AdoShowMeasurementsSupportedEntityTypes.MEASURED
+        ):
             output_df = space.measuredEntitiesTable(
-                property_type=parameters.entities_property_format.value,
+                property_type=parameters.measurements_property_format.value,
                 aggregationMethod=parameters.aggregation_method,
                 virtualPropertyIdentifiers=virtual_property_ids,
             )
-        elif parameters.entities_type == AdoShowEntitiesSupportedEntityTypes.UNMEASURED:
+        elif (
+            parameters.measurements_type
+            == AdoShowMeasurementsSupportedEntityTypes.UNMEASURED
+        ):
             unsampled_entities = unmeasured_entities_from_space(space)
             output_df = entities_to_dataframe(unsampled_entities)
-        elif parameters.entities_type == AdoShowEntitiesSupportedEntityTypes.MISSING:
+        elif (
+            parameters.measurements_type
+            == AdoShowMeasurementsSupportedEntityTypes.MISSING
+        ):
             missing_entities = missing_entities_from_space(space)
             output_df = entities_to_dataframe(missing_entities)
 
     if output_df.empty:
         console_print(
             f"{INFO}Nothing was returned for "
-            f"[i]entity type {magenta(parameters.entities_type.value)}[/i] and "
-            f"[i]property format {magenta(parameters.entities_property_format.value)}[/i] "
+            f"[i]entity type {magenta(parameters.measurements_type.value)}[/i] and "
+            f"[i]property format {magenta(parameters.measurements_property_format.value)}[/i] "
             f"in [i]space {magenta(parameters.resource_id)}[/i].",
             stderr=True,
         )
@@ -158,14 +177,15 @@ def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) 
 
     if (
         parameters.properties
-        and parameters.entities_type != AdoShowEntitiesSupportedEntityTypes.MISSING
+        and parameters.measurements_type
+        != AdoShowMeasurementsSupportedEntityTypes.MISSING
     ):
         df_column_set = set(output_df.columns)
         properties_set = set(parameters.properties)
         available_properties = (
             space.measurementSpace.targetProperties
-            if parameters.entities_property_format
-            == AdoShowEntitiesSupportedPropertyFormats.TARGET
+            if parameters.measurements_property_format
+            == AdoShowMeasurementsSupportedPropertyFormats.TARGET
             else space.measurementSpace.observedProperties
         )
         available_properties_formatted = "-\t" + "\n-\t".join(
@@ -175,7 +195,7 @@ def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) 
         if not properties_set.issubset(df_column_set):
             console_print(
                 f"{ERROR}{properties_set.difference(df_column_set)} are not in the available properties.\n"
-                f"{HINT}Available ones for the {parameters.entities_property_format.value} format are:\n"
+                f"{HINT}Available ones for the {parameters.measurements_property_format.value} format are:\n"
                 f"{available_properties_formatted}\n"
                 f"{HINT}Virtual properties (e.g. {cyan('<property>-<method>')}) are also supported "
                 f"where method is one of: {aggregation_methods}",
@@ -189,7 +209,7 @@ def show_discovery_space_entities(parameters: AdoShowEntitiesCommandParameters) 
 
     df_to_output(
         df=output_df,
-        output_format=parameters.entities_output_format.value,
+        output_format=parameters.measurements_output_format.value,
         output_file=parameters.output_file,
         no_trunc=parameters.no_trunc,
     )

--- a/orchestrator/cli/resources/operation/show_measurements.py
+++ b/orchestrator/cli/resources/operation/show_measurements.py
@@ -3,7 +3,7 @@
 
 from rich.status import Status
 
-from orchestrator.cli.models.parameters import AdoShowEntitiesCommandParameters
+from orchestrator.cli.models.parameters import AdoShowMeasurementsCommandParameters
 from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.output.dataframes import df_to_output
 from orchestrator.cli.utils.output.prints import (
@@ -16,7 +16,9 @@ from orchestrator.metastore.base import (
 )
 
 
-def show_operation_entities(parameters: AdoShowEntitiesCommandParameters) -> None:
+def show_operation_measurements(
+    parameters: AdoShowMeasurementsCommandParameters,
+) -> None:
     sql_store = get_sql_store(
         project_context=parameters.ado_configuration.project_context
     )
@@ -35,14 +37,14 @@ def show_operation_entities(parameters: AdoShowEntitiesCommandParameters) -> Non
         status.update("Fetching measurements")
         output_df = space.complete_measurement_request_with_results_timeseries(
             operation_id=parameters.resource_id,
-            output_format=parameters.entities_property_format.value,
+            output_format=parameters.measurements_property_format.value,
             limit_to_properties=parameters.properties,
             aggregation_method=parameters.aggregation_method,
         )
 
     df_to_output(
         df=output_df,
-        output_format=parameters.entities_output_format.value,
+        output_format=parameters.measurements_output_format.value,
         output_file=parameters.output_file,
         no_trunc=parameters.no_trunc,
     )

--- a/plugins/actuators/example_actuator/README.md
+++ b/plugins/actuators/example_actuator/README.md
@@ -71,9 +71,9 @@ can be reused with multiple `discoveryspaces`.
    ado create operation -f yamls/random_walk_operation.yaml --use-latest space
    ```
 
-At this point, you can try `ado show entities` to get sampled entities or apply
-other operators. The actuator is already fully integrated with `ado`: all you
-need to do is have it perform "real" experiments.
+At this point, you can try `ado show measurements` to get sampled entities or
+apply other operators. The actuator is already fully integrated with `ado`: all
+you need to do is have it perform "real" experiments.
 
 ## Parameterizable Experiments
 

--- a/plugins/actuators/vllm_performance/README.md
+++ b/plugins/actuators/vllm_performance/README.md
@@ -263,7 +263,7 @@ ado create space -f yamls/discoveryspace_override_defaults_small.yaml \
 Before we run any experiment, we can see that the `discoveryspace` is empty:
 
 ```commandline
-ado show entities space --use-latest
+ado show measurements space --use-latest
 ```
 
 Will output:
@@ -280,7 +280,7 @@ To see all the entities (parameter combinations) that are waiting to be
 measured, try executing:
 
 ```commandline
-ado show entities space --include missing --use-latest
+ado show measurements space --include missing --use-latest
 ```
 
 The output will look like:
@@ -372,7 +372,7 @@ If the output contains `EXPERIMENT FAILURE`, then something has gone wrong.
 Verify that the entity has been measured by running:
 
 ```commandline
-ado show entities space --use-latest -o csv --output-file entities.csv
+ado show measurements space --use-latest -o csv --output-file entities.csv
 ```
 
 The csv file will have one line representing the entity featuring values for all
@@ -442,6 +442,7 @@ this is the name of package that contains all `ado` plugins.
 The key files are:
 
 - Entry point registration in `pyproject.toml`
+
   - Registers the actuator class with ado using Python entry points.
   - Example:
 

--- a/plugins/custom_experiments/autoconf/README.md
+++ b/plugins/custom_experiments/autoconf/README.md
@@ -283,7 +283,7 @@ ado create space -f examples/sweep/space.yaml
 ado create operation -f examples/sweep/operation.yaml --use-latest space
 : The above step will take a few minutes to sweep over the points
 : This command will generate a CSV file with the results
-ado show entities --use-latest space -o csv --output-file space-entities.csv
+ado show measurements --use-latest space -o csv --output-file space-entities.csv
 open space-entities.csv
 ```
 

--- a/website/docs/actuators/sft-trainer.md
+++ b/website/docs/actuators/sft-trainer.md
@@ -36,7 +36,8 @@ must already include the appropriate version of `torch`:
 
 <!-- markdownlint-disable line-length -->
 
-**We recommend using the [`ordered_pip`](https://github.com/IBM/ado/blob/main/orchestrator/utilities/ray_env/README.md)
+**We recommend using the
+[`ordered_pip`](https://github.com/IBM/ado/blob/main/orchestrator/utilities/ray_env/README.md)
 RayRuntimeEnv plugin** for all versions of `fms-hf-tuning`. It ensures the
 correct `torch` version is installed before packages that depend on it during
 their build phase. The plugin is included in ado-core and its images (e.g.,
@@ -57,7 +58,8 @@ or use one of the following tested images:
 
 - **`fms-hf-tuning > 2.8.2`**
 
-  - Use the tested image `quay.io/ado/ado:c6ba952ad79a2d86d1174fd9aaebddd8953c78cf-py311-cu121-ofed2410v1140`
+  - Use the tested image
+    `quay.io/ado/ado:c6ba952ad79a2d86d1174fd9aaebddd8953c78cf-py311-cu121-ofed2410v1140`
     (tested with `fms-hf-tuning==3.0.0`, not guaranteed for future versions)
 
   <!-- markdownlint-enable line-length -->
@@ -1953,7 +1955,7 @@ properties on the space you created like so:
 <!-- markdownlint-disable MD046 -->
 
 ```commandline
-ado show entities space --output csv $DISCOVERY_SPACE_ID > entities.csv
+ado show measurements space --output csv $DISCOVERY_SPACE_ID > entities.csv
 ```
 
 <!-- markdownlint-enable MD046 -->

--- a/website/docs/actuators/vllm_performance.md
+++ b/website/docs/actuators/vllm_performance.md
@@ -265,7 +265,6 @@ OpenTelemetry-compatible observability platforms.
 
 Add the `otlp_traces_endpoint` parameter to your actuatorconfiguration:
 
-
 ### Multiple configurations
 
 You can create multiple `actuatorconfiguration`s for the `vllm_performance`

--- a/website/docs/core-concepts/data-sharing.md
+++ b/website/docs/core-concepts/data-sharing.md
@@ -43,14 +43,16 @@ so, the result can be reused.
 
 ## Data retrieval modes
 
-When retrieving data from a Discovery Space (e.g. via `ado show entities`),
+When retrieving data from a Discovery Space (e.g. via `ado show measurements`),
 there are two modes that control whether shared data is included:
 
 <!-- markdownlint-disable line-length -->
-| Mode | What is returned |
-| --- | --- |
-| **measured** | Only Entities and measurements recorded by operations run directly on *this* Discovery Space. Compatible data from other spaces is excluded. |
-| **matching** | All Entities and measurements in the Sample Store that are compatible with this Discovery Space, regardless of which space produced them. |
+
+| Mode         | What is returned                                                                                                                             |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **measured** | Only Entities and measurements recorded by operations run directly on _this_ Discovery Space. Compatible data from other spaces is excluded. |
+| **matching** | All Entities and measurements in the Sample Store that are compatible with this Discovery Space, regardless of which space produced them.    |
+
 <!-- markdownlint-enable line-length -->
 
 Use **measured** when you want to see only the results your operations have
@@ -66,12 +68,12 @@ compatible data from other spaces.
 > [ray tune](../operators/optimisation-with-ray-tune.md) operator documentation
 > for examples of how this setting is controlled.
 
-*Memoization* is the name for data reuse that happens automatically during an
+_Memoization_ is the name for data reuse that happens automatically during an
 explore operation. When an operation samples an Entity it proceeds as follows:
 
 - The Entity is sampled from the Entity Space
-- The Entity's record is retrieved from the Sample Store if present (*matching
-  on constitutive property values*).
+- The Entity's record is retrieved from the Sample Store if present (_matching
+  on constitutive property values_).
 - If **memoization is on**, `ado` checks for existing results for each
   Experiment in the Measurement Space using the Experiment’s unique identifier
   and reuses all matching results if any are found.
@@ -79,7 +81,8 @@ explore operation. When an operation samples an Entity it proceeds as follows:
   Experiment in the Measurement Space to the Entity. The new results are added
   to any that already exist.
 
-See [explore operators](../operators/explore_operators.md#memoization-replaying-measurements)
+See
+[explore operators](../operators/explore_operators.md#memoization-replaying-measurements)
 for how memoization fits into the explore execution loop, and
 [Discovery Spaces](discovery-spaces.md#sampling-and-measurement) for how
 operations and spaces relate.

--- a/website/docs/examples/finetune-locally.md
+++ b/website/docs/examples/finetune-locally.md
@@ -4,8 +4,8 @@
 >
 > This example illustrates:
 >
-> 1. Setting up a local environment for running finetuning performance benchmarks
->    using SFTTrainer
+> 1. Setting up a local environment for running finetuning performance
+>    benchmarks using SFTTrainer
 >
 > 2. Benchmarking a set of finetuning configurations for a small model using a
 >    local context and only the CPU
@@ -100,9 +100,9 @@ ado context local
 SFTTrainer includes parameters that control its behavior. For example, it pushes
 any training metrics it collects, like system profiling metadata, to an
 [AIM](https://github.com/aimhubio/aim) server by default. It also features
-parameters that specify important paths, such as the location of the Hugging Face
-cache and the directory where the actuator expects to find files like the test
-dataset.
+parameters that specify important paths, such as the location of the Hugging
+Face cache and the directory where the actuator expects to find files like the
+test dataset.
 
 In this section you will configure the actuator for running experiments locally
 and storing data under the path `/tmp/ado-sft-trainer-hello-world/`.
@@ -202,43 +202,45 @@ To create the Discovery Space:
 
 1. Create the file `space.yaml` with the following content
 
-    <!-- markdownlint-disable line-length -->
-    ```yaml
-    experiments:
-      - experimentIdentifier: finetune_full_benchmark-v1.0.0
-        actuatorIdentifier: SFTTrainer
-        parameterization:
-          - property:
-              identifier: fms_hf_tuning_version
-            value: "2.8.2"
-          - property:
-              identifier: stop_after_seconds
-            value: 30
-          - property:
-              identifier: flash_attn
-            value: False
+   <!-- markdownlint-disable line-length -->
 
-    entitySpace:
-      - identifier: "model_name"
-        propertyDomain:
-          values: ["smollm2-135m"]
-      - identifier: "number_gpus"
-        propertyDomain:
-          values: [0]
-      - identifier: "model_max_length"
-        propertyDomain:
-          values: [512, 1024]
-      - identifier: "batch_size"
-        propertyDomain:
-          values: [1, 2]
-    ```
-    <!-- markdownlint-enable line-length -->
+   ```yaml
+   experiments:
+     - experimentIdentifier: finetune_full_benchmark-v1.0.0
+       actuatorIdentifier: SFTTrainer
+       parameterization:
+         - property:
+             identifier: fms_hf_tuning_version
+           value: "2.8.2"
+         - property:
+             identifier: stop_after_seconds
+           value: 30
+         - property:
+             identifier: flash_attn
+           value: False
+
+   entitySpace:
+     - identifier: "model_name"
+       propertyDomain:
+         values: ["smollm2-135m"]
+     - identifier: "number_gpus"
+       propertyDomain:
+         values: [0]
+     - identifier: "model_max_length"
+       propertyDomain:
+         values: [512, 1024]
+     - identifier: "batch_size"
+       propertyDomain:
+         values: [1, 2]
+   ```
+
+   <!-- markdownlint-enable line-length -->
 
 2. Create the space:
 
-    ```commandline
-    ado create space -f space.yaml
-    ```
+   ```commandline
+   ado create space -f space.yaml
+   ```
 
    The space will use the `default` sample store.
 
@@ -246,42 +248,46 @@ To create the Discovery Space:
 
 1. Create the file `operation.yaml` with the following content:
 
-    ```yaml
-    spaces:
-      - <will be set by ado>
-    actuatorConfigurationIdentifiers:
-      - <will be set by ado>
+   ```yaml
+   spaces:
+     - <will be set by ado>
+   actuatorConfigurationIdentifiers:
+     - <will be set by ado>
 
-    operation:
-      module:
-        operatorName: "random_walk"
-        operationType: "search"
-      parameters:
-        numberEntities: all
-        singleMeasurement: True
-        samplerConfig:
-          mode: sequential
-          samplerType: generator
-    ```
+   operation:
+     module:
+       operatorName: "random_walk"
+       operationType: "search"
+     parameters:
+       numberEntities: all
+       singleMeasurement: True
+       samplerConfig:
+         mode: sequential
+         samplerType: generator
+   ```
 
 2. Create the operation
 
-    ```commandline
-    ado create operation -f operation.yaml \
-                --use-latest space --use-latest actuatorconfiguration
-    ```
+   ```commandline
+   ado create operation -f operation.yaml \
+               --use-latest space --use-latest actuatorconfiguration
+   ```
 
 The operation will execute the measurements (i.e. apply the experiment
 **finetune_full_benchmark-v1.0.0** on the 4 entities) based on the definition of
 your `discoveryspace`. The remaining three measurements will reuse both the
 cached model weights and the cached data, making them faster to complete.
 
+<!-- markdownlint-disable code-block-style -->
+
 !!! info end
-    <!-- markdownlint-disable-next-line code-block-style -->
+
     Each measurement takes about two minutes to complete, with a total of four
     measurements. Ray may take a few minutes to build the Ray runtime
     environment on participating ray workers, so expect the operation to take around
     10 minutes to complete.
+
+<!-- markdownlint-enable code-block-style -->
 
 ### Examine the results of the exploration
 
@@ -291,7 +297,7 @@ measurements:
 <!-- markdownlint-disable line-length -->
 
 ```commandline
-ado show entities space --output csv --use-latest > entities.csv
+ado show measurements space --output csv --use-latest > entities.csv
 ```
 
 <!-- markdownlint-enable line-length -->
@@ -324,6 +330,7 @@ experiment in the SFTTrainer docs. The complete list of measured properties is
 
 ## Next steps
 
+<!-- prettier-ignore-start -->
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line no-inline-html -->
 <div class="grid cards" markdown>
@@ -354,3 +361,5 @@ experiment in the SFTTrainer docs. The complete list of measured properties is
 
 </div>
 <!-- markdownlint-enable line-length -->
+
+<!-- prettier-ignore-end -->

--- a/website/docs/examples/finetune-remotely.md
+++ b/website/docs/examples/finetune-remotely.md
@@ -4,8 +4,8 @@
 >
 > This example illustrates:
 >
-> 1. Setting up a remote RayCluster environment for running finetuning performance
->    benchmarks with SFTTrainer
+> 1. Setting up a remote RayCluster environment for running finetuning
+>    performance benchmarks with SFTTrainer
 >
 > 2. Benchmarking a set of finetuning configurations using GPUs on a remote
 >    RayCluster
@@ -44,19 +44,21 @@ To explore this space, you will:
 
 2. A [remote RayCluster](../../getting-started/kuberay/) with a GPU worker with
    at least one `NVIDIA-A100-SXM4-80GB` GPU and NVIDIA development/runtime
-   packages. Follow our [KubeRay deployment guide](../../getting-started/kuberay/)
-   and see [SFTTrainer requirements](../../actuators/sft-trainer/#requirements)
-   for environment setup details.
+   packages. Follow our
+   [KubeRay deployment guide](../../getting-started/kuberay/) and see
+   [SFTTrainer requirements](../../actuators/sft-trainer/#requirements) for
+   environment setup details.
 
 3. If you host your RayCluster on Kubernetes or OpenShift, make sure you're
    logged in to the Kubernetes or Openshift cluster.
 
 4. Activate the `finetuning` shared context for the example.
 
-    <!-- markdownlint-disable-next-line code-block-style -->
-    ```commandline
-    ado context finetuning
-    ```
+   <!-- markdownlint-disable-next-line code-block-style -->
+
+   ```commandline
+   ado context finetuning
+   ```
 
 ## Install and Configure the SFTTrainer actuator
 
@@ -67,6 +69,7 @@ To explore this space, you will:
 ### Install the SFTTrainer actuator
 
 <!-- markdownlint-disable code-block-style -->
+
 === "Install the SFTTrainer Actuator plugin from PyPi"
 
     ```commandline
@@ -101,6 +104,7 @@ To explore this space, you will:
     │ robotic_lab        │ 1           │
     └────────────────────┴─────────────┘
      ```
+
  <!-- markdownlint-enable code-block-style -->
 
 ### Configure the SFTTrainer Actuator
@@ -116,6 +120,7 @@ In this section you will configure the actuator for experiments on your remote
 RayCluster.
 
 <!-- markdownlint-disable code-block-style -->
+
 === "If you do not have an AIM server"
 
      Create the file `actuator_configuration.yaml` with the following contents:
@@ -139,9 +144,10 @@ RayCluster.
       hf_home: /hf-models-pvc/huggingface_home
       data_directory: /data/fms-hf-tuning/artificial-dataset/
     ```
+
 <!-- markdownlint-enable code-block-style -->
 
->[!IMPORTANT]
+> [!IMPORTANT]
 >
 > If you have deployed a custom RayCluster then make sure that the `hf_home` and
 > `data_directory` parameters point to paths that can be created by your remote
@@ -162,7 +168,7 @@ See the full list of the actuator parameters you can set in the
 
 ## Prepare the remote RayCluster
 
->[!NOTE]
+> [!NOTE]
 >
 > This section assumes you have
 > [configured your RayCluster for use with SFTTrainer](../../actuators/sft-trainer/#configure-your-raycluster)
@@ -171,7 +177,7 @@ See the full list of the actuator parameters you can set in the
 
 ### For RayClusters on Kubernetes/OpenShift
 
->[!TIP]
+> [!TIP]
 >
 > If your remote RayCluster is not hosted on Kubernetes or OpenShift, you can
 > skip this step.
@@ -183,6 +189,7 @@ experiments finish.
 For example, if the name of your RayCluster is `ray-disorch`, run:
 
 <!-- markdownlint-disable-next-line code-block-style -->
+
 ```commandline
 kubectl port-forward svc/ray-disorch-head-svc 8265
 ```
@@ -210,6 +217,7 @@ You have two options for installing the required packages:
 In this section, we’ll focus on the second approach.
 
 <!-- markdownlint-disable code-block-style -->
+
 === "Use the SFTTrainer plugin wheel from PyPi"
 
     Create the `ray_runtime_env.yaml` file under the directory
@@ -283,6 +291,7 @@ In this section, we’ll focus on the second approach.
     ```
 
     [Reference docs on using ado with remote RayClusters](../../getting-started/remote_run/).
+
 <!-- markdownlint-enable code-block-style -->
 
 You will use the files you created during this step in later steps when
@@ -295,7 +304,7 @@ a job on your remote RayCluster. This job will create the synthetic dataset and
 place it in the correct location under the directory specified by the
 `data_directory` parameter of the SFTTrainer actuator.
 
->[!INFO]
+> [!INFO]
 >
 > You can find instructions for generating the `.whl` and `ray_runtime_env.yaml`
 > files in the
@@ -306,11 +315,13 @@ To submit the job to your remote RayCluster run the command:
 
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line code-block-style -->
+
 ```commandline
 ray job submit --address http://localhost:8265 --runtime-env ray_runtime_env.yaml \
 --working-dir $PWD -v -- sfttrainer_generate_dataset_text \
 -o /data/fms-hf-tuning/artificial-dataset/news-tokens-16384plus-entries-4096.jsonl
 ```
+
 <!-- markdownlint-enable line-length -->
 
 [Reference docs on creating the datasets](../../actuators/sft-trainer/#creating-the-datasets)
@@ -326,6 +337,7 @@ First, save the following YAML to a file `models.yaml` inside your working
 directory (`my-remote-measurements`):
 
 <!-- markdownlint-disable-next-line code-block-style -->
+
 ```yaml
 granite-3.1-2b:
   Vanilla: ibm-granite/granite-3.1-2b-base
@@ -335,11 +347,13 @@ To submit the Ray job run:
 
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line code-block-style -->
+
 ```commandline
 ray job submit --address http://localhost:8265 --runtime-env ray_runtime_env.yaml \
 --working-dir $PWD -v -- \
 sfttrainer_download_hf_weights -i models.yaml -o /hf-models-pvc/huggingface_home
 ```
+
 <!-- markdownlint-enable line-length -->
 
 [Reference docs on pre-fetching weights](../../actuators/sft-trainer/#model-weights)
@@ -370,45 +384,47 @@ experiment.
 
 1. Create the file `space.yaml` with the contents:
 
-    <!-- markdownlint-disable-next-line code-block-style -->
-    ```yaml
-    experiments:
-      - experimentIdentifier: finetune_full_benchmark-v1.0.0
-        actuatorIdentifier: SFTTrainer
-        parameterization:
-          - property:
-              identifier: fms_hf_tuning_version
-            value: "3.0.0"
-          - property:
-              identifier: stop_after_seconds
-            # Set training duration to at least 30 seconds.
-            # For meaningful system metrics, we recommend a minimum of 300 seconds.
-            value: 30
+   <!-- markdownlint-disable-next-line code-block-style -->
 
-    entitySpace:
-      - identifier: "model_name"
-        propertyDomain:
-          values: ["granite-3.1-2b"]
-      - identifier: "number_gpus"
-        propertyDomain:
-          values: [1]
-      - identifier: "gpu_model"
-        propertyDomain:
-          values: ["NVIDIA-A100-SXM4-80GB"]
-      - identifier: "model_max_length"
-        propertyDomain:
-          values: [512, 1024]
-      - identifier: "batch_size"
-        propertyDomain:
-          values: [1, 2]
-    ```
+   ```yaml
+   experiments:
+     - experimentIdentifier: finetune_full_benchmark-v1.0.0
+       actuatorIdentifier: SFTTrainer
+       parameterization:
+         - property:
+             identifier: fms_hf_tuning_version
+           value: "3.0.0"
+         - property:
+             identifier: stop_after_seconds
+           # Set training duration to at least 30 seconds.
+           # For meaningful system metrics, we recommend a minimum of 300 seconds.
+           value: 30
+
+   entitySpace:
+     - identifier: "model_name"
+       propertyDomain:
+         values: ["granite-3.1-2b"]
+     - identifier: "number_gpus"
+       propertyDomain:
+         values: [1]
+     - identifier: "gpu_model"
+       propertyDomain:
+         values: ["NVIDIA-A100-SXM4-80GB"]
+     - identifier: "model_max_length"
+       propertyDomain:
+         values: [512, 1024]
+     - identifier: "batch_size"
+       propertyDomain:
+         values: [1, 2]
+   ```
 
 2. Create the space:
 
     <!-- markdownlint-disable-next-line code-block-style -->
-    ```commandline
-    ado create space -f space.yaml
-    ```
+
+   ```commandline
+   ado create space -f space.yaml
+   ```
 
    The space will use the `default` sample store.
 
@@ -416,58 +432,59 @@ experiment.
 
 1. Create the file `operation.yaml` with the following contents:
 
-    <!-- markdownlint-disable-next-line code-block-style -->
-    ```yaml
-    spaces:
-      - The identifier of the DiscoverySpace resource
-    actuatorConfigurationIdentifiers:
-      - The identifier of the Actuator Configuration resource
+   <!-- markdownlint-disable-next-line code-block-style -->
 
-    operation:
-      module:
-        operatorName: "random_walk"
-        operationType: "search"
-      parameters:
-        numberEntities: all
-        singleMeasurement: True
-        batchSize: 1 # you may increase this number if you have more than 1 GPU
-        samplerConfig:
-          mode: sequential
-          samplerType: generator
-    ```
+   ```yaml
+   spaces:
+     - The identifier of the DiscoverySpace resource
+   actuatorConfigurationIdentifiers:
+     - The identifier of the Actuator Configuration resource
+
+   operation:
+     module:
+       operatorName: "random_walk"
+       operationType: "search"
+     parameters:
+       numberEntities: all
+       singleMeasurement: True
+       batchSize: 1 # you may increase this number if you have more than 1 GPU
+       samplerConfig:
+         mode: sequential
+         samplerType: generator
+   ```
 
 2. Replace the placeholders with your `discoveryspace` ID and
-    `actuatorconfiguration` ID and save it in a file with the name
-    `operation.yaml`.
+   `actuatorconfiguration` ID and save it in a file with the name
+   `operation.yaml`.
 
-3. Export the `finetuning` context so you can supply it to the remote
-    operation.
+3. Export the `finetuning` context so you can supply it to the remote operation.
 
-    <!-- markdownlint-disable-next-line code-block-style -->
-    ```commandline
-    ado get context --output yaml finetuning > context.yaml
-    ```
+   <!-- markdownlint-disable-next-line code-block-style -->
 
-4. For the next step your `my-remote-measurements` directory needs the
-    following files, although the wheels may have different ids.
+   ```commandline
+   ado get context --output yaml finetuning > context.yaml
+   ```
 
-    <!-- markdownlint-disable-next-line code-block-style -->
-    ```terminaloutput
-    my-remote-measurements
-    ├── ado_core-1.1.0.dev133+f4b639c1.dirty-py3-none-any.whl
-    ├── context.yaml
-    ├── operation.yaml
-    ├── ray_runtime_env.yaml
-    └── ado_sfttrainer-1.1.0.dev133+gf4b639c10.d20250812-py3-none-any.whl
-    ```
+4. For the next step your `my-remote-measurements` directory needs the following
+   files, although the wheels may have different ids.
+
+   <!-- markdownlint-disable-next-line code-block-style -->
+
+   ```terminaloutput
+   my-remote-measurements
+   ├── ado_core-1.1.0.dev133+f4b639c1.dirty-py3-none-any.whl
+   ├── context.yaml
+   ├── operation.yaml
+   ├── ray_runtime_env.yaml
+   └── ado_sfttrainer-1.1.0.dev133+gf4b639c10.d20250812-py3-none-any.whl
+   ```
 
 5. Create the operation on the remote RayCluster
 
-Use the `.whl` and `ray_runtime_env.yaml` files to submit a job to your
-remote RayCluster which creates the `operation` that runs your finetuning
-measurements.
+Use the `.whl` and `ray_runtime_env.yaml` files to submit a job to your remote
+RayCluster which creates the `operation` that runs your finetuning measurements.
 
->[!NOTE]
+> [!NOTE]
 >
 > You can find instructions for generating the `.whl` and `ray_runtime_env.yaml`
 > files in the
@@ -478,11 +495,13 @@ Run the command:
 
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line code-block-style -->
+
 ```commandline
 ray job submit --no-wait --address http://localhost:8265  --working-dir . \
 --runtime-env ray_runtime_env.yaml -v -- \
 ado -c context.yaml create operation -f operation.yaml
 ```
+
 <!-- markdownlint-enable line-length -->
 
 The operation will execute the measurements (i.e. apply the experiment
@@ -493,11 +512,10 @@ The operation will execute the measurements (i.e. apply the experiment
 >
 > Each measurement finetunes the
 > [`granite-3.1-2b`](https://huggingface.co/ibm-granite/granite-3.1-2b-base)
-> model and takes about two minutes to complete.
-> There is a total of four measurements.
-> It will also take a couple of minutes for Ray to create the ray environment
-> on participating GPU worker nodes, so expect the `operation`
-> to take around 10 minutes to complete.
+> model and takes about two minutes to complete. There is a total of four
+> measurements. It will also take a couple of minutes for Ray to create the ray
+> environment on participating GPU worker nodes, so expect the `operation` to
+> take around 10 minutes to complete.
 
 [Reference docs for submitting ado operations to remote RayClusters](../../getting-started/remote_run).
 
@@ -506,17 +524,20 @@ The operation will execute the measurements (i.e. apply the experiment
 After the operation completes, you can retrieve the results of your
 measurements:
 
-<!-- markdownlint-disable-next-line code-block-style -->
+<!-- markdownlint-disable line-length -->
+
 ```commandline
-ado show entities --output csv --property-format=target space --use-latest > entities.csv
+ado show measurements --output csv --property-format=target space --use-latest > entities.csv
 ```
+
+<!-- markdownlint-enable line-length -->
 
 > [!NOTE]
 >
 > Notice that because the context we are using refers to a remote project we can
-> access the data created by the operation on the remote ray cluster. Anyone that
-> has access to the `finetuning` context can also retrieve the results of your
-> measurements!
+> access the data created by the operation on the remote ray cluster. Anyone
+> that has access to the `finetuning` context can also retrieve the results of
+> your measurements!
 
 The command will generate a CSV file. Open it to explore the data that your
 operation has collected!
@@ -525,6 +546,7 @@ It should look similar to this:
 
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line code-block-style -->
+
 ```csv
 ,identifier,generatorid,experiment_id,model_name,number_gpus,gpu_model,model_max_length,batch_size,gpu_compute_utilization_min,gpu_compute_utilization_avg,gpu_compute_utilization_max,gpu_memory_utilization_min,gpu_memory_utilization_avg,gpu_memory_utilization_max,gpu_memory_utilization_peak,gpu_power_watts_min,gpu_power_watts_avg,gpu_power_watts_max,gpu_power_percent_min,gpu_power_percent_avg,gpu_power_percent_max,cpu_compute_utilization,cpu_memory_utilization,train_runtime,train_samples_per_second,train_steps_per_second,dataset_tokens_per_second,dataset_tokens_per_second_per_gpu,is_valid
 0,model_name.granite-3.1-2b-number_gpus.1-gpu_model.NVIDIA-A100-SXM4-80GB-model_max_length.512-batch_size.2,explicit_grid_sample_generator,SFTTrainer.finetune_full_benchmark-v1.0.0-fms_hf_tuning_version.3.0.0-stop_after_seconds.30,granite-3.1-2b,1,NVIDIA-A100-SXM4-80GB,512,2,40.0,40.0,40.0,25.49774175,25.49774175,25.49774175,31.498108,169.3855,169.3855,169.3855,42.346375,42.346375,42.346375,74.075,2.6414139999999997,31.3457,130.672,16.334,2744.108442306281,2744.108442306281,1
@@ -532,6 +554,7 @@ It should look similar to this:
 2,model_name.granite-3.1-2b-number_gpus.1-gpu_model.NVIDIA-A100-SXM4-80GB-model_max_length.1024-batch_size.1,explicit_grid_sample_generator,SFTTrainer.finetune_full_benchmark-v1.0.0-fms_hf_tuning_version.3.0.0-stop_after_seconds.30,granite-3.1-2b,1,NVIDIA-A100-SXM4-80GB,1024,1,43.25,43.25,43.25,25.43853775,25.43853775,25.43853775,31.498108,181.79625,181.79625,181.79625,45.4490625,45.4490625,45.4490625,74.32499999999999,2.64201475,30.6802,133.506,33.377,2670.126009608803,2670.126009608803,1
 3,model_name.granite-3.1-2b-number_gpus.1-gpu_model.NVIDIA-A100-SXM4-80GB-model_max_length.1024-batch_size.2,explicit_grid_sample_generator,SFTTrainer.finetune_full_benchmark-v1.0.0-fms_hf_tuning_version.3.0.0-stop_after_seconds.30,granite-3.1-2b,1,NVIDIA-A100-SXM4-80GB,1024,2,63.75,63.75,63.75,25.67718525,25.67718525,25.67718525,31.737366,238.53825,238.53825,238.53825,59.6345625,59.6345625,59.6345625,74.1,2.6399939999999997,30.1566,135.824,16.978,5161.324552502603,5161.324552502603,1
 ```
+
 <!-- markdownlint-enable line-length -->
 
 In the above CSV file you will find 1 column per:
@@ -549,6 +572,7 @@ experiment in the SFTTrainer docs. The complete list of measured properties is
 
 ## Next steps
 
+<!-- prettier-ignore-start -->
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line no-inline-html -->
 <div class="grid cards" markdown>
@@ -563,3 +587,5 @@ experiment in the SFTTrainer docs. The complete list of measured properties is
 
 </div>
 <!-- markdownlint-enable line-length -->
+
+<!-- prettier-ignore-end -->

--- a/website/docs/examples/vllm-performance-endpoint.md
+++ b/website/docs/examples/vllm-performance-endpoint.md
@@ -167,7 +167,7 @@ ado show requests operation --use-latest
 and the results (this outputs the entities in sampled order):
 
 ```commandline
-ado show entities operation --use-latest
+ado show measurements operation --use-latest
 ```
 
 Instead of `--use-latest` you can also supply the operation id directly if you

--- a/website/docs/examples/vllm-performance-full.md
+++ b/website/docs/examples/vllm-performance-full.md
@@ -180,7 +180,7 @@ oc get deployments --watch -n vllm-testing
 You can also get the results table by executing (in another terminal)
 
 ```commandline
-ado show entities operation --use-latest
+ado show measurements operation --use-latest
 ```
 
 ### Check final results

--- a/website/docs/examples/vllm-performance-geospatial.md
+++ b/website/docs/examples/vllm-performance-geospatial.md
@@ -184,7 +184,7 @@ oc get deployments --watch -n vllm-testing
 You can also get the results table by executing (in another terminal):
 
 ```commandline
-ado show entities operation --use-latest
+ado show measurements operation --use-latest
 ```
 
 ### Check final results
@@ -192,7 +192,7 @@ ado show entities operation --use-latest
 When the experiment finishes, inspect all results with:
 
 ```commandline
-ado show entities space --output csv --use-latest > entities.csv
+ado show measurements space --output csv --use-latest > entities.csv
 ```
 
 ## Pre-packaged Datasets

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -787,21 +787,21 @@ ado show details space space-abc123-456def
 ado show details space --use-latest
 ```
 
-#### ado show entities
+#### ado show measurements
 
-_show entities_ supports displaying entities that belong to a space or an
-operation.
+_show measurements_ supports displaying measurement data (entities with their
+measured properties) that belong to a space or an operation.
 
-The complete syntax of the `ado show entities` command is as follows:
+The complete syntax of the `ado show measurements` command is as follows:
 
 ```shell
-ado show entities RESOURCE_TYPE [RESOURCE_ID] [--use-latest] [--file | -f <file.yaml>]\
-                  [--property-format {observed | target}] \
-                  [--output | -o {table | csv | json}] \
-                  [--output-file <path>] \
-                  [--property <property-name>] \
-                  [--include {sampled | matching | missing | unsampled}] \
-                  [--aggregate {mean | median | variance | std | min | max}]
+ado show measurements RESOURCE_TYPE [RESOURCE_ID] [--use-latest] [--file | -f <file.yaml>]\
+                      [--property-format {observed | target}] \
+                      [--output | -o {table | csv | json}] \
+                      [--output-file <path>] \
+                      [--property <property-name>] \
+                      [--include {sampled | matching | missing | unsampled}] \
+                      [--aggregate {mean | median | variance | std | min | max}]
 ```
 
 Where:
@@ -818,12 +818,12 @@ Where:
     <!-- prettier-ignore-end -->
 
 - `RESOURCE_ID` is the unique identifier of the resource you want to see
-  entities for.
+  measurements for.
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
   resource of RESOURCE_TYPE from the current context. It is ignored if a
   RESOURCE_ID is provided.
 - The `--file` (or `-f`) flag is **currently only available for spaces** and
-  enables showing entities that match the space defined in the configuration
+  enables showing measurements that match the space defined in the configuration
   file. **NOTE**: using this flag forces `--include matching`.
 - `--property-format` defines the naming format used for measured properties in
   the output, one of:
@@ -837,8 +837,8 @@ Where:
 
     <!-- prettier-ignore-end -->
 
-- `--output` (or `-o`) is the format in which to display the entity data. One
-  of:
+- `--output` (or `-o`) is the format in which to display the measurement data.
+  One of:
 
     <!-- prettier-ignore-start -->
 
@@ -885,41 +885,45 @@ Where:
 
 ##### Examples
 
-###### Show matching entities in a Space with target format and output them as CSV
+<!-- markdownlint-disable line-length -->
+
+###### Show matching measurements in a Space with target format and output them as CSV
+
+<!-- markdownlint-enable line-length -->
 
 Recommended approach using `--output-file` (ensures columns aren't truncated and
 handles file write errors):
 
 ```shell
- ado show entities space space-abc123-456def --include matching \
-                                             --property-format target \
-                                             -o csv --output-file entities.csv
+ ado show measurements space space-abc123-456def --include matching \
+                                                 --property-format target \
+                                                 -o csv --output-file entities.csv
 ```
 
 Or to write CSV to stdout for piping:
 
 ```shell
- ado show entities space space-abc123-456def --include matching \
-                                             --property-format target \
-                                             -o csv > entities.csv
+ ado show measurements space space-abc123-456def --include matching \
+                                                 --property-format target \
+                                                 -o csv > entities.csv
 ```
 
 <!-- markdownlint-disable line-length -->
 
-###### Show a subset of the properties of entities that are part of an operation and output them as JSON
+###### Show a subset of the properties of measurements that are part of an operation and output them as JSON
+
+```shell
+ado show measurements operation randomwalk-0.5.0-123abc -o json \
+                                                        --property my-property-1 \
+                                                        --property my-property-2
+```
 
 <!-- markdownlint-enable line-length -->
 
-```shell
-ado show entities operation randomwalk-0.5.0-123abc -o json \
-                                                    --property my-property-1 \
-                                                    --property my-property-2
-```
-
-###### Save table output of entities to a file
+###### Save table output of measurements to a file
 
 ```shell
-ado show entities space space-abc123-456def --output-file entities-table.txt
+ado show measurements space space-abc123-456def --output-file entities-table.txt
 ```
 
 #### ado show requests

--- a/website/docs/how-to/plugin-developers.md
+++ b/website/docs/how-to/plugin-developers.md
@@ -59,10 +59,8 @@ Based on your chosen strategy, follow the appropriate setup guide below.
 
 2. **Add `ado-core` as a dependency** in your plugin's `pyproject.toml` file:
 
-  
-
 3. **Install your dependencies**, including `ado-core` and your own plugin in
-    editable mode. 
+    editable mode.
 
         uv pip install -e path/to/your/<plugin-name>
 

--- a/website/docs/how-to/researchers.md
+++ b/website/docs/how-to/researchers.md
@@ -63,15 +63,16 @@ your behalf.
 
 !!! info
 
-  `uv sync` installs `ado` in editable mode along with all its
-  development and testing dependencies, creating the perfect environment for both
-  research and future plugin development.
+`uv sync` installs `ado` in editable mode along with all its development and
+testing dependencies, creating the perfect environment for both research and
+future plugin development.
 
 ### 2. Activate the Agent
 
 Simply open the cloned `ado` folder as the workspace root in your agent-enabled
-IDE. Many coding agents, include Claude, Cursor and Bob, should  automatically detect
-and load the skills. If your IDE doesn't create a link to `.cursor` for it.
+IDE. Many coding agents, include Claude, Cursor and Bob, should automatically
+detect and load the skills. If your IDE doesn't create a link to `.cursor` for
+it.
 
 ### 3. What Your Agent Can Do For You
 
@@ -110,8 +111,8 @@ Whether you choose the CLI path or the agent path, the core research process in
 4. **Execute:** Run the operation locally or on a
    [remote cluster](../getting-started/remote_run.md) with
    `ado create operation ...`
-5. **Analyze:** Examine data with `ado show entities`, run analysis `operators`
-   to get deeper insights, then refine and explore further
+5. **Analyze:** Examine data with `ado show measurements`, run analysis
+   `operators` to get deeper insights, then refine and explore further
 
 See [Core Concepts](../core-concepts/concepts.md) for a full explanation and our
 [Examples](../examples/examples.md) for end-to-end case studies.

--- a/website/docs/operators/explore_operators.md
+++ b/website/docs/operators/explore_operators.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable code-block-style -->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable first-line-h1 -->
+
 A core task is sampling and measuring `entities` from a `discoveryspace` and
 this is the objective of explore `operators`. In fact, other than copying data
 from an external source, `operations` using _explore_ `operators` are the only
@@ -16,7 +17,7 @@ sequence, hence there is an associated timeseries. This timeseries is recorded
 for every `explore` operation. To see it via `ado` CLI use:
 
 ```commandline
-ado show entities operation $OPERATION_IDENTIFIER
+ado show measurements operation $OPERATION_IDENTIFIER
 ```
 
 This will output a table of the entities in the order they were sampled during
@@ -26,6 +27,7 @@ You can access this information programmatically by modifying the following
 snippet:
 
 <!-- markdownlint-disable line-length -->
+
 ```python
 import yaml
 from orchestrator.core.discoveryspace.space import DiscoverySpace
@@ -41,6 +43,7 @@ space = DiscoverySpace.from_stored_configuration(project_context=c, space_identi
 space.complete_measurement_request_with_results_timeseries(operation_id="operation_abc123",
                                                            limit_to_properties=["someexperiment.someproperty"])
 ```
+
 <!-- markdownlint-enable line-length -->
 
 Importantly, the same entity can be visited by multiple different `operations`.
@@ -68,11 +71,11 @@ A core goal of `ado` is transparent data-sharing. This is enabled via the
 [common context provided by `samplestores`](../resources/sample-stores.md) and
 the schema used to store `entities`.
 
-To leverage this data-sharing capability explore operations will, by default, not
-re-measure an entity they sample if it already has data for that measurement.
-For example, an explore operation samples an entity from a space whose
-`measurementspace` includes an experiment called "myexperiment-v1". If it sees
-the entity has values for experiment `myexperiment-v1`, it won't execute it
+To leverage this data-sharing capability explore operations will, by default,
+not re-measure an entity they sample if it already has data for that
+measurement. For example, an explore operation samples an entity from a space
+whose `measurementspace` includes an experiment called "myexperiment-v1". If it
+sees the entity has values for experiment `myexperiment-v1`, it won't execute it
 again, instead it replays it, a feature called **memoization**.
 
 This means if a different user sampled and measured this entity with this
@@ -81,13 +84,13 @@ execution time.
 
 Explore operators should allow turning memoization on and off.
 
-If memoization is off, the entity will be re-measured with the
-experiment and it will have two values for each
+If memoization is off, the entity will be re-measured with the experiment and it
+will have two values for each
 [observed property](../core-concepts/actuators.md#target-and-observed-properties)
-of that experiment. Going back to our example above, if `myexperiment-v1` was executed
-again, and it measured properties `prop1` and `prop2`, then the entity will have
-two values for `myexperiment-v1.prop1` and `myexperiment-v1.prop2`, one from
-each time the experiment was applied to that entity.
+of that experiment. Going back to our example above, if `myexperiment-v1` was
+executed again, and it measured properties `prop1` and `prop2`, then the entity
+will have two values for `myexperiment-v1.prop1` and `myexperiment-v1.prop2`,
+one from each time the experiment was applied to that entity.
 
 What if you switch it on but an entity has multiple measurements of the same
 experiment? In this case _each existing measurement is replayed_. In our
@@ -97,7 +100,8 @@ replayed: the first and the second.
 
 > [!NOTE]
 >
-> See [Shared Sample Stores: Memoization](../core-concepts/data-sharing.md#memoization)
+> See
+> [Shared Sample Stores: Memoization](../core-concepts/data-sharing.md#memoization)
 > for further details on how memoization works at storage-level
 
 ### Failed measurements
@@ -121,10 +125,12 @@ When an explore operation finishes, the system (top-level) metadata field of the
 associated `operation` resource is updated with the following fields.
 
 <!-- markdownlint-disable line-length -->
+
 ```python
 entities_submitted: #The number of entities sampled from the space
 experiments_requested: #The number of experiments requested - should be (number of experiments in measurement space)*entitiesSampled
 ```
+
 <!-- markdownlint-enable line-length -->
 
 Example from a completed random walk `operation`:
@@ -173,8 +179,8 @@ added, and some fraction of the requested entities will have been sampled. Some
 
 Commands that reflect changing state during an `operation`:
 
-- `ado show entities space`
-- `ado show entities operation`
+- `ado show measurements space`
+- `ado show measurements operation`
 - `ado show details space`
 
 Commands that do not reflect changing state during an `operation`:

--- a/website/docs/operators/optimisation-with-ray-tune.md
+++ b/website/docs/operators/optimisation-with-ray-tune.md
@@ -42,7 +42,8 @@ Using RayTune via the ado `ray_tune` operator brings the following advantages:
 
 - Distributed storage and sharing of optimization runs and their results
 - Automatic recording of provenance
-- Transparent and distributed [memoization](../core-concepts/data-sharing.md#memoization)
+- Transparent and distributed
+  [memoization](../core-concepts/data-sharing.md#memoization)
 - Fully declarative interface, no need for programming
 
 However, there are a few drawbacks:
@@ -645,7 +646,7 @@ To see all the configurations (entities) visited during an optimization
 operation $OPERATION_IDENTIFIER run
 
 ```commandline
-ado show entities operation $OPERATION_IDENTIFIER
+ado show measurements operation $OPERATION_IDENTIFIER
 ```
 
 !!! info end

--- a/website/docs/operators/random-walk.md
+++ b/website/docs/operators/random-walk.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable code-block-style -->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable first-line-h1 -->
+
 ## Overview
 
 > [!TIP]
@@ -26,8 +27,8 @@ Use the `random_walk` operator when you want to:
 
 The `random_walk` operator supports
 [memoization](../core-concepts/data-sharing.md#memoization): if it samples the
-same entity twice, and that entity has already had the measurement space applied,
-it will replay the already measured values (by default).
+same entity twice, and that entity has already had the measurement space
+applied, it will replay the already measured values (by default).
 
 ### What happens if I apply multiple `random_walk` operations to a space?
 
@@ -133,8 +134,8 @@ system for (N-1) additional entities to be measured but it will not be used.
 
 ### Batch Size and Concurrent Experiments
 
-When it comes to managing resources during an exploration, the key variable
-to control is the number of concurrent experiments.
+When it comes to managing resources during an exploration, the key variable to
+control is the number of concurrent experiments.
 
 For the `random_walk` operator, this number is its `batchSize` parameter (the
 number of initial entities submitted) multiplied by the number of experiments in
@@ -311,8 +312,7 @@ spaces:
 
 ## Custom Samplers
 
-`random_walk` can also use custom samplers for
-more complex sampling schemes.
+`random_walk` can also use custom samplers for more complex sampling schemes.
 
 For custom samplers the `samplerConfig` field has the following structure:
 
@@ -346,19 +346,19 @@ space:
 - **`sobol`**: Sobol sequences are low-discrepancy quasi-random sequences widely
   used for space-filling designs. They provide better coverage than pure random
   sampling by ensuring points are well-distributed across all dimensions.
-- **`clhs`**: Concatenated Latin Hypercube Sampling (CLHS) samples each dimension
-  independently without replacement, cycling through all values before repeating.
-  This ensures each dimension is uniformly covered.
+- **`clhs`**: Concatenated Latin Hypercube Sampling (CLHS) samples each
+  dimension independently without replacement, cycling through all values before
+  repeating. This ensures each dimension is uniformly covered.
 
-**Collision Handling**: Sobol sampling may produce collisions (duplicate points),
-when this happens the sampler automatically falls back to CLHS to ensure
-the requested number of unique samples.
+**Collision Handling**: Sobol sampling may produce collisions (duplicate
+points), when this happens the sampler automatically falls back to CLHS to
+ensure the requested number of unique samples.
 
 ##### Example: Sobol Sampling
 
-Here we write an example using Sobol ordering for quasi-random
-low-discrepancy coverage. Make sure to install the TRIM package first.
-Then install TRIM custom experiments with
+Here we write an example using Sobol ordering for quasi-random low-discrepancy
+coverage. Make sure to install the TRIM package first. Then install TRIM custom
+experiments with
 
 ```bash
 pip install examples/trim/custom_experiments/
@@ -390,15 +390,15 @@ samplerConfig:
     sampling_strategy: sobol
 ```
 
-Since `batchSize: 1` the operation will sample one point at a time, this
-ensures that the sequence of measurements has the desired uniform coverage
+Since `batchSize: 1` the operation will sample one point at a time, this ensures
+that the sequence of measurements has the desired uniform coverage
 
 ```bash
-ado show entities operation --use-latest  -o csv --output-file your_file.csv
+ado show measurements operation --use-latest  -o csv --output-file your_file.csv
 ```
 
-The file `your_file.csv` will contain the sequence of sampled points, you
-will see something like this:
+The file `your_file.csv` will contain the sequence of sampled points, you will
+see something like this:
 
 <!-- markdownlint-disable line-length -->
 
@@ -476,17 +476,16 @@ which can take the following values:
 
 ## Memoization: Reusing existing measurements
 
-If `singleMeasurement:` is False, all experiments are applied to
-ALL entities sampled, even if they already have the results for that
-experiment.
+If `singleMeasurement:` is False, all experiments are applied to ALL entities
+sampled, even if they already have the results for that experiment.
 
 By setting `singleMeasurement:` to True (the default) a random walk operation
-will check if an experiment has already been applied to an entity and,
-if it has, reuse a.k.a. replay, the result.
+will check if an experiment has already been applied to an entity and, if it
+has, reuse a.k.a. replay, the result.
 
 If the entity has multiple results for the same experiment, each one will be
-replayed.
-See [replayed measurements](explore_operators.md#memoization-replaying-measurements)
+replayed. See
+[replayed measurements](explore_operators.md#memoization-replaying-measurements)
 for more details.
 
 ## Retrying Failed Measurements
@@ -541,6 +540,7 @@ request index 5 has been retried 2 times.
 
 ## What's next
 
+<!-- prettier-ignore-start -->
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable-next-line no-inline-html -->
 <div class="grid cards" markdown>
@@ -563,3 +563,5 @@ request index 5 has been retried 2 times.
 
 </div>
 <!-- markdownlint-enable line-length -->
+
+<!-- prettier-ignore-end -->

--- a/website/docs/operators/trim.md
+++ b/website/docs/operators/trim.md
@@ -499,7 +499,7 @@ Balanced approach for production use:
 To see the entities sampled during a TRIM operation:
 
 ```bash
-ado show entities operation $OPERATION_IDENTIFIER
+ado show measurements operation $OPERATION_IDENTIFIER
 ```
 
 This displays entities in the order they were sampled, showing the progression
@@ -575,7 +575,7 @@ target output property, if this is not the case TRIM raises
 the space with the following command
 
 ```terminal
-ado show entities --use-latest space
+ado show measurements --use-latest space
 ```
 
 Looking at the output you will find out if the target output property
@@ -597,7 +597,7 @@ you see on your terminal. To facilitate the detection of the column, you can run
 the same command with a property filter:
 
 ```terminal
-ado show entities --use-latest space --property [targetOutput]
+ado show measurements --use-latest space --property [targetOutput]
 ```
 
 Here, remember to replace `"[targetOutput]"` with `targetOutput`.

--- a/website/docs/operators/working-with-operators.md
+++ b/website/docs/operators/working-with-operators.md
@@ -1,13 +1,13 @@
 <!-- markdownlint-disable code-block-style -->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable first-line-h1 -->
+
 An `operator` is a code module that provides a capability to perform an
 `operation` on a `discoveryspace`. For example the `RandomWalk` operator
 provides the capability to perform a random walk `operation` on a
 `discoveryspace`.
 
-The pages in this section give details about some of
-the operators available in `ado`: what they are for, what they do and how to use
-them.
+The pages in this section give details about some of the operators available in
+`ado`: what they are for, what they do and how to use them.
 
 !!! info end
 
@@ -63,7 +63,8 @@ Using an operator involves the following steps:
    - `ado create operation -f $YAML`
 4. Retrieve the results of the operation:
    - `ado show related $OPERATION_IDENTIFIER`
-   - in addition `ado show entities $OPERATION_IDENTIFIER` for explore operations
+   - in addition `ado show measurements $OPERATION_IDENTIFIER` for explore
+     operations
 
 These steps are covered in detail in [operations](../resources/operation.md).
 

--- a/website/docs/resources/discovery-spaces.md
+++ b/website/docs/resources/discovery-spaces.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable code-block-style -->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable first-line-h1 -->
+
 !!! info end
 
     If you are not familiar with the concept of a Discovery Space check [here](../core-concepts/discovery-spaces.md)
@@ -126,7 +127,7 @@ The `show` command is used to show things related to a resource. In this case we
 want to show the entities related to a `discoveryspace` so we use:
 
 ```commandline
-ado show entities space
+ado show measurements space
 ```
 
 By default, this will output the entities as a table. There are various option
@@ -141,7 +142,7 @@ If you want to use filter (2) - `entities` in the `samplestore` that match the
 `discoveryspace` - use:
 
 ```commandline
-ado show entities space --include matching
+ado show measurements space --include matching
 ```
 
 !!! info end
@@ -183,8 +184,8 @@ table = space.matchingEntitiesTable()
     For the conceptual distinction between target and observed properties see
     [Target and Observed Properties](../core-concepts/actuators.md#target-and-observed-properties).
 
-There are two formats the entities can be output controlled by the
-`--property-format` option to `show entities`
+There are two formats the measurements can be output controlled by the
+`--property-format` option to `show measurements`
 
 The observed format outputs one row per entity. The columns are constitutive
 property names and the observed property names i.e. they include both the
@@ -251,547 +252,549 @@ ado describe experiment finetune_full_benchmark-v1.0.0 --actuator-id SFTTrainer
 you will get output like
 
 <!-- markdownlint-disable line-length -->
+
 ```terminaloutput
 Identifier: SFTTrainer.finetune_full_benchmark-v1.0.0
-Description: Measures the performance of full-finetuning a model for a given (GPU model, number GPUS, batch_size, 
+Description: Measures the performance of full-finetuning a model for a given (GPU model, number GPUS, batch_size,
 model_max_length, number nodes) combination.
 
 Required Inputs:
-                                                                                                           
-   Constitutive Properties:                                                                                
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: model_name                                                                                
-     Description: The huggingface name or path to the model                                                
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [                                                                                          
-            'allam-1-13b',                                                                                 
-            'granite-13b-v2',                                                                              
-            'granite-20b-v2',                                                                              
-            'granite-3-8b',                                                                                
-            'granite-3.0-1b-a400m-base',                                                                   
-            'granite-3.1-2b',                                                                              
-            'granite-3.1-3b-a800m-instruct',                                                               
-            'granite-3.1-8b-instruct',                                                                     
-            'granite-3.3-8b',                                                                              
-            'granite-34b-code-base',                                                                       
-            'granite-3b-1.5',                                                                              
-            'granite-3b-code-base-128k',                                                                   
-            'granite-4.0-1b',                                                                              
-            'granite-4.0-350m',                                                                            
-            'granite-4.0-h-1b',                                                                            
-            'granite-4.0-h-micro',                                                                         
-            'granite-4.0-h-small',                                                                         
-            'granite-4.0-h-tiny',                                                                          
-            'granite-4.0-micro',                                                                           
-            'granite-7b-base',                                                                             
-            'granite-8b-code-base',                                                                        
-            'granite-8b-code-base-128k',                                                                   
-            'granite-8b-code-instruct',                                                                    
-            'granite-8b-japanese',                                                                         
-            'granite-vision-3.2-2b',                                                                       
-            'hf-tiny-model-private/tiny-random-BloomForCausalLM',                                          
-            'llama-13b',                                                                                   
-            'llama-7b',                                                                                    
-            'llama2-70b',                                                                                  
-            'llama3-70b',                                                                                  
-            'llama3-8b',                                                                                   
-            'llama3.1-405b',                                                                               
-            'llama3.1-70b',                                                                                
-            'llama3.1-8b',                                                                                 
-            'llama3.2-1b',                                                                                 
-            'llama3.2-3b',                                                                                 
-            'llava-v1.6-mistral-7b',                                                                       
-            'mistral-123b-v2',                                                                             
-            'mistral-7b-v0.1',                                                                             
-            'mixtral-8x7b-instruct-v0.1',                                                                  
-            'smollm2-135m'                                                                                 
-        ]                                                                                                  
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: model_max_length                                                                          
-     Description: The maximum context size. Dataset entries with more tokens they are truncated. Entri     
-     are padded                                                                                            
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 131073]                                                                                 
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: batch_size                                                                                
-     Description: The total batch size to use                                                              
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 4097]                                                                                   
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: number_gpus                                                                               
-     Description: The total number of GPUs to use                                                          
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [0, 33]                                                                                     
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-                                                                                                           
+
+   Constitutive Properties:
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: model_name
+     Description: The huggingface name or path to the model
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            'allam-1-13b',
+            'granite-13b-v2',
+            'granite-20b-v2',
+            'granite-3-8b',
+            'granite-3.0-1b-a400m-base',
+            'granite-3.1-2b',
+            'granite-3.1-3b-a800m-instruct',
+            'granite-3.1-8b-instruct',
+            'granite-3.3-8b',
+            'granite-34b-code-base',
+            'granite-3b-1.5',
+            'granite-3b-code-base-128k',
+            'granite-4.0-1b',
+            'granite-4.0-350m',
+            'granite-4.0-h-1b',
+            'granite-4.0-h-micro',
+            'granite-4.0-h-small',
+            'granite-4.0-h-tiny',
+            'granite-4.0-micro',
+            'granite-7b-base',
+            'granite-8b-code-base',
+            'granite-8b-code-base-128k',
+            'granite-8b-code-instruct',
+            'granite-8b-japanese',
+            'granite-vision-3.2-2b',
+            'hf-tiny-model-private/tiny-random-BloomForCausalLM',
+            'llama-13b',
+            'llama-7b',
+            'llama2-70b',
+            'llama3-70b',
+            'llama3-8b',
+            'llama3.1-405b',
+            'llama3.1-70b',
+            'llama3.1-8b',
+            'llama3.2-1b',
+            'llama3.2-3b',
+            'llava-v1.6-mistral-7b',
+            'mistral-123b-v2',
+            'mistral-7b-v0.1',
+            'mixtral-8x7b-instruct-v0.1',
+            'smollm2-135m'
+        ]
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: model_max_length
+     Description: The maximum context size. Dataset entries with more tokens they are truncated. Entri
+     are padded
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 131073]
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: batch_size
+     Description: The total batch size to use
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 4097]
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: number_gpus
+     Description: The total number of GPUs to use
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [0, 33]
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+
 Optional Inputs and Default Values:
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: max_steps                                                                                 
-     Description: The number of optimization steps to perform. Set to -1 to respect num_train_epochs i     
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [-1, 10001]                                                                                 
-                                                                                                           
-     Default value: -1                                                                                     
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: num_train_epochs                                                                          
-     Description: How many epochs to run. Ignored if max_steps is greater than 0                           
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1.0, 10001.0]                                                                              
-                                                                                                           
-     Default value: 1.0                                                                                    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: stop_after_seconds                                                                        
-     Description: If set, the optimizer will be asked to stop after the specified time elapses. The ch     
-     performed after the end of each training step.                                                        
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [-1.0, 1000001.0]                                                                           
-                                                                                                           
-     Default value: -1.0                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: dataset_id                                                                                
-     Description: The identifier of the dataset to use for training                                        
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [                                                                                          
-            'news-chars-1024-entries-1024',                                                                
-            'news-chars-1024-entries-256',                                                                 
-            'news-chars-1024-entries-4096',                                                                
-            'news-chars-2048-entries-1024',                                                                
-            'news-chars-2048-entries-256',                                                                 
-            'news-chars-2048-entries-4096',                                                                
-            'news-chars-512-entries-1024',                                                                 
-            'news-chars-512-entries-256',                                                                  
-            'news-chars-512-entries-4096',                                                                 
-            'news-tokens-128kplus-entries-320',                                                            
-            'news-tokens-128kplus-entries-4096',                                                           
-            'news-tokens-16384plus-entries-4096',                                                          
-            'vision-384x384-16384plus-entries-4096',                                                       
-            'vision-384x768-16384plus-entries-4096'                                                        
-        ]                                                                                                  
-                                                                                                           
-     Default value: 'news-tokens-16384plus-entries-4096'                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: gradient_checkpointing                                                                    
-     Description: If True, use gradient checkpointing to save memory (i.e. higher batchsizes) at the e     
-     slower backward pass                                                                                  
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [True, False]                                                                              
-                                                                                                           
-     Default value: 1                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: torch_dtype                                                                               
-     Description: The torch datatype to use                                                                
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['bfloat16', 'float16', 'float32']                                                         
-                                                                                                           
-     Default value: 'bfloat16'                                                                             
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: gradient_accumulation_steps                                                               
-     Description: Number of update steps to accumulate before performing a backward/update pass.           
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 33]                                                                                     
-                                                                                                           
-     Default value: 4                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: auto_stop_method                                                                          
-     Description: The default value is `None`. This parameter defines the method used to automatically     
-     fine-tuning job. Supported values are `WARMUP_60S_STABLE_120S_OR_10_STEPS` and `None`. If set to      
-     `WARMUP_60S_STABLE_120S_OR_10_STEPS`, the job stops after spending at least 60 seconds in the         
-     warmup phase plus the longer of 120 seconds or the duration of 10 optimization steps. This method     
-     excludes the first 60 seconds of training when calculating throughput and system metrics.             
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['WARMUP_60S_STABLE_120S_OR_10_STEPS', None]                                               
-                                                                                                           
-     Default value: None                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: r                                                                                         
-     Description: The LORA rank                                                                            
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 33]                                                                                     
-                                                                                                           
-     Default value: 4                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: lora_alpha                                                                                
-     Description: LORA Alpha scales the learning weights                                                   
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 33]                                                                                     
-                                                                                                           
-     Default value: 16                                                                                     
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: fast_moe                                                                                  
-     Description: Configures the amount of expert parallel sharding. number_gpus must be divisible by      
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [0, 33]                                                                                     
-                                                                                                           
-     Default value: 0                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: fast_kernels                                                                              
-     Description: Switches on fast kernels, the value is a list with strings of boolean values for [fa     
-     fast_rms_layernorm, fast_rope_embeddings]                                                             
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [None, ['True', 'True', 'True']]                                                           
-                                                                                                           
-     Default value: None                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: optim                                                                                     
-     Description: The optimizer to use.                                                                    
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [                                                                                          
-            'adamw_hf',                                                                                    
-            'adamw_torch',                                                                                 
-            'adamw_torch_fused',                                                                           
-            'adamw_torch_xla',                                                                             
-            'adamw_torch_npu_fused',                                                                       
-            'adamw_apex_fused',                                                                            
-            'adafactor',                                                                                   
-            'adamw_anyprecision',                                                                          
-            'adamw_torch_4bit',                                                                            
-            'ademamix',                                                                                    
-            'sgd',                                                                                         
-            'adagrad',                                                                                     
-            'adamw_bnb_8bit',                                                                              
-            'adamw_8bit',                                                                                  
-            'ademamix_8bit',                                                                               
-            'lion_8bit',                                                                                   
-            'lion_32bit',                                                                                  
-            'paged_adamw_32bit',                                                                           
-            'paged_adamw_8bit',                                                                            
-            'paged_ademamix_32bit',                                                                        
-            'paged_ademamix_8bit',                                                                         
-            'paged_lion_32bit',                                                                            
-            'paged_lion_8bit',                                                                             
-            'rmsprop',                                                                                     
-            'rmsprop_bnb',                                                                                 
-            'rmsprop_bnb_8bit',                                                                            
-            'rmsprop_bnb_32bit',                                                                           
-            'galore_adamw',                                                                                
-            'galore_adamw_8bit',                                                                           
-            'galore_adafactor',                                                                            
-            'galore_adamw_layerwise',                                                                      
-            'galore_adamw_8bit_layerwise',                                                                 
-            'galore_adafactor_layerwise',                                                                  
-            'lomo',                                                                                        
-            'adalomo',                                                                                     
-            'grokadamw',                                                                                   
-            'schedule_free_adamw',                                                                         
-            'schedule_free_sgd'                                                                            
-        ]                                                                                                  
-                                                                                                           
-     Default value: 'adamw_torch'                                                                          
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: bf16                                                                                      
-     Description: Whether to use bf16 (mixed) precision instead of 32-bit. Requires Ampere or higher N     
-     bf16 mixed precision support for NPU architecture or using CPU (use_cpu) or Ascend NPU. This is       
-     an experimental API and it may change.                                                                
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [False, True]                                                                              
-                                                                                                           
-     Default value: 0                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: gradient_checkpointing_use_reentrant                                                      
-     Description: Specify whether to use the activation checkpoint variant that requires reentrant aut     
-     parameter should be passed explicitly. Torch version 2.5 will raise an exception if use_reentrant     
-     is not passed. If use_reentrant=False, checkpoint will use an implementation that does not            
-     require reentrant autograd. This allows checkpoint to support additional functionality, such as       
-     working as expected with torch.autograd.grad and support for keyword arguments input into the         
-     checkpointed function.                                                                                
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [False, True]                                                                              
-                                                                                                           
-     Default value: 0                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: dataset_text_field                                                                        
-     Description: Training dataset text field containing single sequence. Either the dataset_text_fiel     
-     data_formatter_template need to be supplied. For running vision language model tuning pass the        
-     column name for text data.                                                                            
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['output', 'messages']                                                                     
-                                                                                                           
-     Default value: 'output'                                                                               
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: dataset_image_field                                                                       
-     Description: For running vision language model tuning pass the column name of the image data in t     
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [None, 'images']                                                                           
-                                                                                                           
-     Default value: None                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: remove_unused_columns                                                                     
-     Description: Remove columns not required by the model when using an nlp.Dataset.                      
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [True, False]                                                                              
-                                                                                                           
-     Default value: 1                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: dataset_kwargs_skip_prepare_dataset                                                       
-     Description: When True, configures trl to skip preparing the dataset.                                 
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [True, False]                                                                              
-                                                                                                           
-     Default value: 0                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: flash_attn                                                                                
-     Description: Use Flash attention v2 from transformers                                                 
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [True, False]                                                                              
-                                                                                                           
-     Default value: 1                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: gpu_model                                                                                 
-     Description: The GPU model to use                                                                     
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [                                                                                          
-            None,                                                                                          
-            'NVIDIA-A100-SXM4-80GB',                                                                       
-            'NVIDIA-A100-80GB-PCIe',                                                                       
-            'Tesla-T4',                                                                                    
-            'L40S',                                                                                        
-            'Tesla-V100-PCIE-16GB',                                                                        
-            'NVIDIA-H100-PCIe',                                                                            
-            'NVIDIA-H100-80GB-HBM3'                                                                        
-        ]                                                                                                  
-                                                                                                           
-     Default value: None                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: distributed_backend                                                                       
-     Description: Which pytorch backend to use when training with multiple GPU devices                     
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['DDP', 'FSDP', 'None']                                                                    
-                                                                                                           
-     Default value: 'FSDP'                                                                                 
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: number_nodes                                                                              
-     Description: If set, actuator distributes tasks on multiple nodes. Each Node will use number_gpus     
-     GPUs. Each Node will use 1 process for each GPU it uses                                               
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 9]                                                                                      
-                                                                                                           
-     Default value: 1                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: fms_hf_tuning_version                                                                     
-     Description: The version of fms-hf-tuning to use - controls which wrapper to use as well as python     
-     dependencies                                                                                          
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [                                                                                          
-            '2.0.1',                                                                                       
-            '2.1.0',                                                                                       
-            '2.1.1',                                                                                       
-            '2.1.2',                                                                                       
-            '2.2.1',                                                                                       
-            '2.3.1',                                                                                       
-            '2.4.0',                                                                                       
-            '2.5.0',                                                                                       
-            '2.6.0',                                                                                       
-            '2.7.1',                                                                                       
-            '2.8.2',                                                                                       
-            '3.0.0',                                                                                       
-            '3.0.0.1',                                                                                     
-            '3.1.0'                                                                                        
-        ]                                                                                                  
-                                                                                                           
-     Default value: '2.1.2'                                                                                
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: enable_roce                                                                               
-     Description: This setting is only in effect for multi-node runs. It controls whether RDMA over Co     
-     Ethernet (RoCE) is switched on or not                                                                 
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [False, True]                                                                              
-                                                                                                           
-     Default value: 0                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: fsdp_sharding_strategy                                                                    
-     Description: [1] FULL_SHARD (shards optimizer states, gradients and parameters), [2] SHARD_GRAD_O     
-     optimizer states and gradients), [3] NO_SHARD (DDP), [4] HYBRID_SHARD (shards optimizer states,       
-     gradients and parameters within each node while each node has full copy - equivalent to               
-     FULL_SHARD for single-node runs), [5] HYBRID_SHARD_ZERO2 (shards optimizer states and gradients       
-     within each node while each node has full copy). For more information, please refer the official      
-     PyTorch docs.                                                                                         
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['FULL_SHARD', 'SHARD_GRAD_OP', 'NO_SHARD', 'HYBRID_SHARD', 'HYBRID_SHARD_ZERO2']          
-                                                                                                           
-     Default value: 'FULL_SHARD'                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: fsdp_state_dict_type                                                                      
-     Description: [1] FULL_STATE_DICT, [2] LOCAL_STATE_DICT, [3] SHARDED_STATE_DICT                        
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['FULL_STATE_DICT', 'LOCAL_STATE_DICT', 'SHARDED_STATE_DICT']                              
-                                                                                                           
-     Default value: 'FULL_STATE_DICT'                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: fsdp_use_orig_params                                                                      
-     Description: If True, allows non-uniform `requires_grad` during init, which means support for int     
-     frozen and trainable parameters. (useful only when `use_fsdp` flag is passed).                        
-     Domain:                                                                                               
-                                                                                                           
-        Type: BINARY_VARIABLE_TYPE                                                                         
-        Values: [False, True]                                                                              
-                                                                                                           
-     Default value: 1                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: accelerate_config_mixed_precision                                                         
-     Description: Whether or not to use mixed precision training. Choose from 'no', 'fp16', 'bf16' or      
-     requires the installation of transformers-engine.                                                     
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['no', 'fp16', 'bf16', 'fp8']                                                              
-                                                                                                           
-     Default value: 'no'                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: accelerate_config_fsdp_transformer_layer_cls_to_wrap                                      
-     Description: List of transformer layer class names (case-sensitive) to wrap, e.g, BertLayer,          
-     GraniteDecoderLayer, GPTJBlock, T5Block ... (useful only when using FSDP)                             
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: [                                                                                          
-            None,                                                                                          
-            'GraniteDecoderLayer',                                                                         
-            'LlamaDecoderLayer',                                                                           
-            'MistralDecoderLayer',                                                                         
-            'GPTJBlock',                                                                                   
-            'T5Block'                                                                                      
-        ]                                                                                                  
-                                                                                                           
-     Default value: None                                                                                   
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-                                                                                                           
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: max_steps
+     Description: The number of optimization steps to perform. Set to -1 to respect num_train_epochs i
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [-1, 10001]
+
+     Default value: -1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: num_train_epochs
+     Description: How many epochs to run. Ignored if max_steps is greater than 0
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1.0, 10001.0]
+
+     Default value: 1.0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: stop_after_seconds
+     Description: If set, the optimizer will be asked to stop after the specified time elapses. The ch
+     performed after the end of each training step.
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [-1.0, 1000001.0]
+
+     Default value: -1.0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: dataset_id
+     Description: The identifier of the dataset to use for training
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            'news-chars-1024-entries-1024',
+            'news-chars-1024-entries-256',
+            'news-chars-1024-entries-4096',
+            'news-chars-2048-entries-1024',
+            'news-chars-2048-entries-256',
+            'news-chars-2048-entries-4096',
+            'news-chars-512-entries-1024',
+            'news-chars-512-entries-256',
+            'news-chars-512-entries-4096',
+            'news-tokens-128kplus-entries-320',
+            'news-tokens-128kplus-entries-4096',
+            'news-tokens-16384plus-entries-4096',
+            'vision-384x384-16384plus-entries-4096',
+            'vision-384x768-16384plus-entries-4096'
+        ]
+
+     Default value: 'news-tokens-16384plus-entries-4096'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: gradient_checkpointing
+     Description: If True, use gradient checkpointing to save memory (i.e. higher batchsizes) at the e
+     slower backward pass
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [True, False]
+
+     Default value: 1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: torch_dtype
+     Description: The torch datatype to use
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['bfloat16', 'float16', 'float32']
+
+     Default value: 'bfloat16'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: gradient_accumulation_steps
+     Description: Number of update steps to accumulate before performing a backward/update pass.
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 33]
+
+     Default value: 4
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: auto_stop_method
+     Description: The default value is `None`. This parameter defines the method used to automatically
+     fine-tuning job. Supported values are `WARMUP_60S_STABLE_120S_OR_10_STEPS` and `None`. If set to
+     `WARMUP_60S_STABLE_120S_OR_10_STEPS`, the job stops after spending at least 60 seconds in the
+     warmup phase plus the longer of 120 seconds or the duration of 10 optimization steps. This method
+     excludes the first 60 seconds of training when calculating throughput and system metrics.
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['WARMUP_60S_STABLE_120S_OR_10_STEPS', None]
+
+     Default value: None
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: r
+     Description: The LORA rank
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 33]
+
+     Default value: 4
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: lora_alpha
+     Description: LORA Alpha scales the learning weights
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 33]
+
+     Default value: 16
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: fast_moe
+     Description: Configures the amount of expert parallel sharding. number_gpus must be divisible by
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [0, 33]
+
+     Default value: 0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: fast_kernels
+     Description: Switches on fast kernels, the value is a list with strings of boolean values for [fa
+     fast_rms_layernorm, fast_rope_embeddings]
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [None, ['True', 'True', 'True']]
+
+     Default value: None
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: optim
+     Description: The optimizer to use.
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            'adamw_hf',
+            'adamw_torch',
+            'adamw_torch_fused',
+            'adamw_torch_xla',
+            'adamw_torch_npu_fused',
+            'adamw_apex_fused',
+            'adafactor',
+            'adamw_anyprecision',
+            'adamw_torch_4bit',
+            'ademamix',
+            'sgd',
+            'adagrad',
+            'adamw_bnb_8bit',
+            'adamw_8bit',
+            'ademamix_8bit',
+            'lion_8bit',
+            'lion_32bit',
+            'paged_adamw_32bit',
+            'paged_adamw_8bit',
+            'paged_ademamix_32bit',
+            'paged_ademamix_8bit',
+            'paged_lion_32bit',
+            'paged_lion_8bit',
+            'rmsprop',
+            'rmsprop_bnb',
+            'rmsprop_bnb_8bit',
+            'rmsprop_bnb_32bit',
+            'galore_adamw',
+            'galore_adamw_8bit',
+            'galore_adafactor',
+            'galore_adamw_layerwise',
+            'galore_adamw_8bit_layerwise',
+            'galore_adafactor_layerwise',
+            'lomo',
+            'adalomo',
+            'grokadamw',
+            'schedule_free_adamw',
+            'schedule_free_sgd'
+        ]
+
+     Default value: 'adamw_torch'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: bf16
+     Description: Whether to use bf16 (mixed) precision instead of 32-bit. Requires Ampere or higher N
+     bf16 mixed precision support for NPU architecture or using CPU (use_cpu) or Ascend NPU. This is
+     an experimental API and it may change.
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [False, True]
+
+     Default value: 0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: gradient_checkpointing_use_reentrant
+     Description: Specify whether to use the activation checkpoint variant that requires reentrant aut
+     parameter should be passed explicitly. Torch version 2.5 will raise an exception if use_reentrant
+     is not passed. If use_reentrant=False, checkpoint will use an implementation that does not
+     require reentrant autograd. This allows checkpoint to support additional functionality, such as
+     working as expected with torch.autograd.grad and support for keyword arguments input into the
+     checkpointed function.
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [False, True]
+
+     Default value: 0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: dataset_text_field
+     Description: Training dataset text field containing single sequence. Either the dataset_text_fiel
+     data_formatter_template need to be supplied. For running vision language model tuning pass the
+     column name for text data.
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['output', 'messages']
+
+     Default value: 'output'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: dataset_image_field
+     Description: For running vision language model tuning pass the column name of the image data in t
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [None, 'images']
+
+     Default value: None
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: remove_unused_columns
+     Description: Remove columns not required by the model when using an nlp.Dataset.
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [True, False]
+
+     Default value: 1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: dataset_kwargs_skip_prepare_dataset
+     Description: When True, configures trl to skip preparing the dataset.
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [True, False]
+
+     Default value: 0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: flash_attn
+     Description: Use Flash attention v2 from transformers
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [True, False]
+
+     Default value: 1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: gpu_model
+     Description: The GPU model to use
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            None,
+            'NVIDIA-A100-SXM4-80GB',
+            'NVIDIA-A100-80GB-PCIe',
+            'Tesla-T4',
+            'L40S',
+            'Tesla-V100-PCIE-16GB',
+            'NVIDIA-H100-PCIe',
+            'NVIDIA-H100-80GB-HBM3'
+        ]
+
+     Default value: None
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: distributed_backend
+     Description: Which pytorch backend to use when training with multiple GPU devices
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['DDP', 'FSDP', 'None']
+
+     Default value: 'FSDP'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: number_nodes
+     Description: If set, actuator distributes tasks on multiple nodes. Each Node will use number_gpus
+     GPUs. Each Node will use 1 process for each GPU it uses
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 9]
+
+     Default value: 1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: fms_hf_tuning_version
+     Description: The version of fms-hf-tuning to use - controls which wrapper to use as well as python
+     dependencies
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            '2.0.1',
+            '2.1.0',
+            '2.1.1',
+            '2.1.2',
+            '2.2.1',
+            '2.3.1',
+            '2.4.0',
+            '2.5.0',
+            '2.6.0',
+            '2.7.1',
+            '2.8.2',
+            '3.0.0',
+            '3.0.0.1',
+            '3.1.0'
+        ]
+
+     Default value: '2.1.2'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: enable_roce
+     Description: This setting is only in effect for multi-node runs. It controls whether RDMA over Co
+     Ethernet (RoCE) is switched on or not
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [False, True]
+
+     Default value: 0
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: fsdp_sharding_strategy
+     Description: [1] FULL_SHARD (shards optimizer states, gradients and parameters), [2] SHARD_GRAD_O
+     optimizer states and gradients), [3] NO_SHARD (DDP), [4] HYBRID_SHARD (shards optimizer states,
+     gradients and parameters within each node while each node has full copy - equivalent to
+     FULL_SHARD for single-node runs), [5] HYBRID_SHARD_ZERO2 (shards optimizer states and gradients
+     within each node while each node has full copy). For more information, please refer the official
+     PyTorch docs.
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['FULL_SHARD', 'SHARD_GRAD_OP', 'NO_SHARD', 'HYBRID_SHARD', 'HYBRID_SHARD_ZERO2']
+
+     Default value: 'FULL_SHARD'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: fsdp_state_dict_type
+     Description: [1] FULL_STATE_DICT, [2] LOCAL_STATE_DICT, [3] SHARDED_STATE_DICT
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['FULL_STATE_DICT', 'LOCAL_STATE_DICT', 'SHARDED_STATE_DICT']
+
+     Default value: 'FULL_STATE_DICT'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: fsdp_use_orig_params
+     Description: If True, allows non-uniform `requires_grad` during init, which means support for int
+     frozen and trainable parameters. (useful only when `use_fsdp` flag is passed).
+     Domain:
+
+        Type: BINARY_VARIABLE_TYPE
+        Values: [False, True]
+
+     Default value: 1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: accelerate_config_mixed_precision
+     Description: Whether or not to use mixed precision training. Choose from 'no', 'fp16', 'bf16' or
+     requires the installation of transformers-engine.
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['no', 'fp16', 'bf16', 'fp8']
+
+     Default value: 'no'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: accelerate_config_fsdp_transformer_layer_cls_to_wrap
+     Description: List of transformer layer class names (case-sensitive) to wrap, e.g, BertLayer,
+     GraniteDecoderLayer, GPTJBlock, T5Block ... (useful only when using FSDP)
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: [
+            None,
+            'GraniteDecoderLayer',
+            'LlamaDecoderLayer',
+            'MistralDecoderLayer',
+            'GPTJBlock',
+            'T5Block'
+        ]
+
+     Default value: None
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+
 Outputs:
- ───────────────────────────────────────────────────────────────────────────────────────────────────────── 
-   finetune_full_benchmark-v1.0.0-is_valid                                                                 
-   finetune_full_benchmark-v1.0.0-dataset_tokens_per_second_per_gpu                                        
-   finetune_full_benchmark-v1.0.0-train_runtime                                                            
-   finetune_full_benchmark-v1.0.0-dataset_tokens_per_second                                                
-   finetune_full_benchmark-v1.0.0-train_samples_per_second                                                 
-   finetune_full_benchmark-v1.0.0-train_steps_per_second                                                   
-   finetune_full_benchmark-v1.0.0-train_tokens_per_second                                                  
-   finetune_full_benchmark-v1.0.0-train_tokens_per_gpu_per_second                                          
-   finetune_full_benchmark-v1.0.0-cpu_compute_utilization                                                  
-   finetune_full_benchmark-v1.0.0-cpu_memory_utilization                                                   
-   finetune_full_benchmark-v1.0.0-gpu_compute_utilization_min                                              
-   finetune_full_benchmark-v1.0.0-gpu_compute_utilization_avg                                              
-   finetune_full_benchmark-v1.0.0-gpu_compute_utilization_max                                              
-   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_min                                               
-   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_avg                                               
-   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_max                                               
-   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_peak                                              
-   finetune_full_benchmark-v1.0.0-gpu_power_watts_min                                                      
-   finetune_full_benchmark-v1.0.0-gpu_power_watts_avg                                                      
-   finetune_full_benchmark-v1.0.0-gpu_power_watts_max                                                      
-   finetune_full_benchmark-v1.0.0-gpu_power_percent_min                                                    
-   finetune_full_benchmark-v1.0.0-gpu_power_percent_avg                                                    
-   finetune_full_benchmark-v1.0.0-gpu_power_percent_max                                                    
- ───────────────────────────────────────────────────────────────────────────────────────────────────────── 
+ ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+   finetune_full_benchmark-v1.0.0-is_valid
+   finetune_full_benchmark-v1.0.0-dataset_tokens_per_second_per_gpu
+   finetune_full_benchmark-v1.0.0-train_runtime
+   finetune_full_benchmark-v1.0.0-dataset_tokens_per_second
+   finetune_full_benchmark-v1.0.0-train_samples_per_second
+   finetune_full_benchmark-v1.0.0-train_steps_per_second
+   finetune_full_benchmark-v1.0.0-train_tokens_per_second
+   finetune_full_benchmark-v1.0.0-train_tokens_per_gpu_per_second
+   finetune_full_benchmark-v1.0.0-cpu_compute_utilization
+   finetune_full_benchmark-v1.0.0-cpu_memory_utilization
+   finetune_full_benchmark-v1.0.0-gpu_compute_utilization_min
+   finetune_full_benchmark-v1.0.0-gpu_compute_utilization_avg
+   finetune_full_benchmark-v1.0.0-gpu_compute_utilization_max
+   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_min
+   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_avg
+   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_max
+   finetune_full_benchmark-v1.0.0-gpu_memory_utilization_peak
+   finetune_full_benchmark-v1.0.0-gpu_power_watts_min
+   finetune_full_benchmark-v1.0.0-gpu_power_watts_avg
+   finetune_full_benchmark-v1.0.0-gpu_power_watts_max
+   finetune_full_benchmark-v1.0.0-gpu_power_percent_min
+   finetune_full_benchmark-v1.0.0-gpu_power_percent_avg
+   finetune_full_benchmark-v1.0.0-gpu_power_percent_max
+ ─────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
+
 <!-- markdownlint-enable line-length -->
 
 You can see the required inputs under the section `Required Inputs` and the
@@ -807,89 +810,91 @@ explains how to use optional properties.
 ## Parameterizing Experiments
 
 If an experiment has
-[optional input properties](../core-concepts/actuators.md#optional-inputs) you can
-define equivalent properties in the entity space. If you don't, the default
+[optional input properties](../core-concepts/actuators.md#optional-inputs) you
+can define equivalent properties in the entity space. If you don't, the default
 value for the property will be used.
 
 In addition, you can define your own custom parameterization of the experiment.
 For example, take the following experiment:
 
 <!-- markdownlint-disable line-length -->
+
 ```terminaloutput
 Identifier: robotic_lab.peptide_mineralization
 Description: Measures adsorption of peptide lanthanide combinations
 
 Required Inputs:
-                                                                                                           
-   Constitutive Properties:                                                                                
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: peptide_identifier                                                                        
-     Description: The identifier of the peptide to use                                                     
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['test_peptide', 'test_peptide_new']                                                       
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: peptide_concentration                                                                     
-     Description: The concentration of the peptide                                                         
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Values: [0.1, 0.4, 0.6, 0.8]                                                                       
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: lanthanide_concentration                                                                  
-     Description: The concentration of lanthanide                                                          
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Values: [0.1, 0.4, 0.6, 0.8]                                                                       
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-                                                                                                           
+
+   Constitutive Properties:
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: peptide_identifier
+     Description: The identifier of the peptide to use
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['test_peptide', 'test_peptide_new']
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: peptide_concentration
+     Description: The concentration of the peptide
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Values: [0.1, 0.4, 0.6, 0.8]
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: lanthanide_concentration
+     Description: The concentration of lanthanide
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Values: [0.1, 0.4, 0.6, 0.8]
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+
 Optional Inputs and Default Values:
-                                                                                                           
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: temperature                                                                               
-     Description: The temperature at which to execute the experiment                                       
-     Domain:                                                                                               
-                                                                                                           
-        Type: CONTINUOUS_VARIABLE_TYPE                                                                     
-        Range: [0, 100]                                                                                    
-                                                                                                           
-     Default value: 23                                                                                     
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: replicas                                                                                  
-     Description: How many replicas to average the adsorption_timeseries over                              
-     Domain:                                                                                               
-                                                                                                           
-        Type: DISCRETE_VARIABLE_TYPE                                                                       
-        Interval: 1                                                                                        
-        Range: [1, 4]                                                                                      
-                                                                                                           
-     Default value: 1                                                                                      
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-     Identifier: robot_identifier                                                                          
-     Description: The identifier of the robot to use to perform the experiment                             
-     Domain:                                                                                               
-                                                                                                           
-        Type: CATEGORICAL_VARIABLE_TYPE                                                                    
-        Values: ['harry', 'hermione']                                                                      
-                                                                                                           
-     Default value: 'hermione'                                                                             
-    ───────────────────────────────────────────────────────────────────────────────────────────────────    
-                                                                                                           
+
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: temperature
+     Description: The temperature at which to execute the experiment
+     Domain:
+
+        Type: CONTINUOUS_VARIABLE_TYPE
+        Range: [0, 100]
+
+     Default value: 23
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: replicas
+     Description: How many replicas to average the adsorption_timeseries over
+     Domain:
+
+        Type: DISCRETE_VARIABLE_TYPE
+        Interval: 1
+        Range: [1, 4]
+
+     Default value: 1
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+     Identifier: robot_identifier
+     Description: The identifier of the robot to use to perform the experiment
+     Domain:
+
+        Type: CATEGORICAL_VARIABLE_TYPE
+        Values: ['harry', 'hermione']
+
+     Default value: 'hermione'
+    ───────────────────────────────────────────────────────────────────────────────────────────────────
+
 Outputs:
- ───────────────────────────────────────────────────────────────────────────────────────────────────────── 
-   peptide_mineralization-adsorption_timeseries                                                            
-   peptide_mineralization-adsorption_plateau_value                                                         
+ ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+   peptide_mineralization-adsorption_timeseries
+   peptide_mineralization-adsorption_plateau_value
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
+
 <!-- markdownlint-enable line-length -->
 
 It has three optional properties: `temperature`, `robot_identifier` and

--- a/website/docs/resources/sample-stores.md
+++ b/website/docs/resources/sample-stores.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable code-block-style -->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable first-line-h1 -->
+
 A `samplestore` resource is a database containing
 [`entities`](../core-concepts/entity-spaces.md#entities) along with results of
 experiments that have been applied to them.
@@ -36,10 +37,12 @@ ado show related samplestore $SAMPLE_STORE_IDENTIFIER
 
 > [!TIP]
 >
-> The greater the similarity between two `discoveryspace`s, the greater
-> the chance they can share data. So it is usually beneficial to ensure that
-> such `discoveryspace`s use the same `samplestore`.
+> The greater the similarity between two `discoveryspace`s, the greater the
+> chance they can share data. So it is usually beneficial to ensure that such
+> `discoveryspace`s use the same `samplestore`.
+
 <!-- markdownlint-disable-next-line no-blanks-blockquote -->
+
 > [!WARNING]
 >
 > If you use two different `samplestore`s for similar `discoveryspace`s there is
@@ -51,8 +54,8 @@ ado show related samplestore $SAMPLE_STORE_IDENTIFIER
 allow read and write; and **passive** Sample Stores that only have read
 capabilities (for example a CSV file containing measurement data).
 
-All `samplestore` resources created with `ado` will be **active**. However,
-they can copy data in from **passive** Sample Stores.
+All `samplestore` resources created with `ado` will be **active**. However, they
+can copy data in from **passive** Sample Stores.
 
 ## The primary Sample Store type: SQLSampleStore
 
@@ -139,7 +142,7 @@ copyFrom:
       identifierColumn: "config"
       experiments:
         - experimentIdentifier: "benchmark_performance"
-          constitutivePropertyMap: 
+          constitutivePropertyMap:
             - cpu_type
           observedPropertyMap:
             - wallClockRuntime
@@ -152,13 +155,13 @@ You access the entities in a `samplestore` via a discovery space attached to it.
 For an existing `discoveryspace` to retrieve all entities that match it run
 
 ```commandline
-ado show entities space $SPACEID --include matching
+ado show measurements space $SPACEID --include matching
 ```
 
 You can also define a `discoveryspace` in a YAML and run:
 
 ```commandline
-ado show entities space --file $FILE
+ado show measurements space --file $FILE
 ```
 
 This allows you to see what entities match a space without having to create it.
@@ -174,6 +177,7 @@ When you want to copy from another SQLSampleStore you need the identifier and
 the metastore URL to the project it is in
 
 <!-- markdownlint-disable line-length -->
+
 ```yaml
 copyFrom:
   - identifier: source_abc123
@@ -187,6 +191,7 @@ copyFrom:
       user: my_project # The user field is the name of the project containing the samplestore
       password: XXXXXXX
 ```
+
 <!-- markdownlint-enable line-length -->
 
 ### CSVSampleStore
@@ -197,10 +202,11 @@ properties or observed properties.
 
 #### Importing data from external experiments
 
-The below YAML illustrates importing data from a CSV for an experiment
-which is not provided by an installed `ado` actuator.
+The below YAML illustrates importing data from a CSV for an experiment which is
+not provided by an installed `ado` actuator.
 
 <!-- markdownlint-disable line-length -->
+
 ```yaml
 copyFrom:
   - module:
@@ -215,14 +221,15 @@ copyFrom:
         - experimentIdentifier: 'benchmark_performance' # The experiment name you want the following properties to be associated with
           constitutivePropertyMap: # A list of columns which contain constitutive properties. Can also be a dict of property name to column name pairs
             - cpu_value
-          observedPropertyMap: # Dict of target property name:column id pairs, or list of column ids 
+          observedPropertyMap: # Dict of target property name:column id pairs, or list of column ids
             wallClockRuntime: 'wall-clock runtime' # The key is the target property name, the value is the column containing the values for that property
 ```
+
 <!-- markdownlint-enable line-length -->
 
-You must specify which CSV columns contain observed properties (measurements/results)
-and which contain constitutive properties (input parameters/configurations).
-You can do this in one of two ways.
+You must specify which CSV columns contain observed properties
+(measurements/results) and which contain constitutive properties (input
+parameters/configurations). You can do this in one of two ways.
 
 1. **Use CSV column names as-is** - Pass a list:
 
@@ -232,18 +239,19 @@ You can do this in one of two ways.
      - memory_gb
    ```
 
-   This uses `cpu_value` and `memory_gb` as both the column names AND property names.
+   This uses `cpu_value` and `memory_gb` as both the column names AND property
+   names.
 
 2. **Rename columns** - Pass a dictionary:
 
    ```yaml
    observedPropertyMap:
-     wallClockRuntime: 'wall-clock runtime'
-     throughput: 'requests_per_sec'
+     wallClockRuntime: "wall-clock runtime"
+     throughput: "requests_per_sec"
    ```
 
-   This reads from CSV columns `wall-clock runtime` and `requests_per_sec`,
-   but names them `wallClockRuntime` and `throughput` in the experiment.
+   This reads from CSV columns `wall-clock runtime` and `requests_per_sec`, but
+   names them `wallClockRuntime` and `throughput` in the experiment.
 
 #### Importing data from existing actuators
 
@@ -255,21 +263,23 @@ actuator and experiment identifiers. The property mappings
 experiment definition.
 
 <!-- markdownlint-disable line-length -->
+
 ```yaml
 copyFrom:
   - module:
       moduleClass: CSVSampleStore
       moduleName: orchestrator.core.samplestore.csv
     storageLocation:
-      path: 'results_export.csv'
+      path: "results_export.csv"
     parameters:
-      generatorIdentifier: 'vllm-benchmark-run'
-      identifierColumn: 'config'
+      generatorIdentifier: "vllm-benchmark-run"
+      identifierColumn: "config"
       experiments:
-        - experimentIdentifier: 'test-deployment-v1'
-          actuatorIdentifier: 'vllm_performance'  # Specify the actual actuator
-          propertyFormat: 'target' # if the columns for observed properties use target property names or observed property names
+        - experimentIdentifier: "test-deployment-v1"
+          actuatorIdentifier: "vllm_performance" # Specify the actual actuator
+          propertyFormat: "target" # if the columns for observed properties use target property names or observed property names
 ```
+
 <!-- markdownlint-enable line-length -->
 
 `ado` will verify that:
@@ -277,22 +287,21 @@ copyFrom:
 1. The specified actuator exists in the current instance
 2. The experiment exists in that actuator's catalog
 3. The CSV contains all required constitutive properties for the experiment
-(i.e. has columns with correct names)
+   (i.e. has columns with correct names)
 
-If the columns in the CSV don't match the experiments constitutive/observed properties
-you can use the `observedPropertyMap` and/or `constitutivePropertyMap` fields to
-provide a mapping.
-If these are provided the keys will be validated against the experiment definition.
+If the columns in the CSV don't match the experiments constitutive/observed
+properties you can use the `observedPropertyMap` and/or
+`constitutivePropertyMap` fields to provide a mapping. If these are provided the
+keys will be validated against the experiment definition.
 
 If any validation fails, a detailed error message will indicate what's wrong.
 
 > [!WARNING] Parameterized Experiments
 >
-> Importing parameterized experiment is not supported yet.
-> If you use a parameterized experiment identifier the data will fail to
-> import with an UnknownExperimentError
-> If you use the base experiment identifier the data will be mapped to the wrong
-> experiment
+> Importing parameterized experiment is not supported yet. If you use a
+> parameterized experiment identifier the data will fail to import with an
+> UnknownExperimentError If you use the base experiment identifier the data will
+> be mapped to the wrong experiment
 
 ## Deleting sample stores
 


### PR DESCRIPTION
# Summary

This pull request renames the `show entities` CLI command to `show measurements` to better reflect its functionality. The change includes renaming files, functions, classes, and parameters throughout the codebase to use "measurements" terminology instead of "entities".

# Files Changed

📄 `orchestrator/cli/commands/show.py`

Updates imports and function calls to reference the renamed `show_measurements` command instead of `show_entities`.

---

📄 `orchestrator/cli/commands/show_entities.py` → `orchestrator/cli/commands/show_measurements.py`

Renames the main command file and updates all internal references:
- Renames function `show_entities_for_resources()` to `show_measurements_for_resources()`
- Updates all parameter names from `entities_*` to `measurements_*`
- Renames all type references from `AdoShowEntities*` to `AdoShowMeasurements*`
- Updates command registration function from `register_show_entities_command()` to `register_show_measurements_command()`
- Updates help text, documentation, and examples to reference "measurements" instead of "entities"

---

📄 `orchestrator/cli/models/parameters.py`

Renames the parameter model class from `AdoShowEntitiesCommandParameters` to `AdoShowMeasurementsCommandParameters` and updates all field names from `entities_*` to `measurements_*`. Also updates corresponding type imports.

---

📄 `orchestrator/cli/models/types.py`

Renames all enum classes related to the show entities command:
- `AdoShowEntitiesSupportedEntityTypes` → `AdoShowMeasurementsSupportedEntityTypes`
- `AdoShowEntitiesSupportedOutputFormats` → `AdoShowMeasurementsSupportedOutputFormats`
- `AdoShowEntitiesSupportedPropertyFormats` → `AdoShowMeasurementsSupportedPropertyFormats`
- `AdoShowEntitiesSupportedResourceTypes` → `AdoShowMeasurementsSupportedResourceTypes`

---

📄 `orchestrator/cli/resources/discovery_space/show_entities.py` → `orchestrator/cli/resources/discovery_space/show_measurements.py`

Renames the discovery space implementation file and updates the main function from `show_discovery_space_entities()` to `show_discovery_space_measurements()`. Updates all parameter references from `entities_*` to `measurements_*` and adjusts error messages and output text accordingly.

---

📄 `orchestrator/cli/resources/operation/show_entities.py` → `orchestrator/cli/resources/operation/show_measurements.py`

Renames the operation implementation file and updates the main function from `show_operation_entities()` to `show_operation_measurements()`. Updates parameter references from `entities_*` to `measurements_*` throughout the implementation.