### PR TITLE
refactor(sfttrainer_download_hf_weights): do not use ray

### DIFF
--- a/plugins/actuators/sfttrainer/ado_actuators/sfttrainer/scripts/download_hf_weights.py
+++ b/plugins/actuators/sfttrainer/ado_actuators/sfttrainer/scripts/download_hf_weights.py
@@ -12,16 +12,7 @@ import yaml
 app = typer.Typer(rich_markup_mode="markdown")
 
 
-@ray.remote(
-    runtime_env={
-        "pip": ["accelerate", "transformers>=4.40.0"],
-        "env_vars": {
-            "LOG_LEVEL": "debug",
-            "LOGLEVEL": "debug",
-            "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
-        },
-    },
-)
+@ray.remote
 def download_weights(path_model: str, hf_home: pathlib.Path) -> None:
     if os.path.isabs(path_model):
         print("Skipping download - model is stored locally")

--- a/plugins/actuators/sfttrainer/ado_actuators/sfttrainer/scripts/download_hf_weights.py
+++ b/plugins/actuators/sfttrainer/ado_actuators/sfttrainer/scripts/download_hf_weights.py
@@ -5,14 +5,12 @@ import os
 import pathlib
 from typing import Annotated
 
-import ray
 import typer
 import yaml
 
 app = typer.Typer(rich_markup_mode="markdown")
 
 
-@ray.remote
 def download_weights(path_model: str, hf_home: pathlib.Path) -> None:
     if os.path.isabs(path_model):
         print("Skipping download - model is stored locally")
@@ -52,8 +50,6 @@ def main(
         ),
     ] = pathlib.Path(__file__),
 ) -> None:
-    ray.init()
-
     """Keys are the names of models, values are dictionaries with keys indicating the type of the model weight,
     and values the HuggingFace identifier strings.
 
@@ -70,7 +66,7 @@ def main(
         for _model_type, model_path in items.items():  # noqa: PERF102
             print("Downloading", model_path)
             try:
-                ray.get(download_weights.remote(model_path, hf_home))
+                download_weights(model_path, hf_home)
                 print("Success")
             except Exception as e:
                 print(f"Unable to download weights due to {e} - ignoring error")


### PR DESCRIPTION
Since download_weights() no longer configures packages, there's no need to use ray at all.

This also addresses an issue where sfttrainer_download_hf_weights does not work when using ray.