### PR TITLE
feat(core): add function to calculate operation statistics

### DIFF
--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -1077,6 +1077,7 @@ class DiscoverySpace:
             operation_id=operation_id
         )
 
+    @_perform_preflight_checks_for_sample_store_methods
     def operation_entity_statistics(self, operation_id: str) -> dict[str, int]:
         """
         Compute entity-level statistics for an operation using SQL aggregation.
@@ -1122,3 +1123,68 @@ class DiscoverySpace:
                 {result.entityIdentifier for result in measurement_results}
             ),
         }
+
+    @_perform_preflight_checks_for_sample_store_methods
+    def operation_measurement_statistics(
+        self, operation_id: str
+    ) -> "orchestrator.core.operation.stats.OperationMeasurementStatistics":
+        """Compute aggregated measurement statistics for an operation.
+
+        Delegates to the SQL implementation for SQL-backed stores. For all
+        other stores, falls back to a Python implementation that iterates the
+        measurement requests for the operation.
+
+        Args:
+            operation_id: The operation identifier.
+
+        Returns:
+            An OperationMeasurementStatistics instance with request-level,
+            result-level, and entity-level counts.
+        """
+        import orchestrator.core.samplestore.sql
+        from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
+        if isinstance(
+            self.sample_store, orchestrator.core.samplestore.sql.SQLSampleStore
+        ):
+            return self.sample_store.operation_measurement_statistics(
+                operation_id=operation_id
+            )
+
+        # Python fallback for non-SQL stores
+        from orchestrator.schema.request import MeasurementRequestStateEnum
+        from orchestrator.schema.result import ValidMeasurementResult
+
+        requests = self.measurement_requests_for_operation(operation_id=operation_id)
+
+        total_requests = len(requests)
+        failed_requests = sum(
+            1 for r in requests if r.status == MeasurementRequestStateEnum.FAILED
+        )
+        successful_requests = sum(
+            1 for r in requests if r.status == MeasurementRequestStateEnum.SUCCESS
+        )
+
+        total_results = 0
+        successful_results = 0
+        failed_results = 0
+        measured_entity_ids: set[str] = set()
+
+        for request in requests:
+            for result in request.measurements:
+                total_results += 1
+                if isinstance(result, ValidMeasurementResult):
+                    successful_results += 1
+                else:
+                    failed_results += 1
+                measured_entity_ids.add(result.entityIdentifier)
+
+        return OperationMeasurementStatistics(
+            total_requests=total_requests,
+            failed_requests=failed_requests,
+            successful_requests=successful_requests,
+            total_results=total_results,
+            successful_results=successful_results,
+            failed_results=failed_results,
+            measured_entities=len(measured_entity_ids),
+        )

--- a/orchestrator/core/operation/stats.py
+++ b/orchestrator/core/operation/stats.py
@@ -1,0 +1,59 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+from typing import Annotated
+
+import pydantic
+
+
+class OperationMeasurementStatistics(pydantic.BaseModel):
+    """Aggregated measurement statistics for a single operation.
+
+    Attributes:
+        total_requests: Total number of MeasurementRequests for the operation.
+        failed_requests: Number of requests whose status is FAILED.
+        successful_requests: Number of requests whose status is SUCCESS.
+        total_results: Total number of measurement results across all requests.
+        successful_results: Number of valid results (those carrying measurements).
+        failed_results: Number of invalid results (those carrying a failure reason).
+        measured_entities: Count of distinct entities that have at least one result.
+    """
+
+    total_requests: Annotated[
+        int,
+        pydantic.Field(
+            description="Total number of MeasurementRequests for the operation."
+        ),
+    ]
+    failed_requests: Annotated[
+        int,
+        pydantic.Field(description="Number of requests whose status is FAILED."),
+    ]
+    successful_requests: Annotated[
+        int,
+        pydantic.Field(description="Number of requests whose status is SUCCESS."),
+    ]
+    total_results: Annotated[
+        int,
+        pydantic.Field(
+            description="Total number of measurement results across all requests."
+        ),
+    ]
+    successful_results: Annotated[
+        int,
+        pydantic.Field(
+            description="Number of valid results (those carrying measurements)."
+        ),
+    ]
+    failed_results: Annotated[
+        int,
+        pydantic.Field(
+            description="Number of invalid results (those carrying a failure reason)."
+        ),
+    ]
+    measured_entities: Annotated[
+        int,
+        pydantic.Field(
+            description="Count of distinct entities that have at least one result."
+        ),
+    ]

--- a/orchestrator/core/samplestore/base.py
+++ b/orchestrator/core/samplestore/base.py
@@ -22,6 +22,7 @@ from orchestrator.schema.property_value import PropertyValue
 from orchestrator.schema.request import MeasurementRequest
 
 if typing.TYPE_CHECKING:
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
     from orchestrator.core.samplestore.config import (
         SampleStoreConfiguration,
         SampleStoreReference,
@@ -498,6 +499,20 @@ class ActiveSampleStore(SampleStore, ABC):
     def operation_entity_statistics(self, operation_id: str) -> dict[str, int]:
         """
         Compute entity-level statistics for an operation."""
+
+    @abc.abstractmethod
+    def operation_measurement_statistics(
+        self, operation_id: str
+    ) -> "OperationMeasurementStatistics":
+        """Compute aggregated measurement statistics for an operation.
+
+        Args:
+            operation_id: The operation identifier.
+
+        Returns:
+            An OperationMeasurementStatistics instance with request-level,
+            result-level, and entity-level counts.
+        """
 
 
 class MockParams(pydantic.BaseModel):

--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -57,6 +57,8 @@ if TYPE_CHECKING:
     import pandas as pd
     from rich.console import RenderableType
 
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
 # Process-level cache of (db_url, tablename) pairs for which the four DDL tables
 # have already been verified to exist, along with their reflected metadata.
 # Skips the four `CREATE TABLE IF NOT EXISTS` round-trips and metadata reflection
@@ -1480,6 +1482,126 @@ class SQLSampleStore(ActiveSampleStore):
                 }
         except SQLAlchemyError as error:
             msg = f"Unable to get entity statistics for operation {operation_id}"
+            self.log.critical(f"{msg}. Error: {error}")
+            raise SystemError(f"{msg}. Error: {error}") from error
+
+    def operation_measurement_statistics(
+        self, operation_id: str
+    ) -> "OperationMeasurementStatistics":
+        """Compute aggregated measurement statistics for an operation.
+
+        Computes all seven statistics in a single query to avoid multiple
+        DB round-trips: request counts (total/failed/successful), result counts
+        (total/valid/invalid), and distinct measured entity count.
+
+        Args:
+            operation_id: The operation identifier.
+
+        Returns:
+            An OperationMeasurementStatistics instance.
+        """
+        from sqlalchemy import case, func, select
+
+        from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
+        req_table = self._request_table
+        reqres_table = self._request_result_table
+        res_table = self._result_table
+
+        # Equivalent SQL:
+        #
+        #   SELECT
+        #     COUNT(DISTINCT req.uid) AS total_requests,
+        #     COUNT(DISTINCT CASE WHEN req.status = 'Failed' THEN req.uid END) AS failed_requests,
+        #     COUNT(DISTINCT CASE WHEN req.status = 'Success' THEN req.uid END) AS successful_requests,
+        #     COUNT(res.uid) AS total_results,
+        #     SUM(CASE WHEN JSON_EXTRACT(res.data, '$.reason') IS NULL     THEN 1 ELSE 0 END) AS successful_results,
+        #     SUM(CASE WHEN JSON_EXTRACT(res.data, '$.reason') IS NOT NULL THEN 1 ELSE 0 END) AS failed_results,
+        #     COUNT(DISTINCT res.entity_id) AS measured_entities
+        #   FROM <tablename>_measurement_requests req
+        #   LEFT JOIN <tablename>_measurement_requests_results reqres ON reqres.request_uid = req.uid
+        #   LEFT JOIN <tablename>_measurement_results            res  ON reqres.result_uid  = res.uid
+        #   WHERE req.operation_id = :operation_id
+
+        reason_is_null = func.json_extract(res_table.c.data, "$.reason").is_(None)
+
+        stmt = (
+            select(
+                # COUNT(DISTINCT req.uid) AS total_requests,
+                func.count(func.distinct(req_table.c.uid)).label("total_requests"),
+                # COUNT(DISTINCT CASE WHEN req.status = 'Failed' THEN req.uid END) AS failed_requests,
+                func.count(
+                    func.distinct(
+                        case(
+                            (
+                                req_table.c.status
+                                == MeasurementRequestStateEnum.FAILED.value,
+                                req_table.c.uid,
+                            ),
+                            else_=None,
+                        )
+                    )
+                ).label("failed_requests"),
+                # COUNT(DISTINCT CASE WHEN req.status = 'Success' THEN req.uid END) AS successful_requests,
+                func.count(
+                    func.distinct(
+                        case(
+                            (
+                                req_table.c.status
+                                == MeasurementRequestStateEnum.SUCCESS.value,
+                                req_table.c.uid,
+                            ),
+                            else_=None,
+                        )
+                    )
+                ).label("successful_requests"),
+                # COUNT(res.uid) AS total_results,
+                func.count(res_table.c.uid).label("total_results"),
+                # SUM(CASE WHEN JSON_EXTRACT(res.data, '$.reason') IS NULL THEN 1 ELSE 0 END) AS successful_results,
+                func.sum(case((reason_is_null, 1), else_=0)).label(
+                    "successful_results"
+                ),
+                # SUM(CASE WHEN JSON_EXTRACT(res.data, '$.reason') IS NOT NULL THEN 1 ELSE 0 END) AS failed_results,
+                func.sum(case((~reason_is_null, 1), else_=0)).label("failed_results"),
+                # COUNT(DISTINCT res.entity_id) AS measured_entities
+                func.count(func.distinct(res_table.c.entity_id)).label(
+                    "measured_entities"
+                ),
+            )
+            # FROM <tablename>_measurement_requests req
+            .select_from(req_table)
+            # LEFT JOIN <tablename>_measurement_requests_results reqres ON reqres.request_uid = req.uid
+            .outerjoin(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
+            # LEFT JOIN <tablename>_measurement_results res ON reqres.result_uid = res.uid
+            .outerjoin(res_table, reqres_table.c.result_uid == res_table.c.uid)
+            # WHERE req.operation_id =:operation_id
+            .where(req_table.c.operation_id == operation_id)
+        )
+
+        try:
+            with self.engine.begin() as connectable:
+                row = connectable.execute(stmt).one()
+                (
+                    total_requests,
+                    failed_requests,
+                    successful_requests,
+                    total_results,
+                    successful_results,
+                    failed_results,
+                    measured_entities,
+                ) = row
+
+                return OperationMeasurementStatistics(
+                    total_requests=total_requests or 0,
+                    failed_requests=failed_requests or 0,
+                    successful_requests=successful_requests or 0,
+                    total_results=total_results or 0,
+                    successful_results=successful_results or 0,
+                    failed_results=failed_results or 0,
+                    measured_entities=measured_entities or 0,
+                )
+        except SQLAlchemyError as error:
+            msg = f"Unable to get measurement statistics for operation {operation_id}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -901,3 +901,201 @@ def test_entities_in_operation_deduplication(
     retrieved_entity_ids = {e.identifier for e in retrieved_entities}
     assert len(retrieved_entity_ids) == len(retrieved_entities)  # No duplicates
     assert retrieved_entity_ids == all_entity_ids
+
+
+@requires_sqlite_3_38
+def test_operation_measurement_statistics_all_valid(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Test operation_measurement_statistics with all valid measurement results."""
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
+    number_entities = 3
+    number_requests = 4
+    measurements_per_result = 2
+    operation_id = random_identifier()
+
+    sample_store, requests, _request_ids = (
+        simulate_ml_multi_cloud_random_walk_operation(
+            number_entities=number_entities,
+            number_requests=number_requests,
+            measurements_per_result=measurements_per_result,
+            operation_id=operation_id,
+        )
+    )
+
+    expected_entities = {
+        result.entityIdentifier
+        for request in requests
+        for result in request.measurements
+    }
+
+    stats = sample_store.operation_measurement_statistics(operation_id=operation_id)
+
+    assert isinstance(stats, OperationMeasurementStatistics)
+    assert stats.total_requests == number_requests
+    assert stats.failed_requests == 0
+    assert stats.successful_requests == number_requests
+    assert stats.total_results == number_requests * number_entities
+    assert stats.successful_results == number_requests * number_entities
+    assert stats.failed_results == 0
+    assert stats.measured_entities == len(expected_entities)
+
+
+@requires_sqlite_3_38
+def test_operation_measurement_statistics_mixed_valid_invalid(
+    random_identifier: Callable[[], str],
+    ml_multi_cloud_sample_store: SQLSampleStore,
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+    random_ml_multi_cloud_benchmark_performance_measurement_requests: Callable[
+        [int, int, MeasurementRequestStateEnum | None, str | None],
+        ReplayedMeasurement,
+    ],
+    valid_ado_project_context: "ProjectContext",
+    ml_multi_cloud_operation_configuration: "DiscoveryOperationResourceConfiguration",
+) -> None:
+    """Test operation_measurement_statistics with mixed valid/invalid results and a failed request."""
+    from orchestrator.core import OperationResource
+    from orchestrator.core.operation.config import DiscoveryOperationEnum
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
+    from orchestrator.metastore.sqlstore import SQLResourceStore
+    from orchestrator.schema.reference import ExperimentReference
+
+    number_entities = 3
+    measurements_per_result = 2
+    operation_id = random_identifier()
+    sample_store = ml_multi_cloud_sample_store
+
+    sql = SQLResourceStore(project_context=valid_ado_project_context, ensureExists=True)
+    sql.addResourceWithRelationships(
+        OperationResource(
+            identifier=operation_id,
+            config=ml_multi_cloud_operation_configuration,
+            operationType=DiscoveryOperationEnum.SEARCH,
+            operatorIdentifier="test-operator",
+        ),
+        relatedIdentifiers=ml_multi_cloud_operation_configuration.spaces,
+    )
+
+    entities = random_ml_multi_cloud_benchmark_performance_entities(number_entities)
+
+    # Request 0 (SUCCESS): entity0=valid, entity1=valid, entity2=invalid — built manually
+    # so we can control the per-entity result status (the fixture always produces valid results)
+    measurements_req0 = [
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=entities[0],
+            measurements_per_result=measurements_per_result,
+            status=MeasurementResultStateEnum.VALID,
+        ),
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=entities[1],
+            measurements_per_result=measurements_per_result,
+            status=MeasurementResultStateEnum.VALID,
+        ),
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=entities[2],
+            measurements_per_result=measurements_per_result,
+            status=MeasurementResultStateEnum.INVALID,
+        ),
+    ]
+    request0 = ReplayedMeasurement(
+        operation_id=operation_id,
+        requestIndex=0,
+        experimentReference=ExperimentReference(
+            experimentIdentifier="benchmark_performance",
+            actuatorIdentifier="replay",
+        ),
+        entities=entities,
+        requestid=random_identifier(),
+        status=MeasurementRequestStateEnum.SUCCESS,
+        measurements=tuple(measurements_req0),
+    )
+    request_id0 = sample_store.add_measurement_request(request=request0)
+    sample_store.add_measurement_results(
+        results=measurements_req0,
+        skip_relationship_to_request=False,
+        request_db_id=request_id0,
+    )
+
+    # Request 1 (FAILED): use the fixture — it sets the request status and generates
+    # valid results for all entities (valid results on a failed request are fine here;
+    # we are testing the request-level failed_requests count, not result validity)
+    request1 = random_ml_multi_cloud_benchmark_performance_measurement_requests(
+        number_entities=number_entities,
+        measurements_per_result=measurements_per_result,
+        status=MeasurementRequestStateEnum.FAILED,
+        operation_id=operation_id,
+    )
+    request_id1 = sample_store.add_measurement_request(request=request1)
+    sample_store.add_measurement_results(
+        results=list(request1.measurements),
+        skip_relationship_to_request=False,
+        request_db_id=request_id1,
+    )
+
+    # The fixture creates its own fresh entities for request1, so the two requests
+    # cover different entity sets; collect the full expected distinct set.
+    expected_entities = {r.entityIdentifier for r in request0.measurements} | {
+        r.entityIdentifier for r in request1.measurements
+    }
+
+    stats = sample_store.operation_measurement_statistics(operation_id=operation_id)
+
+    assert isinstance(stats, OperationMeasurementStatistics)
+    assert stats.total_requests == 2
+    assert stats.failed_requests == 1
+    assert stats.successful_requests == 1
+    # request0: 3 results (2 valid + 1 invalid); request1: 3 results (all valid)
+    assert stats.total_results == number_entities * 2
+    assert stats.successful_results == 5  # 2 from req0 + 3 from req1
+    assert stats.failed_results == 1  # entity2 from req0 only
+    assert stats.measured_entities == len(expected_entities)
+
+
+@requires_sqlite_3_38
+def test_operation_measurement_statistics_measured_entities_distinct(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Test that measured_entities counts distinct entities across all results."""
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
+    # Use more requests than entities so the same entities appear in multiple requests
+    number_entities = 3
+    number_requests = 5
+    measurements_per_result = 2
+    operation_id = random_identifier()
+
+    sample_store, requests, _request_ids = (
+        simulate_ml_multi_cloud_random_walk_operation(
+            number_entities=number_entities,
+            number_requests=number_requests,
+            measurements_per_result=measurements_per_result,
+            operation_id=operation_id,
+        )
+    )
+
+    expected_entities = {
+        result.entityIdentifier
+        for request in requests
+        for result in request.measurements
+    }
+
+    stats = sample_store.operation_measurement_statistics(operation_id=operation_id)
+
+    assert isinstance(stats, OperationMeasurementStatistics)
+    # measured_entities is DISTINCT — repeated entities across requests count once
+    assert stats.measured_entities == len(expected_entities)
+    # total_results counts every result row, including repeats
+    assert stats.total_results == number_requests * number_entities
+    assert stats.total_results >= stats.measured_entities


### PR DESCRIPTION
## Add `OperationMeasurementStatistics` — aggregated stats for an operation

### Summary

Adds a single method to retrieve comprehensive measurement statistics for an operation in one call. Previously, callers had to issue multiple separate queries to get request counts, result counts, and entity counts. Now all seven stats are returned together as a typed pydantic model.

### Stats returned

| Field | Description |
|---|---|
| `total_requests` | How many measurement requests were issued |
| `failed_requests` | How many requests failed |
| `successful_requests` | How many requests succeeded |
| `total_results` | Total individual measurement results |
| `successful_results` | Results that carried valid measurements |
| `failed_results` | Results that carried a failure reason |
| `measured_entities` | Distinct entities with at least one result |

### What was added

- **`OperationMeasurementStatistics`** — a new pydantic model that holds all seven stats in a typed, serialisable form.
- **`SQLSampleStore.operation_measurement_statistics()`** — computes all stats in a single SQL query using conditional aggregation and joins, avoiding multiple DB round-trips.
- **`DiscoverySpace.operation_measurement_statistics()`** — the standard access-layer entry point. Delegates to the SQL implementation for SQL-backed stores; falls back to a pure-Python iteration for all other store types.
- **Tests** — three test cases covering the all-valid path, a mixed valid/invalid + failed-request scenario, and deduplication of `measured_entities` across repeated requests.