### PR TITLE
feat(core): add get_resources_by_relationship

### DIFF
--- a/orchestrator/metastore/base.py
+++ b/orchestrator/metastore/base.py
@@ -325,8 +325,8 @@ class ResourceStore(abc.ABC):
         identifiers_only: bool = False,
         include_start_resources: bool = False,
     ) -> (
-        dict[CoreResourceKinds, list[str]]
-        | dict[str, dict[CoreResourceKinds, list[str]]]
+        dict[CoreResourceKinds, set[str]]
+        | dict[str, dict[CoreResourceKinds, set[str]]]
         | dict[CoreResourceKinds, dict[str, ADOResource]]
         | dict[str, dict[CoreResourceKinds, dict[str, ADOResource]]]
     ):

--- a/orchestrator/metastore/base.py
+++ b/orchestrator/metastore/base.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pydantic
 
@@ -314,6 +314,48 @@ class ResourceStore(abc.ABC):
     @abc.abstractmethod
     def delete_actuator_configuration(self, identifier: str) -> None:
         pass
+
+    @abc.abstractmethod
+    def get_resources_by_relationship(
+        self,
+        kind: CoreResourceKinds,
+        identifier: str | set[str] | None,
+        hierarchy_direction: Literal["up", "down", "both"],
+        max_hops: int | None = None,
+        identifiers_only: bool = False,
+        include_start_resources: bool = False,
+    ) -> (
+        dict[CoreResourceKinds, list[str]]
+        | dict[str, dict[CoreResourceKinds, list[str]]]
+        | dict[CoreResourceKinds, dict[str, ADOResource]]
+        | dict[str, dict[CoreResourceKinds, dict[str, ADOResource]]]
+    ):
+        """Walk the resource hierarchy and return related resources.
+
+        Args:
+            kind: The :class:`~orchestrator.core.resources.CoreResourceKinds` of
+                the starting resources.
+            identifier: Controls which resources are used as traversal origins.
+                ``str`` for a single start resource, ``set[str]`` for multiple,
+                or ``None`` to seed from all resources of ``kind``.
+            hierarchy_direction: ``'up'`` (child → parent), ``'down'``
+                (parent → child), or ``'both'``.
+            max_hops: Maximum number of relationship hops to follow. ``None``
+                traverses to the full depth of the hierarchy.
+            identifiers_only: When ``True`` return only discovered identifiers;
+                when ``False`` (default) return hydrated
+                :class:`~orchestrator.core.resources.ADOResource` objects.
+            include_start_resources: When ``True`` include the start resource(s)
+                in the result. Requires ``identifiers_only=False`` and
+                ``identifier`` to be a ``str`` or ``set[str]``.
+
+        Returns:
+            A nested dict whose shape depends on whether a single or multiple
+            identifiers were requested and whether ``identifiers_only`` is set.
+
+        Raises:
+            ValueError: If arguments are invalid or incompatible.
+        """
 
 
 def sample_store_dump(

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -687,7 +687,7 @@ def graph_traversal_query(
         # Both directions: up_traversal and down_traversal run independently,
         # each bounded by effective_max_hops, then UNIONed.
         traversal_sql = f"""
-        {_traversal_cte("up", effective_max_hops).strip()},
+        {_traversal_cte("up", effective_max_hops).strip()}
         {_traversal_cte("down", effective_max_hops).strip()}
         SELECT related.origin_identifier AS origin_identifier,
                related.identifier AS identifier,

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -600,6 +600,47 @@ def graph_traversal_query(
         _MAX_HIERARCHY_HOPS if max_hops is None else min(max_hops, _MAX_HIERARCHY_HOPS)
     )
 
+    # Builds the recursive CTE for one direction. Going "up" follows edges
+    # backward (to→from); going "down" follows them forward (from→to).
+    def _traversal_cte(direction: Literal["up", "down"], n: int) -> str:
+        cte_name = f"{direction}_traversal"
+        next_kind = "from_kind" if direction == "up" else "to_kind"
+        next_id = "from_identifier" if direction == "up" else "to_identifier"
+        join_col = (
+            "to_identifier" if direction == "up" else "from_identifier"
+        )  # anchor: opposite end of next_id
+        return f""",
+        {cte_name} AS (
+            SELECT origin.identifier AS origin_identifier,
+                   origin.kind       AS current_kind,
+                   origin.identifier AS current_identifier,
+                   0                 AS depth
+            FROM   resources origin
+            WHERE  origin.kind = :start_kind
+              AND  origin.identifier IN :origins
+
+            UNION ALL
+
+            SELECT {cte_name}.origin_identifier AS origin_identifier,
+                   logical_edges.{next_kind}    AS current_kind,
+                   logical_edges.{next_id}      AS current_identifier,
+                   {cte_name}.depth + 1         AS depth
+            FROM   {cte_name}
+            JOIN   logical_edges
+              ON   logical_edges.{join_col} = {cte_name}.current_identifier
+            WHERE  {cte_name}.depth < {n}
+        )"""  # noqa: S608
+
+    # Produces the final SELECT from a single traversal CTE, excluding the seed row (depth > 0).
+    def _single_select(d: Literal["up", "down"]) -> str:
+        cte_name = f"{d}_traversal"
+        return f"""
+        SELECT {cte_name}.origin_identifier AS origin_identifier,
+               {cte_name}.current_identifier AS identifier,
+               {cte_name}.current_kind AS kind
+        FROM   {cte_name}
+        WHERE  {cte_name}.depth > 0"""  # noqa: S608
+
     # logical_edges is a non-recursive CTE; WITH RECURSIVE is required at the
     # clause level by SQLite because the subsequent traversal CTEs are recursive.
     logical_edges_sql = """
@@ -637,122 +678,26 @@ def graph_traversal_query(
     """
 
     if hierarchy_direction == "up":
-        traversal_sql = f""",
-        up_traversal AS (
-            SELECT origin.identifier AS origin_identifier,
-                   origin.kind       AS current_kind,
-                   origin.identifier AS current_identifier,
-                   0                 AS depth
-            FROM   resources origin
-            WHERE  origin.kind = :start_kind
-              AND  origin.identifier IN :origins
-
-            UNION ALL
-
-            SELECT up_traversal.origin_identifier AS origin_identifier,
-                   logical_edges.from_kind        AS current_kind,
-                   logical_edges.from_identifier  AS current_identifier,
-                   up_traversal.depth + 1         AS depth
-            FROM   up_traversal
-            JOIN   logical_edges
-              ON   logical_edges.to_identifier = up_traversal.current_identifier
-            WHERE  up_traversal.depth < {effective_max_hops}
-        )
-        SELECT up_traversal.origin_identifier AS origin_identifier,
-               up_traversal.current_identifier AS identifier,
-               up_traversal.current_kind AS kind
-        FROM   up_traversal
-        WHERE  up_traversal.depth > 0
-        """  # noqa: S608
+        traversal_sql = _traversal_cte("up", effective_max_hops) + _single_select("up")
     elif hierarchy_direction == "down":
-        traversal_sql = f""",
-        down_traversal AS (
-            SELECT origin.identifier AS origin_identifier,
-                   origin.kind       AS current_kind,
-                   origin.identifier AS current_identifier,
-                   0                 AS depth
-            FROM   resources origin
-            WHERE  origin.kind = :start_kind
-              AND  origin.identifier IN :origins
-
-            UNION ALL
-
-            SELECT down_traversal.origin_identifier AS origin_identifier,
-                   logical_edges.to_kind            AS current_kind,
-                   logical_edges.to_identifier      AS current_identifier,
-                   down_traversal.depth + 1         AS depth
-            FROM   down_traversal
-            JOIN   logical_edges
-              ON   logical_edges.from_identifier = down_traversal.current_identifier
-            WHERE  down_traversal.depth < {effective_max_hops}
+        traversal_sql = _traversal_cte("down", effective_max_hops) + _single_select(
+            "down"
         )
-        SELECT down_traversal.origin_identifier AS origin_identifier,
-               down_traversal.current_identifier AS identifier,
-               down_traversal.current_kind AS kind
-        FROM   down_traversal
-        WHERE  down_traversal.depth > 0
-        """  # noqa: S608
     else:
         # Both directions: up_traversal and down_traversal run independently,
         # each bounded by effective_max_hops, then UNIONed.
-        traversal_sql = f""",
-        up_traversal AS (
-            SELECT origin.identifier AS origin_identifier,
-                   origin.kind       AS current_kind,
-                   origin.identifier AS current_identifier,
-                   0                 AS depth
-            FROM   resources origin
-            WHERE  origin.kind = :start_kind
-              AND  origin.identifier IN :origins
-
-            UNION ALL
-
-            SELECT up_traversal.origin_identifier AS origin_identifier,
-                   logical_edges.from_kind        AS current_kind,
-                   logical_edges.from_identifier  AS current_identifier,
-                   up_traversal.depth + 1         AS depth
-            FROM   up_traversal
-            JOIN   logical_edges
-              ON   logical_edges.to_identifier = up_traversal.current_identifier
-            WHERE  up_traversal.depth < {effective_max_hops}
-        ),
-        down_traversal AS (
-            SELECT origin.identifier AS origin_identifier,
-                   origin.kind       AS current_kind,
-                   origin.identifier AS current_identifier,
-                   0                 AS depth
-            FROM   resources origin
-            WHERE  origin.kind = :start_kind
-              AND  origin.identifier IN :origins
-
-            UNION ALL
-
-            SELECT down_traversal.origin_identifier AS origin_identifier,
-                   logical_edges.to_kind            AS current_kind,
-                   logical_edges.to_identifier      AS current_identifier,
-                   down_traversal.depth + 1         AS depth
-            FROM   down_traversal
-            JOIN   logical_edges
-              ON   logical_edges.from_identifier = down_traversal.current_identifier
-            WHERE  down_traversal.depth < {effective_max_hops}
-        )
+        traversal_sql = f"""
+        {_traversal_cte("up", effective_max_hops).strip()},
+        {_traversal_cte("down", effective_max_hops).strip()}
         SELECT related.origin_identifier AS origin_identifier,
                related.identifier AS identifier,
                related.kind AS kind
         FROM   (
-            SELECT up_traversal.origin_identifier AS origin_identifier,
-                   up_traversal.current_identifier AS identifier,
-                   up_traversal.current_kind AS kind
-            FROM   up_traversal
-            WHERE  up_traversal.depth > 0
+            {_single_select("up").strip()}
 
             UNION ALL
 
-            SELECT down_traversal.origin_identifier AS origin_identifier,
-                   down_traversal.current_identifier AS identifier,
-                   down_traversal.current_kind AS kind
-            FROM   down_traversal
-            WHERE  down_traversal.depth > 0
+            {_single_select("down").strip()}
         ) related
         """  # noqa: S608
 

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -569,8 +569,9 @@ def graph_traversal_query(
         kind: Starting resource kind.
         hierarchy_direction: ``'up'``, ``'down'`` or ``'both'``.
         origin_identifiers: Set of start resource identifiers to bind.
-        stop_at_resource_kind: When provided, recursion stops once a row of this
-            kind is reached. Not supported for ``hierarchy_direction='both'``.
+        stop_at_resource_kind: When provided, the stop-kind row is included in
+            results but recursion does not continue beyond it. Not supported for
+            ``hierarchy_direction='both'``.
 
     Returns:
         A bound :class:`sqlalchemy.TextClause` ready to execute.
@@ -594,7 +595,8 @@ def graph_traversal_query(
             "stop_at_resource_kind is not supported for hierarchy_direction='both'"
         )
 
-    reachable_kinds_by_direction: dict[
+    # Used only to validate stop_at_resource_kind; does not drive the SQL traversal.
+    _valid_stop_kinds: dict[
         Literal["up", "down"], dict[CoreResourceKinds, list[CoreResourceKinds]]
     ] = {
         "up": {
@@ -637,21 +639,21 @@ def graph_traversal_query(
     }
 
     if stop_at_resource_kind is not None:
-        reachable_kinds = reachable_kinds_by_direction[hierarchy_direction].get(
-            kind, []
-        )
-        if stop_at_resource_kind not in reachable_kinds:
+        valid_stops = _valid_stop_kinds[hierarchy_direction].get(kind, [])
+        if stop_at_resource_kind not in valid_stops:
             raise ValueError(
                 f"stop_at_resource_kind={stop_at_resource_kind!r} is not reachable from "
                 f"kind={kind!r} with hierarchy_direction={hierarchy_direction!r}. "
-                f"Reachable kinds: {reachable_kinds}"
+                f"Reachable kinds: {valid_stops}"
             )
 
     stop_kind = (
         stop_at_resource_kind.value if stop_at_resource_kind is not None else None
     )
 
-    traversal_sql = """
+    # logical_edges is a non-recursive CTE; WITH RECURSIVE is required at the
+    # clause level by SQLite because the subsequent traversal CTEs are recursive.
+    logical_edges_sql = """
         WITH RECURSIVE logical_edges AS (
             SELECT parent.identifier AS from_identifier,
                    parent.kind       AS from_kind,
@@ -668,18 +670,26 @@ def graph_traversal_query(
 
             UNION ALL
 
-            SELECT operation.identifier AS from_identifier,
-                   operation.kind       AS from_kind,
-                   actconf.identifier   AS to_identifier,
-                   actconf.kind         AS to_kind
+            -- actuatorconfiguration is stored as subject with operation as object,
+            -- so the logical parent→child direction is reversed compared to the
+            -- other relationships above.
+            SELECT parent.identifier AS from_identifier,
+                   parent.kind       AS from_kind,
+                   child.identifier  AS to_identifier,
+                   child.kind        AS to_kind
             FROM   resource_relationships rr
-            JOIN   resources actconf
-              ON   actconf.identifier = rr.subject_identifier
-             AND   actconf.kind = 'actuatorconfiguration'
-            JOIN   resources operation
-              ON   operation.identifier = rr.object_identifier
-             AND   operation.kind = 'operation'
-        ),
+            JOIN   resources child
+              ON   child.identifier = rr.subject_identifier
+             AND   child.kind = 'actuatorconfiguration'
+            JOIN   resources parent
+              ON   parent.identifier = rr.object_identifier
+             AND   parent.kind = 'operation'
+        )
+    """
+
+    if hierarchy_direction == "up":
+        # Only the up_traversal CTE is needed; max depth == 3 hops (4 kinds).
+        traversal_sql = """,
         up_traversal AS (
             SELECT origin.identifier AS origin_identifier,
                    origin.kind       AS current_kind,
@@ -700,7 +710,16 @@ def graph_traversal_query(
               ON   logical_edges.to_identifier = up_traversal.current_identifier
             WHERE  (:stop_kind IS NULL OR up_traversal.current_kind != :stop_kind)
               AND  up_traversal.depth < 4
-        ),
+        )
+        SELECT up_traversal.origin_identifier AS origin_identifier,
+               up_traversal.current_identifier AS identifier,
+               up_traversal.current_kind AS kind
+        FROM   up_traversal
+        WHERE  up_traversal.depth > 0
+        """
+    elif hierarchy_direction == "down":
+        # Only the down_traversal CTE is needed; max depth == 3 hops (4 kinds).
+        traversal_sql = """,
         down_traversal AS (
             SELECT origin.identifier AS origin_identifier,
                    origin.kind       AS current_kind,
@@ -722,18 +741,6 @@ def graph_traversal_query(
             WHERE  (:stop_kind IS NULL OR down_traversal.current_kind != :stop_kind)
               AND  down_traversal.depth < 4
         )
-    """
-
-    if hierarchy_direction == "up":
-        final_select = """
-        SELECT up_traversal.origin_identifier AS origin_identifier,
-               up_traversal.current_identifier AS identifier,
-               up_traversal.current_kind AS kind
-        FROM   up_traversal
-        WHERE  up_traversal.depth > 0
-        """
-    elif hierarchy_direction == "down":
-        final_select = """
         SELECT down_traversal.origin_identifier AS origin_identifier,
                down_traversal.current_identifier AS identifier,
                down_traversal.current_kind AS kind
@@ -741,7 +748,49 @@ def graph_traversal_query(
         WHERE  down_traversal.depth > 0
         """
     else:
-        final_select = """
+        # Both directions: emit up_traversal and down_traversal, then UNION.
+        # stop_kind is not supported for 'both' (validated above).
+        traversal_sql = """,
+        up_traversal AS (
+            SELECT origin.identifier AS origin_identifier,
+                   origin.kind       AS current_kind,
+                   origin.identifier AS current_identifier,
+                   0                 AS depth
+            FROM   resources origin
+            WHERE  origin.kind = :start_kind
+              AND  origin.identifier IN :origins
+
+            UNION
+
+            SELECT up_traversal.origin_identifier AS origin_identifier,
+                   logical_edges.from_kind        AS current_kind,
+                   logical_edges.from_identifier  AS current_identifier,
+                   up_traversal.depth + 1         AS depth
+            FROM   up_traversal
+            JOIN   logical_edges
+              ON   logical_edges.to_identifier = up_traversal.current_identifier
+            WHERE  up_traversal.depth < 4
+        ),
+        down_traversal AS (
+            SELECT origin.identifier AS origin_identifier,
+                   origin.kind       AS current_kind,
+                   origin.identifier AS current_identifier,
+                   0                 AS depth
+            FROM   resources origin
+            WHERE  origin.kind = :start_kind
+              AND  origin.identifier IN :origins
+
+            UNION
+
+            SELECT down_traversal.origin_identifier AS origin_identifier,
+                   logical_edges.to_kind            AS current_kind,
+                   logical_edges.to_identifier      AS current_identifier,
+                   down_traversal.depth + 1         AS depth
+            FROM   down_traversal
+            JOIN   logical_edges
+              ON   logical_edges.from_identifier = down_traversal.current_identifier
+            WHERE  down_traversal.depth < 4
+        )
         SELECT related.origin_identifier AS origin_identifier,
                related.identifier AS identifier,
                related.kind AS kind
@@ -762,10 +811,15 @@ def graph_traversal_query(
         ) related
         """
 
-    return sqlalchemy.text(traversal_sql + final_select).bindparams(
+    binds = [
         sqlalchemy.bindparam(key="start_kind", value=kind.value),
         sqlalchemy.bindparam(
             key="origins", value=list(origin_identifiers), expanding=True
         ),
-        sqlalchemy.bindparam(key="stop_kind", value=stop_kind),
-    )
+    ]
+    # :stop_kind is only referenced in the up/down SQL; omit it for 'both'
+    # to avoid SQLAlchemy raising ArgumentError for an unrecognised parameter.
+    if hierarchy_direction != "both":
+        binds.append(sqlalchemy.bindparam(key="stop_kind", value=stop_kind))
+
+    return sqlalchemy.text(logical_edges_sql + traversal_sql).bindparams(*binds)

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -550,7 +550,7 @@ def graph_traversal_query(
     kind: "CoreResourceKinds",
     hierarchy_direction: Literal["up", "down", "both"],
     origin_identifiers: set[str],
-    stop_at_resource_kind: "CoreResourceKinds | None" = None,
+    max_hops: int | None = None,
 ) -> sqlalchemy.TextClause:
     """Build and return a recursive CTE traversal SQL for the resource hierarchy.
 
@@ -569,20 +569,20 @@ def graph_traversal_query(
         kind: Starting resource kind.
         hierarchy_direction: ``'up'``, ``'down'`` or ``'both'``.
         origin_identifiers: Set of start resource identifiers to bind.
-        stop_at_resource_kind: When provided, the stop-kind row is included in
-            results but recursion does not continue beyond it. Not supported for
-            ``hierarchy_direction='both'``.
+        max_hops: Maximum number of hops to follow from the start resource.
+            When ``None`` the traversal runs to the full depth of the
+            hierarchy. For ``hierarchy_direction='both'`` the limit is applied
+            independently to each direction (up and down). Must be a positive
+            integer; values exceeding the hierarchy maximum are silently capped
+            at that maximum.
 
     Returns:
         A bound :class:`sqlalchemy.TextClause` ready to execute.
 
     Raises:
         ValueError: If ``hierarchy_direction`` is invalid.
-        ValueError: If ``stop_at_resource_kind`` is not reachable from ``kind`` in
-            the requested direction.
-        ValueError: If ``stop_at_resource_kind`` is used with ``both``.
     """
-    from orchestrator.core.resources import CoreResourceKinds
+    from orchestrator.core.resources import CoreResourceKinds  # noqa: F401 (type check)
 
     if hierarchy_direction not in ("up", "down", "both"):
         raise ValueError(
@@ -590,66 +590,15 @@ def graph_traversal_query(
             f"got {hierarchy_direction!r}"
         )
 
-    if hierarchy_direction == "both" and stop_at_resource_kind is not None:
-        raise ValueError(
-            "stop_at_resource_kind is not supported for hierarchy_direction='both'"
-        )
+    # The resource hierarchy has 4 levels (samplestore → discoveryspace →
+    # operation → {datacontainer, actuatorconfiguration}), so the maximum
+    # meaningful hop count between any two levels is 3.
+    #
+    # If the hierarchy ever gains a new level, update this constant and the
+    # corresponding cap in get_resources_by_relationship().
+    _MAX_HOPS = 3
 
-    # Used only to validate stop_at_resource_kind; does not drive the SQL traversal.
-    _valid_stop_kinds: dict[
-        Literal["up", "down"], dict[CoreResourceKinds, list[CoreResourceKinds]]
-    ] = {
-        "up": {
-            CoreResourceKinds.SAMPLESTORE: [],
-            CoreResourceKinds.DISCOVERYSPACE: [CoreResourceKinds.SAMPLESTORE],
-            CoreResourceKinds.OPERATION: [
-                CoreResourceKinds.DISCOVERYSPACE,
-                CoreResourceKinds.SAMPLESTORE,
-            ],
-            CoreResourceKinds.DATACONTAINER: [
-                CoreResourceKinds.OPERATION,
-                CoreResourceKinds.DISCOVERYSPACE,
-                CoreResourceKinds.SAMPLESTORE,
-            ],
-            CoreResourceKinds.ACTUATORCONFIGURATION: [
-                CoreResourceKinds.OPERATION,
-                CoreResourceKinds.DISCOVERYSPACE,
-                CoreResourceKinds.SAMPLESTORE,
-            ],
-        },
-        "down": {
-            CoreResourceKinds.SAMPLESTORE: [
-                CoreResourceKinds.DISCOVERYSPACE,
-                CoreResourceKinds.OPERATION,
-                CoreResourceKinds.DATACONTAINER,
-                CoreResourceKinds.ACTUATORCONFIGURATION,
-            ],
-            CoreResourceKinds.DISCOVERYSPACE: [
-                CoreResourceKinds.OPERATION,
-                CoreResourceKinds.DATACONTAINER,
-                CoreResourceKinds.ACTUATORCONFIGURATION,
-            ],
-            CoreResourceKinds.OPERATION: [
-                CoreResourceKinds.DATACONTAINER,
-                CoreResourceKinds.ACTUATORCONFIGURATION,
-            ],
-            CoreResourceKinds.DATACONTAINER: [],
-            CoreResourceKinds.ACTUATORCONFIGURATION: [],
-        },
-    }
-
-    if stop_at_resource_kind is not None:
-        valid_stops = _valid_stop_kinds[hierarchy_direction].get(kind, [])
-        if stop_at_resource_kind not in valid_stops:
-            raise ValueError(
-                f"stop_at_resource_kind={stop_at_resource_kind!r} is not reachable from "
-                f"kind={kind!r} with hierarchy_direction={hierarchy_direction!r}. "
-                f"Reachable kinds: {valid_stops}"
-            )
-
-    stop_kind = (
-        stop_at_resource_kind.value if stop_at_resource_kind is not None else None
-    )
+    effective_max_hops = _MAX_HOPS if max_hops is None else min(max_hops, _MAX_HOPS)
 
     # logical_edges is a non-recursive CTE; WITH RECURSIVE is required at the
     # clause level by SQLite because the subsequent traversal CTEs are recursive.
@@ -688,8 +637,7 @@ def graph_traversal_query(
     """
 
     if hierarchy_direction == "up":
-        # Only the up_traversal CTE is needed; max depth == 3 hops (4 kinds).
-        traversal_sql = """,
+        traversal_sql = f""",
         up_traversal AS (
             SELECT origin.identifier AS origin_identifier,
                    origin.kind       AS current_kind,
@@ -708,18 +656,16 @@ def graph_traversal_query(
             FROM   up_traversal
             JOIN   logical_edges
               ON   logical_edges.to_identifier = up_traversal.current_identifier
-            WHERE  (:stop_kind IS NULL OR up_traversal.current_kind != :stop_kind)
-              AND  up_traversal.depth < 4
+            WHERE  up_traversal.depth < {effective_max_hops}
         )
         SELECT up_traversal.origin_identifier AS origin_identifier,
                up_traversal.current_identifier AS identifier,
                up_traversal.current_kind AS kind
         FROM   up_traversal
         WHERE  up_traversal.depth > 0
-        """
+        """  # noqa: S608
     elif hierarchy_direction == "down":
-        # Only the down_traversal CTE is needed; max depth == 3 hops (4 kinds).
-        traversal_sql = """,
+        traversal_sql = f""",
         down_traversal AS (
             SELECT origin.identifier AS origin_identifier,
                    origin.kind       AS current_kind,
@@ -738,19 +684,18 @@ def graph_traversal_query(
             FROM   down_traversal
             JOIN   logical_edges
               ON   logical_edges.from_identifier = down_traversal.current_identifier
-            WHERE  (:stop_kind IS NULL OR down_traversal.current_kind != :stop_kind)
-              AND  down_traversal.depth < 4
+            WHERE  down_traversal.depth < {effective_max_hops}
         )
         SELECT down_traversal.origin_identifier AS origin_identifier,
                down_traversal.current_identifier AS identifier,
                down_traversal.current_kind AS kind
         FROM   down_traversal
         WHERE  down_traversal.depth > 0
-        """
+        """  # noqa: S608
     else:
-        # Both directions: emit up_traversal and down_traversal, then UNION.
-        # stop_kind is not supported for 'both' (validated above).
-        traversal_sql = """,
+        # Both directions: up_traversal and down_traversal run independently,
+        # each bounded by effective_max_hops, then UNIONed.
+        traversal_sql = f""",
         up_traversal AS (
             SELECT origin.identifier AS origin_identifier,
                    origin.kind       AS current_kind,
@@ -769,7 +714,7 @@ def graph_traversal_query(
             FROM   up_traversal
             JOIN   logical_edges
               ON   logical_edges.to_identifier = up_traversal.current_identifier
-            WHERE  up_traversal.depth < 4
+            WHERE  up_traversal.depth < {effective_max_hops}
         ),
         down_traversal AS (
             SELECT origin.identifier AS origin_identifier,
@@ -789,7 +734,7 @@ def graph_traversal_query(
             FROM   down_traversal
             JOIN   logical_edges
               ON   logical_edges.from_identifier = down_traversal.current_identifier
-            WHERE  down_traversal.depth < 4
+            WHERE  down_traversal.depth < {effective_max_hops}
         )
         SELECT related.origin_identifier AS origin_identifier,
                related.identifier AS identifier,
@@ -809,7 +754,7 @@ def graph_traversal_query(
             FROM   down_traversal
             WHERE  down_traversal.depth > 0
         ) related
-        """
+        """  # noqa: S608
 
     binds = [
         sqlalchemy.bindparam(key="start_kind", value=kind.value),
@@ -817,9 +762,5 @@ def graph_traversal_query(
             key="origins", value=list(origin_identifiers), expanding=True
         ),
     ]
-    # :stop_kind is only referenced in the up/down SQL; omit it for 'both'
-    # to avoid SQLAlchemy raising ArgumentError for an unrecognised parameter.
-    if hierarchy_direction != "both":
-        binds.append(sqlalchemy.bindparam(key="stop_kind", value=stop_kind))
 
     return sqlalchemy.text(logical_edges_sql + traversal_sql).bindparams(*binds)

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -587,7 +587,7 @@ def graph_traversal_query(
     Raises:
         ValueError: If ``hierarchy_direction`` is invalid.
     """
-    if hierarchy_direction not in ("up", "down", "both"):
+    if hierarchy_direction not in {"up", "down", "both"}:
         raise ValueError(
             "hierarchy_direction must be 'up', 'down' or 'both', "
             f"got {hierarchy_direction!r}"

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -3,11 +3,14 @@
 
 import json
 from types import NoneType
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import sqlalchemy
 
 from orchestrator.core.resources import ADOResource
+
+if TYPE_CHECKING:
+    from orchestrator.core.resources import CoreResourceKinds
 
 
 def _quote_sql_identifier(identifier: str) -> str:
@@ -541,3 +544,319 @@ def resource_select_latest_by_kinds(
         FROM ranked_resources
         WHERE rn = 1
     """).bindparams(sqlalchemy.bindparam("kinds", value=kinds, expanding=True))
+
+
+def graph_traversal_query(
+    kind: "CoreResourceKinds",
+    hierarchy_direction: Literal["up", "down"],
+    origin_identifiers: set[str],
+    stop_at_resource_kind: "CoreResourceKinds | None" = None,
+) -> sqlalchemy.TextClause:
+    """Build and return the traversal SQL for the resource hierarchy.
+
+    Each branch of the hierarchy emits three columns:
+
+    * ``origin_identifier`` — the start resource identifier.
+    * ``identifier``        — the discovered resource identifier.
+    * ``kind``              — the kind of the discovered resource.
+
+    All active branches are joined with ``UNION ALL``; Python post-processing
+    handles deduplication.  The ``origins`` binding is expanded as an
+    ``IN``-list by SQLAlchemy.
+
+    Hierarchy::
+
+        samplestore
+          └── discoveryspace
+                └── operation
+                      ├── datacontainer
+                      └── actuatorconfiguration
+
+    Parent resources are stored as ``subject_identifier``; child resources
+    as ``object_identifier`` (see ``addResourceWithRelationships``).
+
+    Allowed traversal families
+    --------------------------
+    * ``up``   from ``operation``      (→ discoveryspace → samplestore)
+    * ``up``   from ``discoveryspace`` (→ samplestore)
+    * ``down`` from ``samplestore``    (→ discoveryspace → operation → dc/ac)
+    * ``down`` from ``discoveryspace`` (→ operation → dc/ac)
+    * ``down`` from ``operation``      (→ datacontainer / actuatorconfiguration)
+
+    Args:
+        kind: Starting resource kind.
+        hierarchy_direction: ``'up'`` (child → parent) or ``'down'`` (parent → child).
+        origin_identifiers: Set of start resource identifiers to bind.
+        stop_at_resource_kind: When provided, only branches reaching up to and
+            including this kind are included.  Must be reachable from
+            ``kind`` in the requested ``hierarchy_direction``; raises ``ValueError``
+            otherwise.
+
+    Returns:
+        A bound :class:`sqlalchemy.TextClause` ready to execute.
+
+    Raises:
+        ValueError: If ``hierarchy_direction`` is not ``'up'`` or ``'down'``.
+        ValueError: If ``(kind, hierarchy_direction)`` is not a supported family.
+        ValueError: If ``stop_at_resource_kind`` is not reachable in the family.
+    """
+    from orchestrator.core.resources import CoreResourceKinds
+
+    if hierarchy_direction not in ("up", "down"):
+        raise ValueError(
+            f"hierarchy_direction must be 'up' or 'down', got {hierarchy_direction!r}"
+        )
+
+    _K = CoreResourceKinds
+    _SS = _K.SAMPLESTORE.value
+    _DS = _K.DISCOVERYSPACE.value
+    _OP = _K.OPERATION.value
+    _DC = _K.DATACONTAINER.value
+    _AC = _K.ACTUATORCONFIGURATION.value
+
+    # Each branch is (deepest CoreResourceKinds reached, sql_string).
+    # The sql_string uses the literal token :origins which is bound below.
+    # All kind values in the SQL are from CoreResourceKinds.value — not user input.
+    _branches: list[tuple[CoreResourceKinds, str]]
+
+    if kind == _K.OPERATION and hierarchy_direction == "up":
+        _branches = [
+            (  # op → discoveryspace
+                _K.DISCOVERYSPACE,
+                f"""
+                SELECT rr1.object_identifier  AS origin_identifier,
+                       rr1.subject_identifier AS identifier,
+                       r1.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.subject_identifier
+                 AND   r1.kind = '{_DS}'
+                WHERE  rr1.object_identifier IN :origins
+                """,  # noqa: S608 - kind values are enum literals, not user input
+            ),
+            (  # op → discoveryspace → samplestore
+                _K.SAMPLESTORE,
+                f"""
+                SELECT rr1.object_identifier  AS origin_identifier,
+                       rr2.subject_identifier AS identifier,
+                       r2.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.subject_identifier
+                 AND   r1.kind = '{_DS}'
+                JOIN   resource_relationships rr2
+                  ON   rr2.object_identifier = rr1.subject_identifier
+                JOIN   resources r2
+                  ON   r2.identifier = rr2.subject_identifier
+                 AND   r2.kind = '{_SS}'
+                WHERE  rr1.object_identifier IN :origins
+                """,  # noqa: S608
+            ),
+        ]
+
+    elif kind == _K.DISCOVERYSPACE and hierarchy_direction == "up":
+        _branches = [
+            (  # discoveryspace → samplestore
+                _K.SAMPLESTORE,
+                f"""
+                SELECT rr1.object_identifier  AS origin_identifier,
+                       rr1.subject_identifier AS identifier,
+                       r1.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.subject_identifier
+                 AND   r1.kind = '{_SS}'
+                WHERE  rr1.object_identifier IN :origins
+                """,  # noqa: S608
+            ),
+        ]
+
+    elif kind == _K.SAMPLESTORE and hierarchy_direction == "down":
+        _branches = [
+            (  # samplestore → discoveryspace
+                _K.DISCOVERYSPACE,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr1.object_identifier  AS identifier,
+                       r1.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_DS}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+            (  # samplestore → discoveryspace → operation
+                _K.OPERATION,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr2.object_identifier  AS identifier,
+                       r2.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_DS}'
+                JOIN   resource_relationships rr2
+                  ON   rr2.subject_identifier = rr1.object_identifier
+                JOIN   resources r2
+                  ON   r2.identifier = rr2.object_identifier
+                 AND   r2.kind = '{_OP}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+            (  # samplestore → discoveryspace → operation → datacontainer
+                _K.DATACONTAINER,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr3.object_identifier  AS identifier,
+                       r3.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_DS}'
+                JOIN   resource_relationships rr2
+                  ON   rr2.subject_identifier = rr1.object_identifier
+                JOIN   resources r2
+                  ON   r2.identifier = rr2.object_identifier
+                 AND   r2.kind = '{_OP}'
+                JOIN   resource_relationships rr3
+                  ON   rr3.subject_identifier = rr2.object_identifier
+                JOIN   resources r3
+                  ON   r3.identifier = rr3.object_identifier
+                 AND   r3.kind = '{_DC}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+            (  # samplestore → discoveryspace → operation → actuatorconfiguration
+                _K.ACTUATORCONFIGURATION,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr3.object_identifier  AS identifier,
+                       r3.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_DS}'
+                JOIN   resource_relationships rr2
+                  ON   rr2.subject_identifier = rr1.object_identifier
+                JOIN   resources r2
+                  ON   r2.identifier = rr2.object_identifier
+                 AND   r2.kind = '{_OP}'
+                JOIN   resource_relationships rr3
+                  ON   rr3.subject_identifier = rr2.object_identifier
+                JOIN   resources r3
+                  ON   r3.identifier = rr3.object_identifier
+                 AND   r3.kind = '{_AC}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+        ]
+
+    elif kind == _K.DISCOVERYSPACE and hierarchy_direction == "down":
+        _branches = [
+            (  # discoveryspace → operation
+                _K.OPERATION,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr1.object_identifier  AS identifier,
+                       r1.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_OP}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+            (  # discoveryspace → operation → datacontainer
+                _K.DATACONTAINER,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr2.object_identifier  AS identifier,
+                       r2.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_OP}'
+                JOIN   resource_relationships rr2
+                  ON   rr2.subject_identifier = rr1.object_identifier
+                JOIN   resources r2
+                  ON   r2.identifier = rr2.object_identifier
+                 AND   r2.kind = '{_DC}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+            (  # discoveryspace → operation → actuatorconfiguration
+                _K.ACTUATORCONFIGURATION,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr2.object_identifier  AS identifier,
+                       r2.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_OP}'
+                JOIN   resource_relationships rr2
+                  ON   rr2.subject_identifier = rr1.object_identifier
+                JOIN   resources r2
+                  ON   r2.identifier = rr2.object_identifier
+                 AND   r2.kind = '{_AC}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+        ]
+
+    elif kind == _K.OPERATION and hierarchy_direction == "down":
+        _branches = [
+            (  # operation → datacontainer
+                _K.DATACONTAINER,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr1.object_identifier  AS identifier,
+                       r1.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_DC}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+            (  # operation → actuatorconfiguration
+                _K.ACTUATORCONFIGURATION,
+                f"""
+                SELECT rr1.subject_identifier AS origin_identifier,
+                       rr1.object_identifier  AS identifier,
+                       r1.kind                AS kind
+                FROM   resource_relationships rr1
+                JOIN   resources r1
+                  ON   r1.identifier = rr1.object_identifier
+                 AND   r1.kind = '{_AC}'
+                WHERE  rr1.subject_identifier IN :origins
+                """,  # noqa: S608
+            ),
+        ]
+
+    else:
+        raise ValueError(
+            f"Unsupported traversal family: kind={kind!r}, hierarchy_direction={hierarchy_direction!r}. "
+            f"Allowed families: up from operation/discoveryspace; "
+            f"down from samplestore/discoveryspace/operation."
+        )
+
+    # Apply stop_at_resource_kind trimming
+    if stop_at_resource_kind is not None:
+        reachable_kinds = [b[0] for b in _branches]
+        if stop_at_resource_kind not in reachable_kinds:
+            raise ValueError(
+                f"stop_at_resource_kind={stop_at_resource_kind!r} is not reachable from "
+                f"kind={kind!r} with hierarchy_direction={hierarchy_direction!r}. "
+                f"Reachable kinds: {reachable_kinds}"
+            )
+        cutoff = reachable_kinds.index(stop_at_resource_kind)
+        _branches = _branches[: cutoff + 1]
+
+    full_sql = "\nUNION ALL\n".join(sql for _, sql in _branches)
+    return sqlalchemy.text(full_sql).bindparams(
+        sqlalchemy.bindparam(
+            key="origins", value=list(origin_identifiers), expanding=True
+        )
+    )

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -12,6 +12,11 @@ from orchestrator.core.resources import ADOResource
 if TYPE_CHECKING:
     from orchestrator.core.resources import CoreResourceKinds
 
+# The resource hierarchy has 4 levels (samplestore → discoveryspace →
+# operation → {datacontainer, actuatorconfiguration}), so the maximum
+# meaningful hop count between any two levels is 3.
+_MAX_HIERARCHY_HOPS = 3
+
 
 def _quote_sql_identifier(identifier: str) -> str:
     """
@@ -590,15 +595,12 @@ def graph_traversal_query(
             f"got {hierarchy_direction!r}"
         )
 
-    # The resource hierarchy has 4 levels (samplestore → discoveryspace →
-    # operation → {datacontainer, actuatorconfiguration}), so the maximum
-    # meaningful hop count between any two levels is 3.
-    #
-    # If the hierarchy ever gains a new level, update this constant and the
-    # corresponding cap in get_resources_by_relationship().
-    _MAX_HOPS = 3
+    if max_hops is not None and max_hops < 1:
+        raise ValueError(f"max_hops must be a positive integer, got {max_hops!r}")
 
-    effective_max_hops = _MAX_HOPS if max_hops is None else min(max_hops, _MAX_HOPS)
+    effective_max_hops = (
+        _MAX_HIERARCHY_HOPS if max_hops is None else min(max_hops, _MAX_HIERARCHY_HOPS)
+    )
 
     # logical_edges is a non-recursive CTE; WITH RECURSIVE is required at the
     # clause level by SQLite because the subsequent traversal CTEs are recursive.

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -564,16 +564,22 @@ def graph_traversal_query(
     handles deduplication.  The ``origins`` binding is expanded as an
     ``IN``-list by SQLAlchemy.
 
-    Hierarchy::
+    Resource relationships::
 
         samplestore
           └── discoveryspace
                 └── operation
-                      ├── datacontainer
-                      └── actuatorconfiguration
+                      └── datacontainer
 
-    Parent resources are stored as ``subject_identifier``; child resources
-    as ``object_identifier`` (see ``addResourceWithRelationships``).
+        actuatorconfiguration ──► operation
+                               (subject)  (object)
+
+    actuatorconfiguration resources exist independently and are associated with
+    an operation at creation time.  The association is recorded as
+    ``subject_identifier=actconf``, ``object_identifier=operation`` — the
+    opposite direction from the samplestore/discoveryspace/operation/datacontainer
+    chain, where parent resources are ``subject_identifier`` and children are
+    ``object_identifier`` (see ``addResourceWithRelationships``).
 
     Allowed traversal families
     --------------------------
@@ -728,10 +734,11 @@ def graph_traversal_query(
                 """,  # noqa: S608
             ),
             (  # samplestore → discoveryspace → operation → actuatorconfiguration
+                # actconf is subject, operation is object (reverse of other hops)
                 _K.ACTUATORCONFIGURATION,
                 f"""
                 SELECT rr1.subject_identifier AS origin_identifier,
-                       rr3.object_identifier  AS identifier,
+                       rr3.subject_identifier AS identifier,
                        r3.kind                AS kind
                 FROM   resource_relationships rr1
                 JOIN   resources r1
@@ -743,9 +750,9 @@ def graph_traversal_query(
                   ON   r2.identifier = rr2.object_identifier
                  AND   r2.kind = '{_OP}'
                 JOIN   resource_relationships rr3
-                  ON   rr3.subject_identifier = rr2.object_identifier
+                  ON   rr3.object_identifier = rr2.object_identifier
                 JOIN   resources r3
-                  ON   r3.identifier = rr3.object_identifier
+                  ON   r3.identifier = rr3.subject_identifier
                  AND   r3.kind = '{_AC}'
                 WHERE  rr1.subject_identifier IN :origins
                 """,  # noqa: S608
@@ -786,19 +793,20 @@ def graph_traversal_query(
                 """,  # noqa: S608
             ),
             (  # discoveryspace → operation → actuatorconfiguration
+                # actconf is subject, operation is object (reverse of other hops)
                 _K.ACTUATORCONFIGURATION,
                 f"""
                 SELECT rr1.subject_identifier AS origin_identifier,
-                       rr2.object_identifier  AS identifier,
+                       rr2.subject_identifier AS identifier,
                        r2.kind                AS kind
                 FROM   resource_relationships rr1
                 JOIN   resources r1
                   ON   r1.identifier = rr1.object_identifier
                  AND   r1.kind = '{_OP}'
                 JOIN   resource_relationships rr2
-                  ON   rr2.subject_identifier = rr1.object_identifier
+                  ON   rr2.object_identifier = rr1.object_identifier
                 JOIN   resources r2
-                  ON   r2.identifier = rr2.object_identifier
+                  ON   r2.identifier = rr2.subject_identifier
                  AND   r2.kind = '{_AC}'
                 WHERE  rr1.subject_identifier IN :origins
                 """,  # noqa: S608
@@ -821,16 +829,17 @@ def graph_traversal_query(
                 """,  # noqa: S608
             ),
             (  # operation → actuatorconfiguration
+                # actconf is subject, operation is object (reverse of other hops)
                 _K.ACTUATORCONFIGURATION,
                 f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr1.object_identifier  AS identifier,
+                SELECT rr1.object_identifier  AS origin_identifier,
+                       rr1.subject_identifier AS identifier,
                        r1.kind                AS kind
                 FROM   resource_relationships rr1
                 JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
+                  ON   r1.identifier = rr1.subject_identifier
                  AND   r1.kind = '{_AC}'
-                WHERE  rr1.subject_identifier IN :origins
+                WHERE  rr1.object_identifier IN :origins
                 """,  # noqa: S608
             ),
         ]

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -548,324 +548,224 @@ def resource_select_latest_by_kinds(
 
 def graph_traversal_query(
     kind: "CoreResourceKinds",
-    hierarchy_direction: Literal["up", "down"],
+    hierarchy_direction: Literal["up", "down", "both"],
     origin_identifiers: set[str],
     stop_at_resource_kind: "CoreResourceKinds | None" = None,
 ) -> sqlalchemy.TextClause:
-    """Build and return the traversal SQL for the resource hierarchy.
+    """Build and return a recursive CTE traversal SQL for the resource hierarchy.
 
-    Each branch of the hierarchy emits three columns:
+    The query normalizes the stored relationships into logical directed edges:
 
-    * ``origin_identifier`` — the start resource identifier.
-    * ``identifier``        — the discovered resource identifier.
-    * ``kind``              — the kind of the discovered resource.
+    * samplestore → discoveryspace
+    * discoveryspace → operation
+    * operation → datacontainer
+    * operation → actuatorconfiguration
 
-    All active branches are joined with ``UNION ALL``; Python post-processing
-    handles deduplication.  The ``origins`` binding is expanded as an
-    ``IN``-list by SQLAlchemy.
-
-    Resource relationships::
-
-        samplestore
-          └── discoveryspace
-                └── operation
-                      └── datacontainer
-
-        actuatorconfiguration ──► operation
-                               (subject)  (object)
-
-    actuatorconfiguration resources exist independently and are associated with
-    an operation at creation time.  The association is recorded as
-    ``subject_identifier=actconf``, ``object_identifier=operation`` — the
-    opposite direction from the samplestore/discoveryspace/operation/datacontainer
-    chain, where parent resources are ``subject_identifier`` and children are
-    ``object_identifier`` (see ``addResourceWithRelationships``).
-
-    Allowed traversal families
-    --------------------------
-    * ``up``   from ``operation``      (→ discoveryspace → samplestore)
-    * ``up``   from ``discoveryspace`` (→ samplestore)
-    * ``down`` from ``samplestore``    (→ discoveryspace → operation → dc/ac)
-    * ``down`` from ``discoveryspace`` (→ operation → dc/ac)
-    * ``down`` from ``operation``      (→ datacontainer / actuatorconfiguration)
+    Traversal starts from every identifier in ``origin_identifiers`` whose
+    resource kind matches ``kind`` and recursively follows those logical edges
+    upward, downward, or in both directions.
 
     Args:
         kind: Starting resource kind.
-        hierarchy_direction: ``'up'`` (child → parent) or ``'down'`` (parent → child).
+        hierarchy_direction: ``'up'``, ``'down'`` or ``'both'``.
         origin_identifiers: Set of start resource identifiers to bind.
-        stop_at_resource_kind: When provided, only branches reaching up to and
-            including this kind are included.  Must be reachable from
-            ``kind`` in the requested ``hierarchy_direction``; raises ``ValueError``
-            otherwise.
+        stop_at_resource_kind: When provided, recursion stops once a row of this
+            kind is reached. Not supported for ``hierarchy_direction='both'``.
 
     Returns:
         A bound :class:`sqlalchemy.TextClause` ready to execute.
 
     Raises:
-        ValueError: If ``hierarchy_direction`` is not ``'up'`` or ``'down'``.
-        ValueError: If ``(kind, hierarchy_direction)`` is not a supported family.
-        ValueError: If ``stop_at_resource_kind`` is not reachable in the family.
+        ValueError: If ``hierarchy_direction`` is invalid.
+        ValueError: If ``stop_at_resource_kind`` is not reachable from ``kind`` in
+            the requested direction.
+        ValueError: If ``stop_at_resource_kind`` is used with ``both``.
     """
     from orchestrator.core.resources import CoreResourceKinds
 
-    if hierarchy_direction not in ("up", "down"):
+    if hierarchy_direction not in ("up", "down", "both"):
         raise ValueError(
-            f"hierarchy_direction must be 'up' or 'down', got {hierarchy_direction!r}"
+            "hierarchy_direction must be 'up', 'down' or 'both', "
+            f"got {hierarchy_direction!r}"
         )
 
-    _K = CoreResourceKinds
-    _SS = _K.SAMPLESTORE.value
-    _DS = _K.DISCOVERYSPACE.value
-    _OP = _K.OPERATION.value
-    _DC = _K.DATACONTAINER.value
-    _AC = _K.ACTUATORCONFIGURATION.value
-
-    # Each branch is (deepest CoreResourceKinds reached, sql_string).
-    # The sql_string uses the literal token :origins which is bound below.
-    # All kind values in the SQL are from CoreResourceKinds.value — not user input.
-    _branches: list[tuple[CoreResourceKinds, str]]
-
-    if kind == _K.OPERATION and hierarchy_direction == "up":
-        _branches = [
-            (  # op → discoveryspace
-                _K.DISCOVERYSPACE,
-                f"""
-                SELECT rr1.object_identifier  AS origin_identifier,
-                       rr1.subject_identifier AS identifier,
-                       r1.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.subject_identifier
-                 AND   r1.kind = '{_DS}'
-                WHERE  rr1.object_identifier IN :origins
-                """,  # noqa: S608 - kind values are enum literals, not user input
-            ),
-            (  # op → discoveryspace → samplestore
-                _K.SAMPLESTORE,
-                f"""
-                SELECT rr1.object_identifier  AS origin_identifier,
-                       rr2.subject_identifier AS identifier,
-                       r2.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.subject_identifier
-                 AND   r1.kind = '{_DS}'
-                JOIN   resource_relationships rr2
-                  ON   rr2.object_identifier = rr1.subject_identifier
-                JOIN   resources r2
-                  ON   r2.identifier = rr2.subject_identifier
-                 AND   r2.kind = '{_SS}'
-                WHERE  rr1.object_identifier IN :origins
-                """,  # noqa: S608
-            ),
-        ]
-
-    elif kind == _K.DISCOVERYSPACE and hierarchy_direction == "up":
-        _branches = [
-            (  # discoveryspace → samplestore
-                _K.SAMPLESTORE,
-                f"""
-                SELECT rr1.object_identifier  AS origin_identifier,
-                       rr1.subject_identifier AS identifier,
-                       r1.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.subject_identifier
-                 AND   r1.kind = '{_SS}'
-                WHERE  rr1.object_identifier IN :origins
-                """,  # noqa: S608
-            ),
-        ]
-
-    elif kind == _K.SAMPLESTORE and hierarchy_direction == "down":
-        _branches = [
-            (  # samplestore → discoveryspace
-                _K.DISCOVERYSPACE,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr1.object_identifier  AS identifier,
-                       r1.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_DS}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-            (  # samplestore → discoveryspace → operation
-                _K.OPERATION,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr2.object_identifier  AS identifier,
-                       r2.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_DS}'
-                JOIN   resource_relationships rr2
-                  ON   rr2.subject_identifier = rr1.object_identifier
-                JOIN   resources r2
-                  ON   r2.identifier = rr2.object_identifier
-                 AND   r2.kind = '{_OP}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-            (  # samplestore → discoveryspace → operation → datacontainer
-                _K.DATACONTAINER,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr3.object_identifier  AS identifier,
-                       r3.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_DS}'
-                JOIN   resource_relationships rr2
-                  ON   rr2.subject_identifier = rr1.object_identifier
-                JOIN   resources r2
-                  ON   r2.identifier = rr2.object_identifier
-                 AND   r2.kind = '{_OP}'
-                JOIN   resource_relationships rr3
-                  ON   rr3.subject_identifier = rr2.object_identifier
-                JOIN   resources r3
-                  ON   r3.identifier = rr3.object_identifier
-                 AND   r3.kind = '{_DC}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-            (  # samplestore → discoveryspace → operation → actuatorconfiguration
-                # actconf is subject, operation is object (reverse of other hops)
-                _K.ACTUATORCONFIGURATION,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr3.subject_identifier AS identifier,
-                       r3.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_DS}'
-                JOIN   resource_relationships rr2
-                  ON   rr2.subject_identifier = rr1.object_identifier
-                JOIN   resources r2
-                  ON   r2.identifier = rr2.object_identifier
-                 AND   r2.kind = '{_OP}'
-                JOIN   resource_relationships rr3
-                  ON   rr3.object_identifier = rr2.object_identifier
-                JOIN   resources r3
-                  ON   r3.identifier = rr3.subject_identifier
-                 AND   r3.kind = '{_AC}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-        ]
-
-    elif kind == _K.DISCOVERYSPACE and hierarchy_direction == "down":
-        _branches = [
-            (  # discoveryspace → operation
-                _K.OPERATION,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr1.object_identifier  AS identifier,
-                       r1.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_OP}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-            (  # discoveryspace → operation → datacontainer
-                _K.DATACONTAINER,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr2.object_identifier  AS identifier,
-                       r2.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_OP}'
-                JOIN   resource_relationships rr2
-                  ON   rr2.subject_identifier = rr1.object_identifier
-                JOIN   resources r2
-                  ON   r2.identifier = rr2.object_identifier
-                 AND   r2.kind = '{_DC}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-            (  # discoveryspace → operation → actuatorconfiguration
-                # actconf is subject, operation is object (reverse of other hops)
-                _K.ACTUATORCONFIGURATION,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr2.subject_identifier AS identifier,
-                       r2.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_OP}'
-                JOIN   resource_relationships rr2
-                  ON   rr2.object_identifier = rr1.object_identifier
-                JOIN   resources r2
-                  ON   r2.identifier = rr2.subject_identifier
-                 AND   r2.kind = '{_AC}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-        ]
-
-    elif kind == _K.OPERATION and hierarchy_direction == "down":
-        _branches = [
-            (  # operation → datacontainer
-                _K.DATACONTAINER,
-                f"""
-                SELECT rr1.subject_identifier AS origin_identifier,
-                       rr1.object_identifier  AS identifier,
-                       r1.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.object_identifier
-                 AND   r1.kind = '{_DC}'
-                WHERE  rr1.subject_identifier IN :origins
-                """,  # noqa: S608
-            ),
-            (  # operation → actuatorconfiguration
-                # actconf is subject, operation is object (reverse of other hops)
-                _K.ACTUATORCONFIGURATION,
-                f"""
-                SELECT rr1.object_identifier  AS origin_identifier,
-                       rr1.subject_identifier AS identifier,
-                       r1.kind                AS kind
-                FROM   resource_relationships rr1
-                JOIN   resources r1
-                  ON   r1.identifier = rr1.subject_identifier
-                 AND   r1.kind = '{_AC}'
-                WHERE  rr1.object_identifier IN :origins
-                """,  # noqa: S608
-            ),
-        ]
-
-    else:
+    if hierarchy_direction == "both" and stop_at_resource_kind is not None:
         raise ValueError(
-            f"Unsupported traversal family: kind={kind!r}, hierarchy_direction={hierarchy_direction!r}. "
-            f"Allowed families: up from operation/discoveryspace; "
-            f"down from samplestore/discoveryspace/operation."
+            "stop_at_resource_kind is not supported for hierarchy_direction='both'"
         )
 
-    # Apply stop_at_resource_kind trimming
+    reachable_kinds_by_direction: dict[
+        Literal["up", "down"], dict[CoreResourceKinds, list[CoreResourceKinds]]
+    ] = {
+        "up": {
+            CoreResourceKinds.SAMPLESTORE: [],
+            CoreResourceKinds.DISCOVERYSPACE: [CoreResourceKinds.SAMPLESTORE],
+            CoreResourceKinds.OPERATION: [
+                CoreResourceKinds.DISCOVERYSPACE,
+                CoreResourceKinds.SAMPLESTORE,
+            ],
+            CoreResourceKinds.DATACONTAINER: [
+                CoreResourceKinds.OPERATION,
+                CoreResourceKinds.DISCOVERYSPACE,
+                CoreResourceKinds.SAMPLESTORE,
+            ],
+            CoreResourceKinds.ACTUATORCONFIGURATION: [
+                CoreResourceKinds.OPERATION,
+                CoreResourceKinds.DISCOVERYSPACE,
+                CoreResourceKinds.SAMPLESTORE,
+            ],
+        },
+        "down": {
+            CoreResourceKinds.SAMPLESTORE: [
+                CoreResourceKinds.DISCOVERYSPACE,
+                CoreResourceKinds.OPERATION,
+                CoreResourceKinds.DATACONTAINER,
+                CoreResourceKinds.ACTUATORCONFIGURATION,
+            ],
+            CoreResourceKinds.DISCOVERYSPACE: [
+                CoreResourceKinds.OPERATION,
+                CoreResourceKinds.DATACONTAINER,
+                CoreResourceKinds.ACTUATORCONFIGURATION,
+            ],
+            CoreResourceKinds.OPERATION: [
+                CoreResourceKinds.DATACONTAINER,
+                CoreResourceKinds.ACTUATORCONFIGURATION,
+            ],
+            CoreResourceKinds.DATACONTAINER: [],
+            CoreResourceKinds.ACTUATORCONFIGURATION: [],
+        },
+    }
+
     if stop_at_resource_kind is not None:
-        reachable_kinds = [b[0] for b in _branches]
+        reachable_kinds = reachable_kinds_by_direction[hierarchy_direction].get(
+            kind, []
+        )
         if stop_at_resource_kind not in reachable_kinds:
             raise ValueError(
                 f"stop_at_resource_kind={stop_at_resource_kind!r} is not reachable from "
                 f"kind={kind!r} with hierarchy_direction={hierarchy_direction!r}. "
                 f"Reachable kinds: {reachable_kinds}"
             )
-        cutoff = reachable_kinds.index(stop_at_resource_kind)
-        _branches = _branches[: cutoff + 1]
 
-    full_sql = "\nUNION ALL\n".join(sql for _, sql in _branches)
-    return sqlalchemy.text(full_sql).bindparams(
+    stop_kind = (
+        stop_at_resource_kind.value if stop_at_resource_kind is not None else None
+    )
+
+    traversal_sql = """
+        WITH RECURSIVE logical_edges AS (
+            SELECT parent.identifier AS from_identifier,
+                   parent.kind       AS from_kind,
+                   child.identifier  AS to_identifier,
+                   child.kind        AS to_kind
+            FROM   resource_relationships rr
+            JOIN   resources parent
+              ON   parent.identifier = rr.subject_identifier
+            JOIN   resources child
+              ON   child.identifier = rr.object_identifier
+            WHERE  (parent.kind = 'samplestore' AND child.kind = 'discoveryspace')
+                OR (parent.kind = 'discoveryspace' AND child.kind = 'operation')
+                OR (parent.kind = 'operation' AND child.kind = 'datacontainer')
+
+            UNION ALL
+
+            SELECT operation.identifier AS from_identifier,
+                   operation.kind       AS from_kind,
+                   actconf.identifier   AS to_identifier,
+                   actconf.kind         AS to_kind
+            FROM   resource_relationships rr
+            JOIN   resources actconf
+              ON   actconf.identifier = rr.subject_identifier
+             AND   actconf.kind = 'actuatorconfiguration'
+            JOIN   resources operation
+              ON   operation.identifier = rr.object_identifier
+             AND   operation.kind = 'operation'
+        ),
+        up_traversal AS (
+            SELECT origin.identifier AS origin_identifier,
+                   origin.kind       AS current_kind,
+                   origin.identifier AS current_identifier,
+                   0                 AS depth
+            FROM   resources origin
+            WHERE  origin.kind = :start_kind
+              AND  origin.identifier IN :origins
+
+            UNION
+
+            SELECT up_traversal.origin_identifier AS origin_identifier,
+                   logical_edges.from_kind        AS current_kind,
+                   logical_edges.from_identifier  AS current_identifier,
+                   up_traversal.depth + 1         AS depth
+            FROM   up_traversal
+            JOIN   logical_edges
+              ON   logical_edges.to_identifier = up_traversal.current_identifier
+            WHERE  (:stop_kind IS NULL OR up_traversal.current_kind != :stop_kind)
+              AND  up_traversal.depth < 4
+        ),
+        down_traversal AS (
+            SELECT origin.identifier AS origin_identifier,
+                   origin.kind       AS current_kind,
+                   origin.identifier AS current_identifier,
+                   0                 AS depth
+            FROM   resources origin
+            WHERE  origin.kind = :start_kind
+              AND  origin.identifier IN :origins
+
+            UNION
+
+            SELECT down_traversal.origin_identifier AS origin_identifier,
+                   logical_edges.to_kind            AS current_kind,
+                   logical_edges.to_identifier      AS current_identifier,
+                   down_traversal.depth + 1         AS depth
+            FROM   down_traversal
+            JOIN   logical_edges
+              ON   logical_edges.from_identifier = down_traversal.current_identifier
+            WHERE  (:stop_kind IS NULL OR down_traversal.current_kind != :stop_kind)
+              AND  down_traversal.depth < 4
+        )
+    """
+
+    if hierarchy_direction == "up":
+        final_select = """
+        SELECT up_traversal.origin_identifier AS origin_identifier,
+               up_traversal.current_identifier AS identifier,
+               up_traversal.current_kind AS kind
+        FROM   up_traversal
+        WHERE  up_traversal.depth > 0
+        """
+    elif hierarchy_direction == "down":
+        final_select = """
+        SELECT down_traversal.origin_identifier AS origin_identifier,
+               down_traversal.current_identifier AS identifier,
+               down_traversal.current_kind AS kind
+        FROM   down_traversal
+        WHERE  down_traversal.depth > 0
+        """
+    else:
+        final_select = """
+        SELECT related.origin_identifier AS origin_identifier,
+               related.identifier AS identifier,
+               related.kind AS kind
+        FROM   (
+            SELECT up_traversal.origin_identifier AS origin_identifier,
+                   up_traversal.current_identifier AS identifier,
+                   up_traversal.current_kind AS kind
+            FROM   up_traversal
+            WHERE  up_traversal.depth > 0
+
+            UNION
+
+            SELECT down_traversal.origin_identifier AS origin_identifier,
+                   down_traversal.current_identifier AS identifier,
+                   down_traversal.current_kind AS kind
+            FROM   down_traversal
+            WHERE  down_traversal.depth > 0
+        ) related
+        """
+
+    return sqlalchemy.text(traversal_sql + final_select).bindparams(
+        sqlalchemy.bindparam(key="start_kind", value=kind.value),
         sqlalchemy.bindparam(
             key="origins", value=list(origin_identifiers), expanding=True
-        )
+        ),
+        sqlalchemy.bindparam(key="stop_kind", value=stop_kind),
     )

--- a/orchestrator/metastore/sql/statements.py
+++ b/orchestrator/metastore/sql/statements.py
@@ -587,8 +587,6 @@ def graph_traversal_query(
     Raises:
         ValueError: If ``hierarchy_direction`` is invalid.
     """
-    from orchestrator.core.resources import CoreResourceKinds  # noqa: F401 (type check)
-
     if hierarchy_direction not in ("up", "down", "both"):
         raise ValueError(
             "hierarchy_direction must be 'up', 'down' or 'both', "
@@ -615,9 +613,9 @@ def graph_traversal_query(
               ON   parent.identifier = rr.subject_identifier
             JOIN   resources child
               ON   child.identifier = rr.object_identifier
-            WHERE  (parent.kind = 'samplestore' AND child.kind = 'discoveryspace')
-                OR (parent.kind = 'discoveryspace' AND child.kind = 'operation')
-                OR (parent.kind = 'operation' AND child.kind = 'datacontainer')
+            WHERE  (parent.kind = :samplestore_kind AND child.kind = :discoveryspace_kind)
+                OR (parent.kind = :discoveryspace_kind AND child.kind = :operation_kind)
+                OR (parent.kind = :operation_kind AND child.kind = :datacontainer_kind)
 
             UNION ALL
 
@@ -631,10 +629,10 @@ def graph_traversal_query(
             FROM   resource_relationships rr
             JOIN   resources child
               ON   child.identifier = rr.subject_identifier
-             AND   child.kind = 'actuatorconfiguration'
+             AND   child.kind = :actuatorconfiguration_kind
             JOIN   resources parent
               ON   parent.identifier = rr.object_identifier
-             AND   parent.kind = 'operation'
+             AND   parent.kind = :operation_kind
         )
     """
 
@@ -649,7 +647,7 @@ def graph_traversal_query(
             WHERE  origin.kind = :start_kind
               AND  origin.identifier IN :origins
 
-            UNION
+            UNION ALL
 
             SELECT up_traversal.origin_identifier AS origin_identifier,
                    logical_edges.from_kind        AS current_kind,
@@ -677,7 +675,7 @@ def graph_traversal_query(
             WHERE  origin.kind = :start_kind
               AND  origin.identifier IN :origins
 
-            UNION
+            UNION ALL
 
             SELECT down_traversal.origin_identifier AS origin_identifier,
                    logical_edges.to_kind            AS current_kind,
@@ -707,7 +705,7 @@ def graph_traversal_query(
             WHERE  origin.kind = :start_kind
               AND  origin.identifier IN :origins
 
-            UNION
+            UNION ALL
 
             SELECT up_traversal.origin_identifier AS origin_identifier,
                    logical_edges.from_kind        AS current_kind,
@@ -727,7 +725,7 @@ def graph_traversal_query(
             WHERE  origin.kind = :start_kind
               AND  origin.identifier IN :origins
 
-            UNION
+            UNION ALL
 
             SELECT down_traversal.origin_identifier AS origin_identifier,
                    logical_edges.to_kind            AS current_kind,
@@ -748,7 +746,7 @@ def graph_traversal_query(
             FROM   up_traversal
             WHERE  up_traversal.depth > 0
 
-            UNION
+            UNION ALL
 
             SELECT down_traversal.origin_identifier AS origin_identifier,
                    down_traversal.current_identifier AS identifier,
@@ -758,10 +756,28 @@ def graph_traversal_query(
         ) related
         """  # noqa: S608
 
+    from orchestrator.core.resources import CoreResourceKinds
+
     binds = [
         sqlalchemy.bindparam(key="start_kind", value=kind.value),
         sqlalchemy.bindparam(
             key="origins", value=list(origin_identifiers), expanding=True
+        ),
+        sqlalchemy.bindparam(
+            key="samplestore_kind", value=CoreResourceKinds.SAMPLESTORE.value
+        ),
+        sqlalchemy.bindparam(
+            key="discoveryspace_kind", value=CoreResourceKinds.DISCOVERYSPACE.value
+        ),
+        sqlalchemy.bindparam(
+            key="operation_kind", value=CoreResourceKinds.OPERATION.value
+        ),
+        sqlalchemy.bindparam(
+            key="datacontainer_kind", value=CoreResourceKinds.DATACONTAINER.value
+        ),
+        sqlalchemy.bindparam(
+            key="actuatorconfiguration_kind",
+            value=CoreResourceKinds.ACTUATORCONFIGURATION.value,
         ),
     ]
 

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1723,22 +1723,8 @@ class SQLResourceStore(ResourceStore):
             raw_rows = connectable.execute(query).fetchall()
 
         # ------------------------------------------------------------------
-        # 3. Process raw rows into:
-        #
-        #    related_by_origin
-        #        Maps each origin identifier to the related identifiers it
-        #        reached, grouped by kind.  This is the final return value
-        #        for identifiers_only mode, and the skeleton used to build
-        #        the hydrated return value.
-        #            { origin_id -> { CoreResourceKinds -> {related_id, ...} } }
-        #
-        #    identifiers_to_fetch
-        #        The set of every discovered identifier across all origins.
-        #        Used in hydrated mode to fetch all resources in one batched
-        #        query.
-        #
-        #    Start identifiers (_identifiers_requested) are excluded from
-        #    both structures so they never appear in the result.
+        # 3. Build the mapping
+        #    { origin_id -> { CoreResourceKinds -> {related_id, ...} } }
         # ------------------------------------------------------------------
         related_by_origin: dict[str, dict[CoreResourceKinds, set[str]]] = {}
         identifiers_to_fetch: set[str] = set()

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1579,7 +1579,7 @@ class SQLResourceStore(ResourceStore):
         self,
         kind: CoreResourceKinds,
         identifier: str | set[str] | None,
-        hierarchy_direction: Literal["up", "down"],
+        hierarchy_direction: Literal["up", "down", "both"],
         stop_at_resource_kind: CoreResourceKinds | None = None,
         identifiers_only: bool = False,
     ) -> (
@@ -1598,41 +1598,12 @@ class SQLResourceStore(ResourceStore):
 
         The method issues at most **three** SQL queries: when ``identifier=None``
         a seed query fetches all identifiers of ``kind`` via
-        :meth:`getResourceIdentifiersOfKind`; then one traversal query
-        (assembled from pre-defined path branches via
-        :func:`orchestrator.metastore.sql.statements.graph_traversal_query`);
+        :meth:`getResourceIdentifiersOfKind`; then one recursive traversal query
+        via :func:`orchestrator.metastore.sql.statements.graph_traversal_query`;
         and, when ``identifiers_only=False``, one additional batched resource
-        query via :meth:`getResources`.  When ``identifier`` is a ``str`` or
+        query via :meth:`getResources`. When ``identifier`` is a ``str`` or
         ``set[str]`` only the latter two queries (or one, if
         ``identifiers_only=True``) are issued.
-
-        Resource relationships
-        ----------------------
-        ::
-
-            samplestore
-              └── discoveryspace
-                    └── operation
-                          └── datacontainer
-
-            actuatorconfiguration ──► operation
-                                   (subject)  (object)
-
-        actuatorconfiguration resources exist independently and are associated
-        with an operation at creation time.  The association is recorded as
-        ``subject_identifier=actconf``, ``object_identifier=operation`` — the
-        opposite direction from the samplestore/discoveryspace/operation/datacontainer
-        chain, where parent resources are ``subject_identifier`` and children
-        are ``object_identifier``
-        (see :meth:`addResourceWithRelationships`).
-
-        Allowed traversal families
-        --------------------------
-        * ``up`` from ``operation``
-        * ``up`` from ``discoveryspace``
-        * ``down`` from ``samplestore``
-        * ``down`` from ``discoveryspace``
-        * ``down`` from ``operation``
 
         Parameters
         ----------
@@ -1644,15 +1615,17 @@ class SQLResourceStore(ResourceStore):
               is unwrapped (no outer origin key).
             * ``set[str]`` — multiple explicit start resource identifiers.
             * ``None`` — all resources of ``kind`` are used as start resources
-              (seeded via :meth:`getResourceIdentifiersOfKind`).
+              (seeded via :meth:`getResourceIdentifiersOfKind`). Not supported
+              when ``hierarchy_direction='both'``.
             * An **empty set** returns an empty result immediately.
         hierarchy_direction:
-            ``'up'`` (child → parent) or ``'down'`` (parent → child).
+            ``'up'`` (child → parent), ``'down'`` (parent → child), or
+            ``'both'``.
         stop_at_resource_kind:
-            When provided, only traversal branches that reach resources of
-            kinds *up to and including* ``stop_at_resource_kind`` are included.
-            Must be a valid kind reachable from ``kind`` in the requested
-            ``hierarchy_direction``.  Raises ``ValueError`` for invalid combinations.
+            When provided, recursion stops once this kind is reached. Must be a
+            valid kind reachable from ``kind`` in the requested
+            ``hierarchy_direction``. Not supported when
+            ``hierarchy_direction='both'``.
         identifiers_only:
             When ``False`` (default) discovered identifiers are hydrated into
             full :class:`~orchestrator.core.resources.ADOResource` objects via
@@ -1675,13 +1648,14 @@ class SQLResourceStore(ResourceStore):
         Raises
         ------
         ValueError
-            If ``hierarchy_direction`` is not ``'up'`` or ``'down'``.
+            If ``hierarchy_direction`` is not ``'up'``, ``'down'`` or ``'both'``.
         ValueError
-            If the ``(kind, hierarchy_direction)`` combination is not a supported
-            traversal family.
+            If ``identifier=None`` is used with ``hierarchy_direction='both'``.
         ValueError
             If ``stop_at_resource_kind`` is not reachable from ``kind`` in the
             requested ``hierarchy_direction``.
+        ValueError
+            If ``stop_at_resource_kind`` is used with ``hierarchy_direction='both'``.
         """
         # ------------------------------------------------------------------
         # 1. Resolve the requested identifiers and record whether a single
@@ -1694,6 +1668,10 @@ class SQLResourceStore(ResourceStore):
             _single_identifier_requested = True
             _identifiers_requested = {identifier}
         elif identifier is None:
+            if hierarchy_direction == "both":
+                raise ValueError(
+                    "identifier=None is not supported for hierarchy_direction='both'"
+                )
             _single_identifier_requested = False
             df = self.getResourceIdentifiersOfKind(kind=kind.value)
             _identifiers_requested = set(df["IDENTIFIER"].tolist())

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1606,21 +1606,25 @@ class SQLResourceStore(ResourceStore):
         ``set[str]`` only the latter two queries (or one, if
         ``identifiers_only=True``) are issued.
 
-        Hierarchy
-        ---------
-        The supported resource hierarchy is::
+        Resource relationships
+        ----------------------
+        ::
 
             samplestore
               └── discoveryspace
                     └── operation
-                          ├── datacontainer
-                          └── actuatorconfiguration
+                          └── datacontainer
 
-        Parent resources are stored as ``subject_identifier`` and child
-        resources as ``object_identifier`` in the ``resource_relationships``
-        table (see :meth:`addResourceWithRelationships`).  Accordingly,
-        ``hierarchy_direction='down'`` follows subject → object, and
-        ``hierarchy_direction='up'`` follows object → subject.
+            actuatorconfiguration ──► operation
+                                   (subject)  (object)
+
+        actuatorconfiguration resources exist independently and are associated
+        with an operation at creation time.  The association is recorded as
+        ``subject_identifier=actconf``, ``object_identifier=operation`` — the
+        opposite direction from the samplestore/discoveryspace/operation/datacontainer
+        chain, where parent resources are ``subject_identifier`` and children
+        are ``object_identifier``
+        (see :meth:`addResourceWithRelationships`).
 
         Allowed traversal families
         --------------------------

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1737,6 +1737,8 @@ class SQLResourceStore(ResourceStore):
         #    both structures so they never appear in the result.
         # ------------------------------------------------------------------
         related_by_origin: dict[str, dict[CoreResourceKinds, list[str]]] = {}
+        # seen_by_origin tracks per-(origin, kind) seen sets for O(1) dedup
+        seen_by_origin: dict[str, dict[CoreResourceKinds, set[str]]] = {}
         identifiers_to_fetch: list[str] = []
         seen_identifiers: set[str] = set()
 
@@ -1750,11 +1752,14 @@ class SQLResourceStore(ResourceStore):
                 continue
 
             resource_kind = CoreResourceKinds(identifier_to_kind)
-            kind_list = related_by_origin.setdefault(identifier_from, {}).setdefault(
-                resource_kind, []
-            )
-            if identifier_to not in kind_list:
-                kind_list.append(identifier_to)
+
+            origin_seen = seen_by_origin.setdefault(identifier_from, {})
+            kind_seen = origin_seen.setdefault(resource_kind, set())
+            if identifier_to not in kind_seen:
+                kind_seen.add(identifier_to)
+                related_by_origin.setdefault(identifier_from, {}).setdefault(
+                    resource_kind, []
+                ).append(identifier_to)
 
             if identifier_to not in seen_identifiers:
                 identifiers_to_fetch.append(identifier_to)
@@ -1774,11 +1779,9 @@ class SQLResourceStore(ResourceStore):
         # so they can be merged into each origin's result under their own kind.
         all_identifiers_to_fetch = list(identifiers_to_fetch)
         if include_start_resources:
-            all_identifiers_to_fetch.extend(
-                start_id
-                for start_id in _identifiers_requested
-                if start_id not in seen_identifiers
-            )
+            # Start identifiers are always excluded from seen_identifiers (filtered
+            # out in the loop above), so extend unconditionally.
+            all_identifiers_to_fetch.extend(_identifiers_requested - seen_identifiers)
 
         resources_by_identifier = self.getResources(
             identifiers=all_identifiers_to_fetch

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -4,7 +4,7 @@
 import json
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pydantic
 import sqlalchemy
@@ -1570,3 +1570,242 @@ class SQLResourceStore(ResourceStore):
                     resource_kind=CoreResourceKinds.ACTUATORCONFIGURATION,
                     rollback_occurred=True,
                 ) from e
+
+    # ---------------------------------------------------------------------------
+    # Graph-aware traversal
+    # ---------------------------------------------------------------------------
+
+    def get_related_resources_by_relationship(
+        self,
+        kind: CoreResourceKinds,
+        identifier: str | set[str] | None,
+        hierarchy_direction: Literal["up", "down"],
+        stop_at_resource_kind: CoreResourceKinds | None = None,
+        identifiers_only: bool = False,
+    ) -> (
+        dict[CoreResourceKinds, list[str]]
+        | dict[str, dict[CoreResourceKinds, list[str]]]
+        | dict[CoreResourceKinds, dict[str, "orchestrator.core.resources.ADOResource"]]
+        | dict[
+            str,
+            dict[
+                CoreResourceKinds,
+                dict[str, "orchestrator.core.resources.ADOResource"],
+            ],
+        ]
+    ):
+        """Walk the resource hierarchy stored in ``resource_relationships``.
+
+        The method issues at most **three** SQL queries: when ``identifier=None``
+        a seed query fetches all identifiers of ``kind`` via
+        :meth:`getResourceIdentifiersOfKind`; then one traversal query
+        (assembled from pre-defined path branches via
+        :func:`orchestrator.metastore.sql.statements.graph_traversal_query`);
+        and, when ``identifiers_only=False``, one additional batched resource
+        query via :meth:`getResources`.  When ``identifier`` is a ``str`` or
+        ``set[str]`` only the latter two queries (or one, if
+        ``identifiers_only=True``) are issued.
+
+        Hierarchy
+        ---------
+        The supported resource hierarchy is::
+
+            samplestore
+              └── discoveryspace
+                    └── operation
+                          ├── datacontainer
+                          └── actuatorconfiguration
+
+        Parent resources are stored as ``subject_identifier`` and child
+        resources as ``object_identifier`` in the ``resource_relationships``
+        table (see :meth:`addResourceWithRelationships`).  Accordingly,
+        ``hierarchy_direction='down'`` follows subject → object, and
+        ``hierarchy_direction='up'`` follows object → subject.
+
+        Allowed traversal families
+        --------------------------
+        * ``up`` from ``operation``
+        * ``up`` from ``discoveryspace``
+        * ``down`` from ``samplestore``
+        * ``down`` from ``discoveryspace``
+        * ``down`` from ``operation``
+
+        Parameters
+        ----------
+        kind:
+            The :class:`~orchestrator.core.resources.CoreResourceKinds` of the
+            starting resources.
+        identifier:
+            * ``str`` — a single start resource identifier; the return value
+              is unwrapped (no outer origin key).
+            * ``set[str]`` — multiple explicit start resource identifiers.
+            * ``None`` — all resources of ``kind`` are used as start resources
+              (seeded via :meth:`getResourceIdentifiersOfKind`).
+            * An **empty set** returns an empty result immediately.
+        hierarchy_direction:
+            ``'up'`` (child → parent) or ``'down'`` (parent → child).
+        stop_at_resource_kind:
+            When provided, only traversal branches that reach resources of
+            kinds *up to and including* ``stop_at_resource_kind`` are included.
+            Must be a valid kind reachable from ``kind`` in the requested
+            ``hierarchy_direction``.  Raises ``ValueError`` for invalid combinations.
+        identifiers_only:
+            When ``False`` (default) discovered identifiers are hydrated into
+            full :class:`~orchestrator.core.resources.ADOResource` objects via
+            :meth:`getResources`.
+            When ``True`` only discovered identifiers are returned.
+
+        Returns
+        -------
+        The return type depends on whether a single identifier (str) or
+        multiple identifiers (set / None) were requested, and whether
+        ``identifiers_only`` is set:
+
+        * single identifier, hydrated     → ``dict[CoreResourceKinds, dict[str, ADOResource]]``
+        * multiple identifiers, hydrated  → ``dict[str, dict[CoreResourceKinds, dict[str, ADOResource]]]``
+        * single identifier, identifiers  → ``dict[CoreResourceKinds, list[str]]``
+        * multiple identifiers, identifiers  → ``dict[str, dict[CoreResourceKinds, list[str]]]``
+
+        Start identifiers are **excluded** from the returned results.
+
+        Raises
+        ------
+        ValueError
+            If ``hierarchy_direction`` is not ``'up'`` or ``'down'``.
+        ValueError
+            If the ``(kind, hierarchy_direction)`` combination is not a supported
+            traversal family.
+        ValueError
+            If ``stop_at_resource_kind`` is not reachable from ``kind`` in the
+            requested ``hierarchy_direction``.
+        """
+        # ------------------------------------------------------------------
+        # 1. Resolve the requested identifiers and record whether a single
+        #    identifier was requested (determines the unwrapped return shape)
+        # ------------------------------------------------------------------
+        _single_identifier_requested: bool
+        _identifiers_requested: set[str]
+
+        if isinstance(identifier, str):
+            _single_identifier_requested = True
+            _identifiers_requested = {identifier}
+        elif identifier is None:
+            _single_identifier_requested = False
+            df = self.getResourceIdentifiersOfKind(kind=kind.value)
+            _identifiers_requested = set(df["IDENTIFIER"].tolist())
+        else:
+            # set[str]
+            _single_identifier_requested = False
+            _identifiers_requested = identifier
+
+        # Empty identifier set → immediate empty result
+        if not _identifiers_requested:
+            return {}
+
+        # ------------------------------------------------------------------
+        # 2. Build and execute the single traversal query
+        # ------------------------------------------------------------------
+        query = orchestrator.metastore.sql.statements.graph_traversal_query(
+            kind=kind,
+            hierarchy_direction=hierarchy_direction,
+            origin_identifiers=_identifiers_requested,
+            stop_at_resource_kind=stop_at_resource_kind,
+        )
+
+        with self.engine.connect() as connectable:
+            raw_rows = connectable.execute(query).fetchall()
+
+        # ------------------------------------------------------------------
+        # 3. Process raw rows into two parallel data structures:
+        #
+        #    relationship_graph
+        #        Maps each origin identifier to the related identifiers it
+        #        reached, grouped by kind.  This is the final return value
+        #        for identifier mode, and the skeleton used to build the
+        #        hydrated return value.
+        #            { origin_id -> { CoreResourceKinds -> [related_id, ...] } }
+        #
+        #    ordered_identifiers_retrieved / identifiers_retrieved
+        #        A deduplication-paired list+set of every discovered
+        #        identifier across all origins, in first-seen row order.
+        #        Used in hydrated mode to fetch all resources in a single
+        #        batched query while preserving a stable ordering.
+        #
+        #    Start identifiers (_identifiers_requested) are excluded from
+        #    both structures so they never appear in the result.
+        # ------------------------------------------------------------------
+        relationship_graph: dict[str, dict[CoreResourceKinds, list[str]]] = {}
+        ordered_identifiers_retrieved: list[str] = []
+        identifiers_retrieved: set[str] = set()
+
+        for row in raw_rows:
+            identifier_from = row.origin_identifier
+            identifier_to = row.identifier
+            identifier_to_kind = row.kind
+
+            # Never include the start identifiers in discovered results
+            if identifier_to in _identifiers_requested:
+                continue
+
+            resource_kind = CoreResourceKinds(identifier_to_kind)
+            # Register identifier_to under its origin and kind, deduplicating
+            # within each list by only appending when not already present.
+            # On the first row for a given (identifier_from, resource_kind) pair,
+            # setdefault seeds the list with [identifier_to] and returns it; the
+            # subsequent guard finds it already present and skips the append.
+            # For later rows with the same pair, setdefault returns the existing
+            # list and the guard appends only if identifier_to is not yet in it.
+            related_identifiers_by_kind = relationship_graph.setdefault(
+                identifier_from, {}
+            ).setdefault(resource_kind, [identifier_to])
+            if identifier_to not in related_identifiers_by_kind:
+                related_identifiers_by_kind.append(identifier_to)
+
+            if identifier_to not in identifiers_retrieved:
+                ordered_identifiers_retrieved.append(identifier_to)
+                identifiers_retrieved.add(identifier_to)
+
+        # ------------------------------------------------------------------
+        # 4. Shape the result
+        # ------------------------------------------------------------------
+        if identifiers_only:
+            # Identifier mode
+            if _single_identifier_requested:
+                return relationship_graph.get(next(iter(_identifiers_requested)), {})
+            return relationship_graph
+
+        # Hydrated mode: fetch all discovered identifiers in one query,
+        # then rebuild the graph with full resources
+        resources_by_identifier = self.getResources(
+            identifiers=ordered_identifiers_retrieved
+        )
+
+        hydrated: dict[
+            str,
+            dict[CoreResourceKinds, dict[str, orchestrator.core.resources.ADOResource]],
+        ] = {}
+
+        for identifier_from, related_identifiers_by_kind in relationship_graph.items():
+
+            hydrated_related_resources_by_kind: dict[
+                CoreResourceKinds,
+                dict[str, orchestrator.core.resources.ADOResource],
+            ] = {}
+
+            for (
+                resource_kind,
+                related_identifiers,
+            ) in related_identifiers_by_kind.items():
+                hydrated_related_resources_by_kind[resource_kind] = {
+                    identifier_to: resources_by_identifier[identifier_to]
+                    for identifier_to in related_identifiers
+                    if identifier_to in resources_by_identifier
+                }
+
+            if hydrated_related_resources_by_kind:
+                hydrated[identifier_from] = hydrated_related_resources_by_kind
+
+        if _single_identifier_requested:
+            return hydrated.get(next(iter(_identifiers_requested)), {})
+
+        return hydrated

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1572,10 +1572,10 @@ class SQLResourceStore(ResourceStore):
                 ) from e
 
     # ---------------------------------------------------------------------------
-    # Graph-aware traversal
+    # Hierarchy traversal
     # ---------------------------------------------------------------------------
 
-    def get_related_resources_by_relationship(
+    def get_resources_by_relationship(
         self,
         kind: CoreResourceKinds,
         identifier: str | set[str] | None,
@@ -1596,8 +1596,8 @@ class SQLResourceStore(ResourceStore):
     ):
         """Walk the resource hierarchy stored in ``resource_relationships``.
 
-        The method issues at most **three** SQL queries: when ``identifier=None``
-        a seed query fetches all identifiers of ``kind`` via
+        Issues at most three SQL queries: when ``identifier=None`` a seed query
+        fetches all identifiers of ``kind`` via
         :meth:`getResourceIdentifiersOfKind`; then one recursive traversal query
         via :func:`orchestrator.metastore.sql.statements.graph_traversal_query`;
         and, when ``identifiers_only=False``, one additional batched resource
@@ -1605,57 +1605,53 @@ class SQLResourceStore(ResourceStore):
         ``set[str]`` only the latter two queries (or one, if
         ``identifiers_only=True``) are issued.
 
-        Parameters
-        ----------
-        kind:
-            The :class:`~orchestrator.core.resources.CoreResourceKinds` of the
-            starting resources.
-        identifier:
-            * ``str`` — a single start resource identifier; the return value
-              is unwrapped (no outer origin key).
-            * ``set[str]`` — multiple explicit start resource identifiers.
-            * ``None`` — all resources of ``kind`` are used as start resources
-              (seeded via :meth:`getResourceIdentifiersOfKind`). Not supported
-              when ``hierarchy_direction='both'``.
-            * An **empty set** returns an empty result immediately.
-        hierarchy_direction:
-            ``'up'`` (child → parent), ``'down'`` (parent → child), or
-            ``'both'``.
-        stop_at_resource_kind:
-            When provided, recursion stops once this kind is reached. Must be a
-            valid kind reachable from ``kind`` in the requested
-            ``hierarchy_direction``. Not supported when
-            ``hierarchy_direction='both'``.
-        identifiers_only:
-            When ``False`` (default) discovered identifiers are hydrated into
-            full :class:`~orchestrator.core.resources.ADOResource` objects via
-            :meth:`getResources`.
-            When ``True`` only discovered identifiers are returned.
+        Args:
+            kind: The :class:`~orchestrator.core.resources.CoreResourceKinds` of
+                the starting resources.
+            identifier: Controls which resources are used as traversal origins.
 
-        Returns
-        -------
-        The return type depends on whether a single identifier (str) or
-        multiple identifiers (set / None) were requested, and whether
-        ``identifiers_only`` is set:
+                * ``str`` — a single start resource identifier; the return value
+                  is unwrapped (no outer origin key).
+                * ``set[str]`` — multiple explicit start resource identifiers.
+                * ``None`` — all resources of ``kind`` are used as start
+                  resources (seeded via :meth:`getResourceIdentifiersOfKind`).
+                  Not supported when ``hierarchy_direction='both'``.
+                * An **empty set** returns an empty result immediately.
 
-        * single identifier, hydrated     → ``dict[CoreResourceKinds, dict[str, ADOResource]]``
-        * multiple identifiers, hydrated  → ``dict[str, dict[CoreResourceKinds, dict[str, ADOResource]]]``
-        * single identifier, identifiers  → ``dict[CoreResourceKinds, list[str]]``
-        * multiple identifiers, identifiers  → ``dict[str, dict[CoreResourceKinds, list[str]]]``
+            hierarchy_direction: ``'up'`` (child → parent), ``'down'``
+                (parent → child), or ``'both'``.
+            stop_at_resource_kind: When provided, the stop-kind row is included
+                in results but recursion does not continue beyond it. Must be a
+                valid kind reachable from ``kind`` in the requested
+                ``hierarchy_direction``. Not supported when
+                ``hierarchy_direction='both'``.
+            identifiers_only: When ``False`` (default) discovered identifiers
+                are hydrated into full
+                :class:`~orchestrator.core.resources.ADOResource` objects via
+                :meth:`getResources`. When ``True`` only discovered identifiers
+                are returned.
 
-        Start identifiers are **excluded** from the returned results.
+        Returns:
+            The return type depends on whether a single identifier (``str``) or
+            multiple identifiers (``set`` / ``None``) were requested, and
+            whether ``identifiers_only`` is set:
 
-        Raises
-        ------
-        ValueError
-            If ``hierarchy_direction`` is not ``'up'``, ``'down'`` or ``'both'``.
-        ValueError
-            If ``identifier=None`` is used with ``hierarchy_direction='both'``.
-        ValueError
-            If ``stop_at_resource_kind`` is not reachable from ``kind`` in the
-            requested ``hierarchy_direction``.
-        ValueError
-            If ``stop_at_resource_kind`` is used with ``hierarchy_direction='both'``.
+            * single identifier, hydrated    → ``dict[CoreResourceKinds, dict[str, ADOResource]]``
+            * multiple identifiers, hydrated → ``dict[str, dict[CoreResourceKinds, dict[str, ADOResource]]]``
+            * single identifier, ids only    → ``dict[CoreResourceKinds, list[str]]``
+            * multiple identifiers, ids only → ``dict[str, dict[CoreResourceKinds, list[str]]]``
+
+            Start identifiers are **excluded** from the returned results.
+
+        Raises:
+            ValueError: If ``hierarchy_direction`` is not ``'up'``, ``'down'``
+                or ``'both'``.
+            ValueError: If ``identifier=None`` is used with
+                ``hierarchy_direction='both'``.
+            ValueError: If ``stop_at_resource_kind`` is not reachable from
+                ``kind`` in the requested ``hierarchy_direction``.
+            ValueError: If ``stop_at_resource_kind`` is used with
+                ``hierarchy_direction='both'``.
         """
         # ------------------------------------------------------------------
         # 1. Resolve the requested identifiers and record whether a single
@@ -1700,25 +1696,25 @@ class SQLResourceStore(ResourceStore):
         # ------------------------------------------------------------------
         # 3. Process raw rows into two parallel data structures:
         #
-        #    relationship_graph
+        #    related_by_origin
         #        Maps each origin identifier to the related identifiers it
         #        reached, grouped by kind.  This is the final return value
         #        for identifier mode, and the skeleton used to build the
         #        hydrated return value.
         #            { origin_id -> { CoreResourceKinds -> [related_id, ...] } }
         #
-        #    ordered_identifiers_retrieved / identifiers_retrieved
-        #        A deduplication-paired list+set of every discovered
-        #        identifier across all origins, in first-seen row order.
-        #        Used in hydrated mode to fetch all resources in a single
-        #        batched query while preserving a stable ordering.
+        #    identifiers_to_fetch / seen_identifiers
+        #        A deduplication-paired list+set of every discovered identifier
+        #        across all origins, in first-seen row order.  Used in hydrated
+        #        mode to fetch all resources in a single batched query while
+        #        preserving a stable ordering.
         #
         #    Start identifiers (_identifiers_requested) are excluded from
         #    both structures so they never appear in the result.
         # ------------------------------------------------------------------
-        relationship_graph: dict[str, dict[CoreResourceKinds, list[str]]] = {}
-        ordered_identifiers_retrieved: list[str] = []
-        identifiers_retrieved: set[str] = set()
+        related_by_origin: dict[str, dict[CoreResourceKinds, list[str]]] = {}
+        identifiers_to_fetch: list[str] = []
+        seen_identifiers: set[str] = set()
 
         for row in raw_rows:
             identifier_from = row.origin_identifier
@@ -1730,44 +1726,34 @@ class SQLResourceStore(ResourceStore):
                 continue
 
             resource_kind = CoreResourceKinds(identifier_to_kind)
-            # Register identifier_to under its origin and kind, deduplicating
-            # within each list by only appending when not already present.
-            # On the first row for a given (identifier_from, resource_kind) pair,
-            # setdefault seeds the list with [identifier_to] and returns it; the
-            # subsequent guard finds it already present and skips the append.
-            # For later rows with the same pair, setdefault returns the existing
-            # list and the guard appends only if identifier_to is not yet in it.
-            related_identifiers_by_kind = relationship_graph.setdefault(
-                identifier_from, {}
-            ).setdefault(resource_kind, [identifier_to])
-            if identifier_to not in related_identifiers_by_kind:
-                related_identifiers_by_kind.append(identifier_to)
+            kind_list = related_by_origin.setdefault(identifier_from, {}).setdefault(
+                resource_kind, []
+            )
+            if identifier_to not in kind_list:
+                kind_list.append(identifier_to)
 
-            if identifier_to not in identifiers_retrieved:
-                ordered_identifiers_retrieved.append(identifier_to)
-                identifiers_retrieved.add(identifier_to)
+            if identifier_to not in seen_identifiers:
+                identifiers_to_fetch.append(identifier_to)
+                seen_identifiers.add(identifier_to)
 
         # ------------------------------------------------------------------
         # 4. Shape the result
         # ------------------------------------------------------------------
         if identifiers_only:
-            # Identifier mode
             if _single_identifier_requested:
-                return relationship_graph.get(next(iter(_identifiers_requested)), {})
-            return relationship_graph
+                return related_by_origin.get(next(iter(_identifiers_requested)), {})
+            return related_by_origin
 
         # Hydrated mode: fetch all discovered identifiers in one query,
         # then rebuild the graph with full resources
-        resources_by_identifier = self.getResources(
-            identifiers=ordered_identifiers_retrieved
-        )
+        resources_by_identifier = self.getResources(identifiers=identifiers_to_fetch)
 
         hydrated: dict[
             str,
             dict[CoreResourceKinds, dict[str, orchestrator.core.resources.ADOResource]],
         ] = {}
 
-        for identifier_from, related_identifiers_by_kind in relationship_graph.items():
+        for identifier_from, related_identifiers_by_kind in related_by_origin.items():
 
             hydrated_related_resources_by_kind: dict[
                 CoreResourceKinds,

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1752,14 +1752,15 @@ class SQLResourceStore(ResourceStore):
             identifier_to = row.identifier
             identifier_to_kind = row.kind
 
-            # Never include the start identifiers in discovered results
+            # Don't include the start identifiers in discovered results
+            # This should never happen, if it does, we have a bug.
             if identifier_to in _identifiers_requested:
                 continue
 
             resource_kind = CoreResourceKinds(identifier_to_kind)
-
             origin_seen = seen_by_origin.setdefault(identifier_from, {})
             kind_seen = origin_seen.setdefault(resource_kind, set())
+
             if identifier_to not in kind_seen:
                 kind_seen.add(identifier_to)
                 related_by_origin.setdefault(identifier_from, {}).setdefault(

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1582,6 +1582,7 @@ class SQLResourceStore(ResourceStore):
         hierarchy_direction: Literal["up", "down", "both"],
         max_hops: int | None = None,
         identifiers_only: bool = False,
+        include_start_resources: bool = False,
     ) -> (
         dict[CoreResourceKinds, list[str]]
         | dict[str, dict[CoreResourceKinds, list[str]]]
@@ -1632,6 +1633,12 @@ class SQLResourceStore(ResourceStore):
                 :class:`~orchestrator.core.resources.ADOResource` objects via
                 :meth:`getResources`. When ``True`` only discovered identifiers
                 are returned.
+            include_start_resources: When ``True``, the start resource(s)
+                provided via ``identifier`` are included in the returned result
+                under their own ``kind`` key, alongside the discovered related
+                resources. Requires ``identifiers_only=False`` and
+                ``identifier`` to be a ``str`` or ``set[str]`` (not ``None``);
+                raises ``ValueError`` if either constraint is violated.
 
         Returns:
             The return type depends on whether a single identifier (``str``) or
@@ -1643,14 +1650,31 @@ class SQLResourceStore(ResourceStore):
             * single identifier, ids only    → ``dict[CoreResourceKinds, list[str]]``
             * multiple identifiers, ids only → ``dict[str, dict[CoreResourceKinds, list[str]]]``
 
-            Start identifiers are **excluded** from the returned results.
+            By default start identifiers are **excluded** from the returned
+            results. Pass ``include_start_resources=True`` to include them.
 
         Raises:
             ValueError: If ``hierarchy_direction`` is not ``'up'``, ``'down'``
                 or ``'both'``.
             ValueError: If ``identifier=None`` is used with
                 ``hierarchy_direction='both'``.
+            ValueError: If ``include_start_resources=True`` is used together
+                with ``identifiers_only=True``.
+            ValueError: If ``include_start_resources=True`` is used with
+                ``identifier=None``.
         """
+        # ------------------------------------------------------------------
+        # 0. Validate incompatible flag combination
+        # ------------------------------------------------------------------
+        if include_start_resources and identifiers_only:
+            raise ValueError(
+                "include_start_resources=True requires identifiers_only=False"
+            )
+        if include_start_resources and identifier is None:
+            raise ValueError(
+                "include_start_resources=True requires identifier to be a str or set[str], not None"
+            )
+
         # ------------------------------------------------------------------
         # 1. Resolve the requested identifiers and record whether a single
         #    identifier was requested (determines the unwrapped return shape)
@@ -1745,8 +1769,20 @@ class SQLResourceStore(ResourceStore):
             return related_by_origin
 
         # Hydrated mode: fetch all discovered identifiers in one query,
-        # then rebuild the graph with full resources
-        resources_by_identifier = self.getResources(identifiers=identifiers_to_fetch)
+        # then rebuild the graph with full resources.
+        # When include_start_resources is True, also fetch the start resources
+        # so they can be merged into each origin's result under their own kind.
+        all_identifiers_to_fetch = list(identifiers_to_fetch)
+        if include_start_resources:
+            all_identifiers_to_fetch.extend(
+                start_id
+                for start_id in _identifiers_requested
+                if start_id not in seen_identifiers
+            )
+
+        resources_by_identifier = self.getResources(
+            identifiers=all_identifiers_to_fetch
+        )
 
         hydrated: dict[
             str,
@@ -1770,8 +1806,24 @@ class SQLResourceStore(ResourceStore):
                     if identifier_to in resources_by_identifier
                 }
 
+            if include_start_resources and identifier_from in resources_by_identifier:
+                start_resource = resources_by_identifier[identifier_from]
+                hydrated_related_resources_by_kind.setdefault(kind, {})[
+                    identifier_from
+                ] = start_resource
+
             if hydrated_related_resources_by_kind:
                 hydrated[identifier_from] = hydrated_related_resources_by_kind
+
+        # When include_start_resources is True but a start identifier had no
+        # related resources, it won't appear in related_by_origin yet — ensure
+        # it still gets an entry in hydrated.
+        if include_start_resources:
+            for start_id in _identifiers_requested:
+                if start_id not in hydrated and start_id in resources_by_identifier:
+                    hydrated[start_id] = {
+                        kind: {start_id: resources_by_identifier[start_id]}
+                    }
 
         if _single_identifier_requested:
             return hydrated.get(next(iter(_identifiers_requested)), {})

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1666,6 +1666,11 @@ class SQLResourceStore(ResourceStore):
         # ------------------------------------------------------------------
         # 0. Validate parameters eagerly
         # ------------------------------------------------------------------
+        if hierarchy_direction not in {"up", "down", "both"}:
+            raise ValueError(
+                f"hierarchy_direction must be 'up', 'down' or 'both', got {hierarchy_direction!r}"
+            )
+
         if max_hops is not None and max_hops < 1:
             raise ValueError(f"max_hops must be a positive integer, got {max_hops!r}")
 

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1673,9 +1673,15 @@ class SQLResourceStore(ResourceStore):
             raise ValueError(
                 "include_start_resources=True requires identifiers_only=False"
             )
+
         if include_start_resources and identifier is None:
             raise ValueError(
                 "include_start_resources=True requires identifier to be a str or set[str], not None"
+            )
+
+        if identifier is None and hierarchy_direction == "both":
+            raise ValueError(
+                "identifier=None is not supported for hierarchy_direction='both'"
             )
 
         # ------------------------------------------------------------------
@@ -1685,17 +1691,13 @@ class SQLResourceStore(ResourceStore):
         _single_identifier_requested: bool
         _identifiers_requested: set[str]
 
-        if isinstance(identifier, str):
-            _single_identifier_requested = True
-            _identifiers_requested = {identifier}
-        elif identifier is None:
-            if hierarchy_direction == "both":
-                raise ValueError(
-                    "identifier=None is not supported for hierarchy_direction='both'"
-                )
+        if identifier is None:
             _single_identifier_requested = False
             df = self.getResourceIdentifiersOfKind(kind=kind.value)
             _identifiers_requested = set(df["IDENTIFIER"].tolist())
+        elif isinstance(identifier, str):
+            _single_identifier_requested = True
+            _identifiers_requested = {identifier}
         else:
             # set[str]
             _single_identifier_requested = False

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1580,7 +1580,7 @@ class SQLResourceStore(ResourceStore):
         kind: CoreResourceKinds,
         identifier: str | set[str] | None,
         hierarchy_direction: Literal["up", "down", "both"],
-        stop_at_resource_kind: CoreResourceKinds | None = None,
+        max_hops: int | None = None,
         identifiers_only: bool = False,
     ) -> (
         dict[CoreResourceKinds, list[str]]
@@ -1620,11 +1620,13 @@ class SQLResourceStore(ResourceStore):
 
             hierarchy_direction: ``'up'`` (child → parent), ``'down'``
                 (parent → child), or ``'both'``.
-            stop_at_resource_kind: When provided, the stop-kind row is included
-                in results but recursion does not continue beyond it. Must be a
-                valid kind reachable from ``kind`` in the requested
-                ``hierarchy_direction``. Not supported when
-                ``hierarchy_direction='both'``.
+            max_hops: Maximum number of relationship hops to follow from each
+                start resource. When ``None`` the traversal runs to the full
+                depth of the hierarchy. For ``hierarchy_direction='both'`` the
+                limit is applied independently to each direction (e.g.
+                ``max_hops=1`` yields one hop up *and* one hop down). Values
+                exceeding the hierarchy maximum (currently 3, matching the 4
+                resource levels) are silently capped at that maximum.
             identifiers_only: When ``False`` (default) discovered identifiers
                 are hydrated into full
                 :class:`~orchestrator.core.resources.ADOResource` objects via
@@ -1647,10 +1649,6 @@ class SQLResourceStore(ResourceStore):
             ValueError: If ``hierarchy_direction`` is not ``'up'``, ``'down'``
                 or ``'both'``.
             ValueError: If ``identifier=None`` is used with
-                ``hierarchy_direction='both'``.
-            ValueError: If ``stop_at_resource_kind`` is not reachable from
-                ``kind`` in the requested ``hierarchy_direction``.
-            ValueError: If ``stop_at_resource_kind`` is used with
                 ``hierarchy_direction='both'``.
         """
         # ------------------------------------------------------------------
@@ -1683,11 +1681,13 @@ class SQLResourceStore(ResourceStore):
         # ------------------------------------------------------------------
         # 2. Build and execute the single traversal query
         # ------------------------------------------------------------------
+        # The hierarchy maximum (3 hops across 4 levels) is enforced inside
+        # graph_traversal_query; passing max_hops=None lets it use the full cap.
         query = orchestrator.metastore.sql.statements.graph_traversal_query(
             kind=kind,
             hierarchy_direction=hierarchy_direction,
             origin_identifiers=_identifiers_requested,
-            stop_at_resource_kind=stop_at_resource_kind,
+            max_hops=max_hops,
         )
 
         with self.engine.connect() as connectable:

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1584,8 +1584,8 @@ class SQLResourceStore(ResourceStore):
         identifiers_only: bool = False,
         include_start_resources: bool = False,
     ) -> (
-        dict[CoreResourceKinds, list[str]]
-        | dict[str, dict[CoreResourceKinds, list[str]]]
+        dict[CoreResourceKinds, set[str]]
+        | dict[str, dict[CoreResourceKinds, set[str]]]
         | dict[CoreResourceKinds, dict[str, "orchestrator.core.resources.ADOResource"]]
         | dict[
             str,
@@ -1647,8 +1647,8 @@ class SQLResourceStore(ResourceStore):
 
             * single identifier, hydrated    → ``dict[CoreResourceKinds, dict[str, ADOResource]]``
             * multiple identifiers, hydrated → ``dict[str, dict[CoreResourceKinds, dict[str, ADOResource]]]``
-            * single identifier, ids only    → ``dict[CoreResourceKinds, list[str]]``
-            * multiple identifiers, ids only → ``dict[str, dict[CoreResourceKinds, list[str]]]``
+            * single identifier, ids only    → ``dict[CoreResourceKinds, set[str]]``
+            * multiple identifiers, ids only → ``dict[str, dict[CoreResourceKinds, set[str]]]``
 
             By default start identifiers are **excluded** from the returned
             results. Pass ``include_start_resources=True`` to include them.
@@ -1723,32 +1723,28 @@ class SQLResourceStore(ResourceStore):
             raw_rows = connectable.execute(query).fetchall()
 
         # ------------------------------------------------------------------
-        # 3. Process raw rows into two parallel data structures:
+        # 3. Process raw rows into:
         #
         #    related_by_origin
         #        Maps each origin identifier to the related identifiers it
         #        reached, grouped by kind.  This is the final return value
-        #        for identifier mode, and the skeleton used to build the
-        #        hydrated return value.
-        #            { origin_id -> { CoreResourceKinds -> [related_id, ...] } }
+        #        for identifiers_only mode, and the skeleton used to build
+        #        the hydrated return value.
+        #            { origin_id -> { CoreResourceKinds -> {related_id, ...} } }
         #
-        #    identifiers_to_fetch / seen_identifiers
-        #        A deduplication-paired list+set of every discovered identifier
-        #        across all origins, in first-seen row order.  Used in hydrated
-        #        mode to fetch all resources in a single batched query while
-        #        preserving a stable ordering.
+        #    identifiers_to_fetch
+        #        The set of every discovered identifier across all origins.
+        #        Used in hydrated mode to fetch all resources in one batched
+        #        query.
         #
         #    Start identifiers (_identifiers_requested) are excluded from
         #    both structures so they never appear in the result.
         # ------------------------------------------------------------------
-        related_by_origin: dict[str, dict[CoreResourceKinds, list[str]]] = {}
-        # seen_by_origin tracks per-(origin, kind) seen sets for O(1) dedup
-        seen_by_origin: dict[str, dict[CoreResourceKinds, set[str]]] = {}
-        identifiers_to_fetch: list[str] = []
-        seen_identifiers: set[str] = set()
+        related_by_origin: dict[str, dict[CoreResourceKinds, set[str]]] = {}
+        identifiers_to_fetch: set[str] = set()
 
         for row in raw_rows:
-            identifier_from = row.origin_identifier
+            origin_identifier = row.origin_identifier
             identifier_to = row.identifier
             identifier_to_kind = row.kind
 
@@ -1757,19 +1753,11 @@ class SQLResourceStore(ResourceStore):
             if identifier_to in _identifiers_requested:
                 continue
 
+            identifiers_to_fetch.add(identifier_to)
             resource_kind = CoreResourceKinds(identifier_to_kind)
-            origin_seen = seen_by_origin.setdefault(identifier_from, {})
-            kind_seen = origin_seen.setdefault(resource_kind, set())
-
-            if identifier_to not in kind_seen:
-                kind_seen.add(identifier_to)
-                related_by_origin.setdefault(identifier_from, {}).setdefault(
-                    resource_kind, []
-                ).append(identifier_to)
-
-            if identifier_to not in seen_identifiers:
-                identifiers_to_fetch.append(identifier_to)
-                seen_identifiers.add(identifier_to)
+            related_by_origin.setdefault(origin_identifier, {}).setdefault(
+                resource_kind, set()
+            ).add(identifier_to)
 
         # ------------------------------------------------------------------
         # 4. Shape the result
@@ -1781,22 +1769,18 @@ class SQLResourceStore(ResourceStore):
 
         # Hydrated mode: fetch all discovered identifiers in one query,
         # then rebuild the graph with full resources.
-        # When include_start_resources is True, also fetch the start resources
-        # so they can be merged into each origin's result under their own kind.
-        all_identifiers_to_fetch = list(identifiers_to_fetch)
+        # When include_start_resources is True, also fetch the start resources.
         if include_start_resources:
-            all_identifiers_to_fetch.extend(_identifiers_requested)
+            identifiers_to_fetch = identifiers_to_fetch.union(_identifiers_requested)
 
-        resources_by_identifier = self.getResources(
-            identifiers=all_identifiers_to_fetch
-        )
+        resources = self.getResources(identifiers=list(identifiers_to_fetch))
 
         hydrated: dict[
             str,
             dict[CoreResourceKinds, dict[str, orchestrator.core.resources.ADOResource]],
         ] = {}
 
-        for identifier_from, related_identifiers_by_kind in related_by_origin.items():
+        for origin_identifier, related_identifiers_by_kind in related_by_origin.items():
 
             hydrated_related_resources_by_kind: dict[
                 CoreResourceKinds,
@@ -1807,30 +1791,29 @@ class SQLResourceStore(ResourceStore):
                 resource_kind,
                 related_identifiers,
             ) in related_identifiers_by_kind.items():
+
                 hydrated_related_resources_by_kind[resource_kind] = {
-                    identifier_to: resources_by_identifier[identifier_to]
-                    for identifier_to in related_identifiers
-                    if identifier_to in resources_by_identifier
+                    identifier: resources[identifier]
+                    for identifier in related_identifiers
+                    if identifier in resources
                 }
 
-            if include_start_resources and identifier_from in resources_by_identifier:
-                start_resource = resources_by_identifier[identifier_from]
+            if include_start_resources and origin_identifier in resources:
+                start_resource = resources[origin_identifier]
                 hydrated_related_resources_by_kind.setdefault(kind, {})[
-                    identifier_from
+                    origin_identifier
                 ] = start_resource
 
             if hydrated_related_resources_by_kind:
-                hydrated[identifier_from] = hydrated_related_resources_by_kind
+                hydrated[origin_identifier] = hydrated_related_resources_by_kind
 
         # When include_start_resources is True but a start identifier had no
         # related resources, it won't appear in related_by_origin yet — ensure
         # it still gets an entry in hydrated.
         if include_start_resources:
             for start_id in _identifiers_requested:
-                if start_id not in hydrated and start_id in resources_by_identifier:
-                    hydrated[start_id] = {
-                        kind: {start_id: resources_by_identifier[start_id]}
-                    }
+                if start_id not in hydrated and start_id in resources:
+                    hydrated[start_id] = {kind: {start_id: resources[start_id]}}
 
         if _single_identifier_requested:
             return hydrated.get(next(iter(_identifiers_requested)), {})

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1664,8 +1664,11 @@ class SQLResourceStore(ResourceStore):
                 ``identifier=None``.
         """
         # ------------------------------------------------------------------
-        # 0. Validate incompatible flag combination
+        # 0. Validate parameters eagerly
         # ------------------------------------------------------------------
+        if max_hops is not None and max_hops < 1:
+            raise ValueError(f"max_hops must be a positive integer, got {max_hops!r}")
+
         if include_start_resources and identifiers_only:
             raise ValueError(
                 "include_start_resources=True requires identifiers_only=False"
@@ -1779,9 +1782,7 @@ class SQLResourceStore(ResourceStore):
         # so they can be merged into each origin's result under their own kind.
         all_identifiers_to_fetch = list(identifiers_to_fetch)
         if include_start_resources:
-            # Start identifiers are always excluded from seen_identifiers (filtered
-            # out in the loop above), so extend unconditionally.
-            all_identifiers_to_fetch.extend(_identifiers_requested - seen_identifiers)
+            all_identifiers_to_fetch.extend(_identifiers_requested)
 
         resources_by_identifier = self.getResources(
             identifiers=all_identifiers_to_fetch

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -660,7 +660,7 @@ def test_get_latest_resource_identifiers_of_kinds_multiple_invalid_kinds(
 
 
 ###############################################################################
-# get_related_resources_by_relationship
+# get_resources_by_relationship
 ###############################################################################
 
 # ---------------------------------------------------------------------------
@@ -682,6 +682,10 @@ def resource_hierarchy(
         samplestore_id, discoveryspace_id, operation_id,
         datacontainer_id, actuatorconfiguration_id, store
     """
+    import pathlib
+
+    import yaml
+
     import orchestrator.core.actuatorconfiguration.config
     from orchestrator.core import ActuatorConfigurationResource, SampleStoreResource
     from orchestrator.core.samplestore.config import (
@@ -722,14 +726,10 @@ def resource_hierarchy(
     # 5. actuatorconfiguration — stored as subject, operation as object,
     #    matching the production path in addResourceWithRelationships(operation,
     #    relatedIdentifiers=[..., actconf_id]).
-    import yaml
-
     ac_config = orchestrator.core.actuatorconfiguration.config.ActuatorConfiguration.model_validate(
         yaml.safe_load(
-            (
-                __import__("pathlib").Path(
-                    "tests/resources/replay_actuatorconfiguration.yaml"
-                )
+            pathlib.Path(
+                "tests/resources/replay_actuatorconfiguration.yaml"
             ).read_text()
         )
     )
@@ -764,7 +764,7 @@ def test_up_from_operation_capped_at_discoveryspace(
     op_id = resource_hierarchy["operation_id"]
     ds_id = resource_hierarchy["discoveryspace_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="up",
@@ -787,7 +787,7 @@ def test_up_from_operation_uncapped_returns_discoveryspace_and_samplestore(
     ds_id = resource_hierarchy["discoveryspace_id"]
     ss_id = resource_hierarchy["samplestore_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="up",
@@ -808,7 +808,7 @@ def test_up_from_operation_capped_at_samplestore_returns_both_kinds(
     store: SQLStore = resource_hierarchy["store"]
     op_id = resource_hierarchy["operation_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="up",
@@ -834,7 +834,7 @@ def test_up_from_discoveryspace_returns_samplestore_only(
     ds_id = resource_hierarchy["discoveryspace_id"]
     ss_id = resource_hierarchy["samplestore_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.DISCOVERYSPACE,
         identifier=ds_id,
         hierarchy_direction="up",
@@ -859,7 +859,7 @@ def test_down_from_samplestore_capped_at_discoveryspace(
     ss_id = resource_hierarchy["samplestore_id"]
     ds_id = resource_hierarchy["discoveryspace_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=ss_id,
         hierarchy_direction="down",
@@ -883,7 +883,7 @@ def test_down_from_samplestore_capped_at_operation(
     ss_id = resource_hierarchy["samplestore_id"]
     op_id = resource_hierarchy["operation_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=ss_id,
         hierarchy_direction="down",
@@ -908,7 +908,7 @@ def test_down_from_samplestore_uncapped_returns_full_hierarchy(
     dc_id = resource_hierarchy["datacontainer_id"]
     ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=ss_id,
         hierarchy_direction="down",
@@ -937,7 +937,7 @@ def test_down_from_discoveryspace_capped_at_operation(
     ds_id = resource_hierarchy["discoveryspace_id"]
     op_id = resource_hierarchy["operation_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.DISCOVERYSPACE,
         identifier=ds_id,
         hierarchy_direction="down",
@@ -961,7 +961,7 @@ def test_down_from_discoveryspace_uncapped_returns_operation_dc_ac(
     dc_id = resource_hierarchy["datacontainer_id"]
     ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.DISCOVERYSPACE,
         identifier=ds_id,
         hierarchy_direction="down",
@@ -990,7 +990,7 @@ def test_down_from_operation_returns_datacontainer_and_actuatorconfiguration(
     dc_id = resource_hierarchy["datacontainer_id"]
     ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="down",
@@ -1015,7 +1015,7 @@ def test_both_from_operation_returns_ancestors_and_descendants(
     dc_id = resource_hierarchy["datacontainer_id"]
     ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="both",  # type: ignore[arg-type]
@@ -1039,7 +1039,7 @@ def test_up_from_datacontainer_returns_operation_discoveryspace_and_samplestore(
     ds_id = resource_hierarchy["discoveryspace_id"]
     ss_id = resource_hierarchy["samplestore_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.DATACONTAINER,
         identifier=dc_id,
         hierarchy_direction="up",
@@ -1055,14 +1055,22 @@ def test_up_from_datacontainer_returns_operation_discoveryspace_and_samplestore(
 def test_both_from_datacontainer_returns_rooted_ancestors_only(
     resource_hierarchy: dict,
 ) -> None:
-    """both from datacontainer returns rooted ancestors only, not siblings via operation."""
+    """both from datacontainer returns ancestors only, not siblings via operation.
+
+    The resource_hierarchy fixture creates an actuatorconfiguration linked to
+    the same operation as the datacontainer.  When traversing 'both' from the
+    datacontainer that actuatorconfiguration is a sibling (reachable only via
+    the shared operation going down then across), not an ancestor or descendant,
+    so it must not appear in the result.
+    """
     store: SQLStore = resource_hierarchy["store"]
     dc_id = resource_hierarchy["datacontainer_id"]
     op_id = resource_hierarchy["operation_id"]
     ds_id = resource_hierarchy["discoveryspace_id"]
     ss_id = resource_hierarchy["samplestore_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.DATACONTAINER,
         identifier=dc_id,
         hierarchy_direction="both",  # type: ignore[arg-type]
@@ -1072,7 +1080,11 @@ def test_both_from_datacontainer_returns_rooted_ancestors_only(
     assert op_id in result[CoreResourceKinds.OPERATION]
     assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
     assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+    # The actuatorconfiguration exists in the store and shares the same
+    # parent operation, but must not appear because it is not an ancestor
+    # or descendant of dc_id.
     assert CoreResourceKinds.ACTUATORCONFIGURATION not in result
+    assert ac_id not in {ident for kind_ids in result.values() for ident in kind_ids}
 
 
 @requires_sqlite_3_38
@@ -1086,7 +1098,7 @@ def test_up_from_actuatorconfiguration_returns_operation_discoveryspace_and_samp
     ds_id = resource_hierarchy["discoveryspace_id"]
     ss_id = resource_hierarchy["samplestore_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.ACTUATORCONFIGURATION,
         identifier=ac_id,
         hierarchy_direction="up",
@@ -1109,7 +1121,7 @@ def test_both_from_actuatorconfiguration_returns_rooted_ancestors_only(
     ds_id = resource_hierarchy["discoveryspace_id"]
     ss_id = resource_hierarchy["samplestore_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.ACTUATORCONFIGURATION,
         identifier=ac_id,
         hierarchy_direction="both",  # type: ignore[arg-type]
@@ -1134,7 +1146,7 @@ def test_both_from_discoveryspace_returns_rooted_ancestors_and_descendants_only(
     dc_id = resource_hierarchy["datacontainer_id"]
     ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.DISCOVERYSPACE,
         identifier=ds_id,
         hierarchy_direction="both",  # type: ignore[arg-type]
@@ -1256,7 +1268,7 @@ def test_multi_start_returns_per_origin_grouping(
     dc1_id = two_op_hierarchy["dc1_id"]
     dc2_id = two_op_hierarchy["dc2_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier={op1_id, op2_id},
         hierarchy_direction="down",
@@ -1286,7 +1298,7 @@ def test_multi_start_shared_resource_appears_under_each_origin(
     op2_id = two_op_hierarchy["op2_id"]
     ds_id = two_op_hierarchy["ds_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier={op1_id, op2_id},
         hierarchy_direction="up",
@@ -1312,7 +1324,7 @@ def test_identifier_none_seeds_from_all_resources_of_kind(
     op_id = resource_hierarchy["operation_id"]
     ds_id = resource_hierarchy["discoveryspace_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=None,
         hierarchy_direction="up",
@@ -1342,7 +1354,7 @@ def test_hydrated_single_start_returns_resources(
     op_id = resource_hierarchy["operation_id"]
     dc_id = resource_hierarchy["datacontainer_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="down",
@@ -1368,13 +1380,13 @@ def test_hydrated_multi_start_grouping_matches_identifier_mode(
     dc1_id = two_op_hierarchy["dc1_id"]
     dc2_id = two_op_hierarchy["dc2_id"]
 
-    result_ids = store.get_related_resources_by_relationship(
+    result_ids = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier={op1_id, op2_id},
         hierarchy_direction="down",
         identifiers_only=True,
     )
-    result_hydrated = store.get_related_resources_by_relationship(
+    result_hydrated = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier={op1_id, op2_id},
         hierarchy_direction="down",
@@ -1406,7 +1418,7 @@ def test_hydrated_start_identifier_excluded(
     store: SQLStore = resource_hierarchy["store"]
     op_id = resource_hierarchy["operation_id"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="down",
@@ -1432,7 +1444,7 @@ def test_invalid_direction_raises_value_error(
     with pytest.raises(
         ValueError, match="hierarchy_direction must be 'up', 'down' or 'both'"
     ):
-        store.get_related_resources_by_relationship(
+        store.get_resources_by_relationship(
             kind=CoreResourceKinds.OPERATION,
             identifier="any",
             hierarchy_direction="sideways",  # type: ignore[arg-type]
@@ -1445,7 +1457,7 @@ def test_valid_kind_direction_combo_with_no_reachable_resources_returns_empty(
     """A valid traversal family with no reachable resources returns an empty dict."""
     store: SQLStore = resource_hierarchy["store"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=resource_hierarchy["samplestore_id"],
         hierarchy_direction="up",
@@ -1461,7 +1473,7 @@ def test_invalid_max_target_kind_raises_value_error(
     """max_target_kind not reachable in selected family raises ValueError."""
     store: SQLStore = resource_hierarchy["store"]
     with pytest.raises(ValueError, match="stop_at_resource_kind="):
-        store.get_related_resources_by_relationship(
+        store.get_resources_by_relationship(
             kind=CoreResourceKinds.OPERATION,
             identifier="any",
             hierarchy_direction="up",
@@ -1480,7 +1492,7 @@ def test_identifier_none_with_both_raises_value_error(
         ValueError,
         match="identifier=None is not supported for hierarchy_direction='both'",
     ):
-        store.get_related_resources_by_relationship(
+        store.get_resources_by_relationship(
             kind=CoreResourceKinds.OPERATION,
             identifier=None,
             hierarchy_direction="both",  # type: ignore[arg-type]
@@ -1499,7 +1511,7 @@ def test_stop_at_resource_kind_with_both_raises_value_error(
         ValueError,
         match="stop_at_resource_kind is not supported for hierarchy_direction='both'",
     ):
-        store.get_related_resources_by_relationship(
+        store.get_resources_by_relationship(
             kind=CoreResourceKinds.OPERATION,
             identifier=resource_hierarchy["operation_id"],
             hierarchy_direction="both",  # type: ignore[arg-type]
@@ -1514,7 +1526,7 @@ def test_empty_identifier_set_returns_empty(
     """Empty identifier set returns an empty result immediately."""
     store: SQLStore = resource_hierarchy["store"]
 
-    result = store.get_related_resources_by_relationship(
+    result = store.get_resources_by_relationship(
         kind=CoreResourceKinds.OPERATION,
         identifier=set(),
         hierarchy_direction="down",
@@ -1555,7 +1567,7 @@ def test_valid_traversal_with_no_related_resources(
     )
     sql_store.addResource(ss)
 
-    result = sql_store.get_related_resources_by_relationship(
+    result = sql_store.get_resources_by_relationship(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=ss.identifier,
         hierarchy_direction="down",

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -1003,6 +1003,151 @@ def test_down_from_operation_returns_datacontainer_and_actuatorconfiguration(
     assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
 
 
+@requires_sqlite_3_38
+def test_both_from_operation_returns_ancestors_and_descendants(
+    resource_hierarchy: dict,
+) -> None:
+    """both from operation returns discoveryspace, samplestore, datacontainer and actuatorconfiguration."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="both",  # type: ignore[arg-type]
+        identifiers_only=True,
+    )
+
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+    assert dc_id in result[CoreResourceKinds.DATACONTAINER]
+    assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
+
+
+@requires_sqlite_3_38
+def test_up_from_datacontainer_returns_operation_discoveryspace_and_samplestore(
+    resource_hierarchy: dict,
+) -> None:
+    """up from datacontainer returns operation, discoveryspace and samplestore."""
+    store: SQLStore = resource_hierarchy["store"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.DATACONTAINER,
+        identifier=dc_id,
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+
+
+@requires_sqlite_3_38
+def test_both_from_datacontainer_returns_rooted_ancestors_only(
+    resource_hierarchy: dict,
+) -> None:
+    """both from datacontainer returns rooted ancestors only, not siblings via operation."""
+    store: SQLStore = resource_hierarchy["store"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.DATACONTAINER,
+        identifier=dc_id,
+        hierarchy_direction="both",  # type: ignore[arg-type]
+        identifiers_only=True,
+    )
+
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+    assert CoreResourceKinds.ACTUATORCONFIGURATION not in result
+
+
+@requires_sqlite_3_38
+def test_up_from_actuatorconfiguration_returns_operation_discoveryspace_and_samplestore(
+    resource_hierarchy: dict,
+) -> None:
+    """up from actuatorconfiguration returns operation, discoveryspace and samplestore."""
+    store: SQLStore = resource_hierarchy["store"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.ACTUATORCONFIGURATION,
+        identifier=ac_id,
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+
+
+@requires_sqlite_3_38
+def test_both_from_actuatorconfiguration_returns_rooted_ancestors_only(
+    resource_hierarchy: dict,
+) -> None:
+    """both from actuatorconfiguration returns rooted ancestors only, not siblings via operation."""
+    store: SQLStore = resource_hierarchy["store"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.ACTUATORCONFIGURATION,
+        identifier=ac_id,
+        hierarchy_direction="both",  # type: ignore[arg-type]
+        identifiers_only=True,
+    )
+
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+    assert CoreResourceKinds.DATACONTAINER not in result
+
+
+@requires_sqlite_3_38
+def test_both_from_discoveryspace_returns_rooted_ancestors_and_descendants_only(
+    resource_hierarchy: dict,
+) -> None:
+    """both from discoveryspace excludes sibling discoveryspaces under the same samplestore."""
+    store: SQLStore = resource_hierarchy["store"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+    op_id = resource_hierarchy["operation_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=ds_id,
+        hierarchy_direction="both",  # type: ignore[arg-type]
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE not in result
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert dc_id in result[CoreResourceKinds.DATACONTAINER]
+    assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
+
+
 # ---------------------------------------------------------------------------
 # multi-start
 # ---------------------------------------------------------------------------
@@ -1284,7 +1429,9 @@ def test_invalid_direction_raises_value_error(
 ) -> None:
     """Unsupported hierarchy_direction raises ValueError."""
     store: SQLStore = resource_hierarchy["store"]
-    with pytest.raises(ValueError, match="hierarchy_direction must be 'up' or 'down'"):
+    with pytest.raises(
+        ValueError, match="hierarchy_direction must be 'up', 'down' or 'both'"
+    ):
         store.get_related_resources_by_relationship(
             kind=CoreResourceKinds.OPERATION,
             identifier="any",
@@ -1292,17 +1439,20 @@ def test_invalid_direction_raises_value_error(
         )
 
 
-def test_invalid_kind_direction_combo_raises_value_error(
+def test_valid_kind_direction_combo_with_no_reachable_resources_returns_empty(
     resource_hierarchy: dict,
 ) -> None:
-    """Unsupported (kind, direction) combination raises ValueError."""
+    """A valid traversal family with no reachable resources returns an empty dict."""
     store: SQLStore = resource_hierarchy["store"]
-    with pytest.raises(ValueError, match="Unsupported traversal family"):
-        store.get_related_resources_by_relationship(
-            kind=CoreResourceKinds.SAMPLESTORE,
-            identifier="any",
-            hierarchy_direction="up",
-        )
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.SAMPLESTORE,
+        identifier=resource_hierarchy["samplestore_id"],
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    assert result == {}
 
 
 def test_invalid_max_target_kind_raises_value_error(
@@ -1316,6 +1466,45 @@ def test_invalid_max_target_kind_raises_value_error(
             identifier="any",
             hierarchy_direction="up",
             stop_at_resource_kind=CoreResourceKinds.DATACONTAINER,
+        )
+
+
+@requires_sqlite_3_38
+def test_identifier_none_with_both_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """identifier=None is not supported when hierarchy_direction is both."""
+    store: SQLStore = resource_hierarchy["store"]
+
+    with pytest.raises(
+        ValueError,
+        match="identifier=None is not supported for hierarchy_direction='both'",
+    ):
+        store.get_related_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=None,
+            hierarchy_direction="both",  # type: ignore[arg-type]
+            identifiers_only=True,
+        )
+
+
+@requires_sqlite_3_38
+def test_stop_at_resource_kind_with_both_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """stop_at_resource_kind is not supported when hierarchy_direction is both."""
+    store: SQLStore = resource_hierarchy["store"]
+
+    with pytest.raises(
+        ValueError,
+        match="stop_at_resource_kind is not supported for hierarchy_direction='both'",
+    ):
+        store.get_related_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=resource_hierarchy["operation_id"],
+            hierarchy_direction="both",  # type: ignore[arg-type]
+            stop_at_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+            identifiers_only=True,
         )
 
 

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -1571,3 +1571,121 @@ def test_valid_traversal_with_no_related_resources(
     )
 
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# include_start_resources
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_include_start_resources_single_identifier(
+    resource_hierarchy: dict,
+) -> None:
+    """include_start_resources=True adds the start resource to the result."""
+    from orchestrator.core.resources import ADOResource
+
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+
+    result = store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="down",
+        identifiers_only=False,
+        include_start_resources=True,
+    )
+
+    assert CoreResourceKinds.OPERATION in result
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert isinstance(result[CoreResourceKinds.OPERATION][op_id], ADOResource)
+
+
+@requires_sqlite_3_38
+def test_include_start_resources_multi_identifier(
+    two_op_hierarchy: dict,
+) -> None:
+    """include_start_resources=True adds each start resource in the multi-identifier result."""
+    from orchestrator.core.resources import ADOResource
+
+    store: SQLStore = two_op_hierarchy["store"]
+    op1_id = two_op_hierarchy["op1_id"]
+    op2_id = two_op_hierarchy["op2_id"]
+
+    result = store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier={op1_id, op2_id},
+        hierarchy_direction="down",
+        identifiers_only=False,
+        include_start_resources=True,
+    )
+
+    for op_id in [op1_id, op2_id]:
+        assert op_id in result
+        assert CoreResourceKinds.OPERATION in result[op_id]
+        assert op_id in result[op_id][CoreResourceKinds.OPERATION]
+        assert isinstance(
+            result[op_id][CoreResourceKinds.OPERATION][op_id], ADOResource
+        )
+
+
+@requires_sqlite_3_38
+def test_include_start_resources_no_related_resources(
+    resource_hierarchy: dict,
+) -> None:
+    """include_start_resources=True still returns the start resource when traversal finds nothing."""
+    from orchestrator.core.resources import ADOResource
+
+    store: SQLStore = resource_hierarchy["store"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_resources_by_relationship(
+        kind=CoreResourceKinds.SAMPLESTORE,
+        identifier=ss_id,
+        hierarchy_direction="up",
+        identifiers_only=False,
+        include_start_resources=True,
+    )
+
+    assert CoreResourceKinds.SAMPLESTORE in result
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+    assert isinstance(result[CoreResourceKinds.SAMPLESTORE][ss_id], ADOResource)
+
+
+def test_include_start_resources_with_identifiers_only_raises(
+    resource_hierarchy: dict,
+) -> None:
+    """include_start_resources=True combined with identifiers_only=True raises ValueError."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+
+    with pytest.raises(
+        ValueError,
+        match="include_start_resources=True requires identifiers_only=False",
+    ):
+        store.get_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=op_id,
+            hierarchy_direction="down",
+            identifiers_only=True,
+            include_start_resources=True,
+        )
+
+
+def test_include_start_resources_with_identifier_none_raises(
+    resource_hierarchy: dict,
+) -> None:
+    """include_start_resources=True combined with identifier=None raises ValueError."""
+    store: SQLStore = resource_hierarchy["store"]
+
+    with pytest.raises(
+        ValueError,
+        match="include_start_resources=True requires identifier to be a str or set",
+    ):
+        store.get_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=None,
+            hierarchy_direction="down",
+            identifiers_only=False,
+            include_start_resources=True,
+        )

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -756,10 +756,10 @@ def resource_hierarchy(
 
 
 @requires_sqlite_3_38
-def test_up_from_operation_capped_at_discoveryspace(
+def test_up_from_operation_max_hops_1(
     resource_hierarchy: dict,
 ) -> None:
-    """up from operation capped at discoveryspace returns only discoveryspace ids."""
+    """up from operation with max_hops=1 returns only discoveryspace ids."""
     store: SQLStore = resource_hierarchy["store"]
     op_id = resource_hierarchy["operation_id"]
     ds_id = resource_hierarchy["discoveryspace_id"]
@@ -768,7 +768,7 @@ def test_up_from_operation_capped_at_discoveryspace(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="up",
-        stop_at_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+        max_hops=1,
         identifiers_only=True,
     )
 
@@ -801,10 +801,10 @@ def test_up_from_operation_uncapped_returns_discoveryspace_and_samplestore(
 
 
 @requires_sqlite_3_38
-def test_up_from_operation_capped_at_samplestore_returns_both_kinds(
+def test_up_from_operation_max_hops_2(
     resource_hierarchy: dict,
 ) -> None:
-    """up from operation capped at samplestore returns both discoveryspace and samplestore."""
+    """up from operation with max_hops=2 returns both discoveryspace and samplestore."""
     store: SQLStore = resource_hierarchy["store"]
     op_id = resource_hierarchy["operation_id"]
 
@@ -812,7 +812,7 @@ def test_up_from_operation_capped_at_samplestore_returns_both_kinds(
         kind=CoreResourceKinds.OPERATION,
         identifier=op_id,
         hierarchy_direction="up",
-        stop_at_resource_kind=CoreResourceKinds.SAMPLESTORE,
+        max_hops=2,
         identifiers_only=True,
     )
 
@@ -851,10 +851,10 @@ def test_up_from_discoveryspace_returns_samplestore_only(
 
 
 @requires_sqlite_3_38
-def test_down_from_samplestore_capped_at_discoveryspace(
+def test_down_from_samplestore_max_hops_1(
     resource_hierarchy: dict,
 ) -> None:
-    """down from samplestore capped at discoveryspace returns only discoveryspace ids."""
+    """down from samplestore with max_hops=1 returns only discoveryspace ids."""
     store: SQLStore = resource_hierarchy["store"]
     ss_id = resource_hierarchy["samplestore_id"]
     ds_id = resource_hierarchy["discoveryspace_id"]
@@ -863,7 +863,7 @@ def test_down_from_samplestore_capped_at_discoveryspace(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=ss_id,
         hierarchy_direction="down",
-        stop_at_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+        max_hops=1,
         identifiers_only=True,
     )
 
@@ -875,10 +875,10 @@ def test_down_from_samplestore_capped_at_discoveryspace(
 
 
 @requires_sqlite_3_38
-def test_down_from_samplestore_capped_at_operation(
+def test_down_from_samplestore_max_hops_2(
     resource_hierarchy: dict,
 ) -> None:
-    """down from samplestore capped at operation returns discoveryspace and operation ids."""
+    """down from samplestore with max_hops=2 returns discoveryspace and operation ids."""
     store: SQLStore = resource_hierarchy["store"]
     ss_id = resource_hierarchy["samplestore_id"]
     op_id = resource_hierarchy["operation_id"]
@@ -887,7 +887,7 @@ def test_down_from_samplestore_capped_at_operation(
         kind=CoreResourceKinds.SAMPLESTORE,
         identifier=ss_id,
         hierarchy_direction="down",
-        stop_at_resource_kind=CoreResourceKinds.OPERATION,
+        max_hops=2,
         identifiers_only=True,
     )
 
@@ -929,10 +929,10 @@ def test_down_from_samplestore_uncapped_returns_full_hierarchy(
 
 
 @requires_sqlite_3_38
-def test_down_from_discoveryspace_capped_at_operation(
+def test_down_from_discoveryspace_max_hops_1(
     resource_hierarchy: dict,
 ) -> None:
-    """down from discoveryspace capped at operation returns only operation ids."""
+    """down from discoveryspace with max_hops=1 returns only operation ids."""
     store: SQLStore = resource_hierarchy["store"]
     ds_id = resource_hierarchy["discoveryspace_id"]
     op_id = resource_hierarchy["operation_id"]
@@ -941,7 +941,7 @@ def test_down_from_discoveryspace_capped_at_operation(
         kind=CoreResourceKinds.DISCOVERYSPACE,
         identifier=ds_id,
         hierarchy_direction="down",
-        stop_at_resource_kind=CoreResourceKinds.OPERATION,
+        max_hops=1,
         identifiers_only=True,
     )
 
@@ -1467,20 +1467,6 @@ def test_valid_kind_direction_combo_with_no_reachable_resources_returns_empty(
     assert result == {}
 
 
-def test_invalid_max_target_kind_raises_value_error(
-    resource_hierarchy: dict,
-) -> None:
-    """max_target_kind not reachable in selected family raises ValueError."""
-    store: SQLStore = resource_hierarchy["store"]
-    with pytest.raises(ValueError, match="stop_at_resource_kind="):
-        store.get_resources_by_relationship(
-            kind=CoreResourceKinds.OPERATION,
-            identifier="any",
-            hierarchy_direction="up",
-            stop_at_resource_kind=CoreResourceKinds.DATACONTAINER,
-        )
-
-
 @requires_sqlite_3_38
 def test_identifier_none_with_both_raises_value_error(
     resource_hierarchy: dict,
@@ -1501,23 +1487,33 @@ def test_identifier_none_with_both_raises_value_error(
 
 
 @requires_sqlite_3_38
-def test_stop_at_resource_kind_with_both_raises_value_error(
+def test_both_from_operation_max_hops_1_returns_one_level_each_direction(
     resource_hierarchy: dict,
 ) -> None:
-    """stop_at_resource_kind is not supported when hierarchy_direction is both."""
+    """both from operation with max_hops=1 returns one hop up and one hop down."""
     store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
 
-    with pytest.raises(
-        ValueError,
-        match="stop_at_resource_kind is not supported for hierarchy_direction='both'",
-    ):
-        store.get_resources_by_relationship(
-            kind=CoreResourceKinds.OPERATION,
-            identifier=resource_hierarchy["operation_id"],
-            hierarchy_direction="both",  # type: ignore[arg-type]
-            stop_at_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
-            identifiers_only=True,
-        )
+    result = store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="both",  # type: ignore[arg-type]
+        max_hops=1,
+        identifiers_only=True,
+    )
+
+    # One hop up → discoveryspace only (not samplestore)
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert CoreResourceKinds.SAMPLESTORE not in result
+    # One hop down → datacontainer and actuatorconfiguration
+    assert CoreResourceKinds.DATACONTAINER in result
+    assert dc_id in result[CoreResourceKinds.DATACONTAINER]
+    assert CoreResourceKinds.ACTUATORCONFIGURATION in result
+    assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
 
 
 def test_empty_identifier_set_returns_empty(

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -1441,13 +1441,46 @@ def test_invalid_direction_raises_value_error(
 ) -> None:
     """Unsupported hierarchy_direction raises ValueError."""
     store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
     with pytest.raises(
         ValueError, match="hierarchy_direction must be 'up', 'down' or 'both'"
     ):
         store.get_resources_by_relationship(
             kind=CoreResourceKinds.OPERATION,
-            identifier="any",
+            identifier=op_id,
             hierarchy_direction="sideways",  # type: ignore[arg-type]
+        )
+
+
+def test_invalid_max_hops_zero_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """max_hops=0 raises ValueError before any DB query."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    with pytest.raises(ValueError, match="max_hops must be a positive integer"):
+        store.get_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=op_id,
+            hierarchy_direction="up",
+            max_hops=0,
+            identifiers_only=True,
+        )
+
+
+def test_invalid_max_hops_negative_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """max_hops=-1 raises ValueError before any DB query."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    with pytest.raises(ValueError, match="max_hops must be a positive integer"):
+        store.get_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=op_id,
+            hierarchy_direction="down",
+            max_hops=-1,
+            identifiers_only=True,
         )
 
 

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -1484,6 +1484,7 @@ def test_invalid_max_hops_negative_raises_value_error(
         )
 
 
+@requires_sqlite_3_38
 def test_valid_kind_direction_combo_with_no_reachable_resources_returns_empty(
     resource_hierarchy: dict,
 ) -> None:

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -657,3 +657,716 @@ def test_get_latest_resource_identifiers_of_kinds_multiple_invalid_kinds(
         resource_store.get_latest_resource_identifiers_of_kinds(
             kinds=[invalid_kind1, invalid_kind2]
         )
+
+
+###############################################################################
+# get_related_resources_by_relationship
+###############################################################################
+
+# ---------------------------------------------------------------------------
+# Helper fixture: a complete samplestore → discoveryspace → operation →
+#                 datacontainer / actuatorconfiguration hierarchy
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def resource_hierarchy(
+    sql_store: SQLStore,
+    random_space_resource_from_file: Callable[[str | None], DiscoverySpaceResource],
+    operation_resource: OperationResource,
+    data_container_resource: orchestrator.core.datacontainer.resource.DataContainerResource,
+) -> dict:
+    """Build and persist a minimal linked hierarchy.
+
+    Returns a dict with keys:
+        samplestore_id, discoveryspace_id, operation_id,
+        datacontainer_id, actuatorconfiguration_id, store
+    """
+    import orchestrator.core.actuatorconfiguration.config
+    from orchestrator.core import ActuatorConfigurationResource, SampleStoreResource
+    from orchestrator.core.samplestore.config import (
+        SampleStoreConfiguration,
+        SampleStoreModuleConf,
+        SampleStoreSpecification,
+    )
+
+    # 1. samplestore
+    ss = SampleStoreResource(
+        config=SampleStoreConfiguration(
+            specification=SampleStoreSpecification(
+                module=SampleStoreModuleConf(
+                    moduleClass="SQLSampleStore",
+                    moduleName="orchestrator.core.samplestore.sql",
+                )
+            )
+        )
+    )
+    sql_store.addResource(ss)
+
+    # 2. discoveryspace (child of samplestore)
+    ds = random_space_resource_from_file(sample_store_id=ss.identifier)
+    sql_store.addResourceWithRelationships(ds, relatedIdentifiers=[ss.identifier])
+
+    # 3. operation (child of discoveryspace)
+    operation_resource.config.spaces = [ds.identifier]
+    sql_store.addResourceWithRelationships(
+        operation_resource, relatedIdentifiers=[ds.identifier]
+    )
+
+    # 4. datacontainer (child of operation)
+    sql_store.addResourceWithRelationships(
+        data_container_resource,
+        relatedIdentifiers=[operation_resource.identifier],
+    )
+
+    # 5. actuatorconfiguration (child of operation)
+    import yaml
+
+    ac_config = orchestrator.core.actuatorconfiguration.config.ActuatorConfiguration.model_validate(
+        yaml.safe_load(
+            (
+                __import__("pathlib").Path(
+                    "tests/resources/replay_actuatorconfiguration.yaml"
+                )
+            ).read_text()
+        )
+    )
+    ac = ActuatorConfigurationResource(config=ac_config)
+    sql_store.addResourceWithRelationships(
+        ac, relatedIdentifiers=[operation_resource.identifier]
+    )
+
+    return {
+        "samplestore_id": ss.identifier,
+        "discoveryspace_id": ds.identifier,
+        "operation_id": operation_resource.identifier,
+        "datacontainer_id": data_container_resource.identifier,
+        "actuatorconfiguration_id": ac.identifier,
+        "store": sql_store,
+    }
+
+
+# ---------------------------------------------------------------------------
+# up from operation
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_up_from_operation_capped_at_discoveryspace(
+    resource_hierarchy: dict,
+) -> None:
+    """up from operation capped at discoveryspace returns only discoveryspace ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="up",
+        stop_at_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert CoreResourceKinds.SAMPLESTORE not in result
+
+
+@requires_sqlite_3_38
+def test_up_from_operation_uncapped_returns_discoveryspace_and_samplestore(
+    resource_hierarchy: dict,
+) -> None:
+    """up from operation without cap returns discoveryspace and samplestore ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert CoreResourceKinds.SAMPLESTORE in result
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+
+
+@requires_sqlite_3_38
+def test_up_from_operation_capped_at_samplestore_returns_both_kinds(
+    resource_hierarchy: dict,
+) -> None:
+    """up from operation capped at samplestore returns both discoveryspace and samplestore."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="up",
+        stop_at_resource_kind=CoreResourceKinds.SAMPLESTORE,
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert CoreResourceKinds.SAMPLESTORE in result
+
+
+# ---------------------------------------------------------------------------
+# up from discoveryspace
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_up_from_discoveryspace_returns_samplestore_only(
+    resource_hierarchy: dict,
+) -> None:
+    """up from discoveryspace returns only samplestore identifiers."""
+    store: SQLStore = resource_hierarchy["store"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    ss_id = resource_hierarchy["samplestore_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=ds_id,
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    assert list(result.keys()) == [CoreResourceKinds.SAMPLESTORE]
+    assert ss_id in result[CoreResourceKinds.SAMPLESTORE]
+
+
+# ---------------------------------------------------------------------------
+# down from samplestore
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_down_from_samplestore_capped_at_discoveryspace(
+    resource_hierarchy: dict,
+) -> None:
+    """down from samplestore capped at discoveryspace returns only discoveryspace ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    ss_id = resource_hierarchy["samplestore_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.SAMPLESTORE,
+        identifier=ss_id,
+        hierarchy_direction="down",
+        stop_at_resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert ds_id in result[CoreResourceKinds.DISCOVERYSPACE]
+    assert CoreResourceKinds.OPERATION not in result
+    assert CoreResourceKinds.DATACONTAINER not in result
+    assert CoreResourceKinds.ACTUATORCONFIGURATION not in result
+
+
+@requires_sqlite_3_38
+def test_down_from_samplestore_capped_at_operation(
+    resource_hierarchy: dict,
+) -> None:
+    """down from samplestore capped at operation returns discoveryspace and operation ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    ss_id = resource_hierarchy["samplestore_id"]
+    op_id = resource_hierarchy["operation_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.SAMPLESTORE,
+        identifier=ss_id,
+        hierarchy_direction="down",
+        stop_at_resource_kind=CoreResourceKinds.OPERATION,
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert CoreResourceKinds.OPERATION in result
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert CoreResourceKinds.DATACONTAINER not in result
+    assert CoreResourceKinds.ACTUATORCONFIGURATION not in result
+
+
+@requires_sqlite_3_38
+def test_down_from_samplestore_uncapped_returns_full_hierarchy(
+    resource_hierarchy: dict,
+) -> None:
+    """down from samplestore uncapped returns discoveryspace, operation, dc and ac ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    ss_id = resource_hierarchy["samplestore_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.SAMPLESTORE,
+        identifier=ss_id,
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DISCOVERYSPACE in result
+    assert CoreResourceKinds.OPERATION in result
+    assert CoreResourceKinds.DATACONTAINER in result
+    assert CoreResourceKinds.ACTUATORCONFIGURATION in result
+    assert dc_id in result[CoreResourceKinds.DATACONTAINER]
+    assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
+
+
+# ---------------------------------------------------------------------------
+# down from discoveryspace
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_down_from_discoveryspace_capped_at_operation(
+    resource_hierarchy: dict,
+) -> None:
+    """down from discoveryspace capped at operation returns only operation ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    op_id = resource_hierarchy["operation_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=ds_id,
+        hierarchy_direction="down",
+        stop_at_resource_kind=CoreResourceKinds.OPERATION,
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.OPERATION in result
+    assert op_id in result[CoreResourceKinds.OPERATION]
+    assert CoreResourceKinds.DATACONTAINER not in result
+    assert CoreResourceKinds.ACTUATORCONFIGURATION not in result
+
+
+@requires_sqlite_3_38
+def test_down_from_discoveryspace_uncapped_returns_operation_dc_ac(
+    resource_hierarchy: dict,
+) -> None:
+    """down from discoveryspace uncapped returns operation, datacontainer and actuatorconfiguration."""
+    store: SQLStore = resource_hierarchy["store"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=ds_id,
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.OPERATION in result
+    assert CoreResourceKinds.DATACONTAINER in result
+    assert CoreResourceKinds.ACTUATORCONFIGURATION in result
+    assert dc_id in result[CoreResourceKinds.DATACONTAINER]
+    assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
+
+
+# ---------------------------------------------------------------------------
+# down from operation
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_down_from_operation_returns_datacontainer_and_actuatorconfiguration(
+    resource_hierarchy: dict,
+) -> None:
+    """down from operation returns datacontainer and actuatorconfiguration ids."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+    ac_id = resource_hierarchy["actuatorconfiguration_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+
+    assert CoreResourceKinds.DATACONTAINER in result
+    assert CoreResourceKinds.ACTUATORCONFIGURATION in result
+    assert dc_id in result[CoreResourceKinds.DATACONTAINER]
+    assert ac_id in result[CoreResourceKinds.ACTUATORCONFIGURATION]
+
+
+# ---------------------------------------------------------------------------
+# multi-start
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_op_hierarchy(
+    sql_store: SQLStore,
+    random_space_resource_from_file: Callable[[str | None], DiscoverySpaceResource],
+    data_container_resource: orchestrator.core.datacontainer.resource.DataContainerResource,
+) -> dict:
+    """Two operations sharing the same discoveryspace, each with its own datacontainer."""
+
+    from orchestrator.core import (
+        SampleStoreResource,
+    )
+    from orchestrator.core.operation.config import (
+        DiscoveryOperationConfiguration,
+        DiscoveryOperationEnum,
+        DiscoveryOperationResourceConfiguration,
+    )
+    from orchestrator.core.operation.resource import OperationResource
+    from orchestrator.core.samplestore.config import (
+        SampleStoreConfiguration,
+        SampleStoreModuleConf,
+        SampleStoreSpecification,
+    )
+
+    ss = SampleStoreResource(
+        config=SampleStoreConfiguration(
+            specification=SampleStoreSpecification(
+                module=SampleStoreModuleConf(
+                    moduleClass="SQLSampleStore",
+                    moduleName="orchestrator.core.samplestore.sql",
+                )
+            )
+        )
+    )
+    sql_store.addResource(ss)
+
+    ds = random_space_resource_from_file(sample_store_id=ss.identifier)
+    sql_store.addResourceWithRelationships(ds, relatedIdentifiers=[ss.identifier])
+
+    op1_config = DiscoveryOperationResourceConfiguration(
+        spaces=[ds.identifier],
+        operation=DiscoveryOperationConfiguration(),
+    )
+    op1 = OperationResource(
+        config=op1_config,
+        operationType=DiscoveryOperationEnum.SEARCH,
+        operatorIdentifier="test-op-1",
+    )
+    sql_store.addResourceWithRelationships(op1, relatedIdentifiers=[ds.identifier])
+
+    op2_config = DiscoveryOperationResourceConfiguration(
+        spaces=[ds.identifier],
+        operation=DiscoveryOperationConfiguration(),
+    )
+    op2 = OperationResource(
+        config=op2_config,
+        operationType=DiscoveryOperationEnum.SEARCH,
+        operatorIdentifier="test-op-2",
+    )
+    sql_store.addResourceWithRelationships(op2, relatedIdentifiers=[ds.identifier])
+
+    # dc1 belongs to op1; dc2 belongs to op2
+    sql_store.addResourceWithRelationships(
+        data_container_resource, relatedIdentifiers=[op1.identifier]
+    )
+
+    import pandas as pd
+
+    from orchestrator.core.datacontainer.resource import (
+        DataContainer,
+        DataContainerResource,
+        TabularData,
+    )
+
+    df = pd.read_csv("examples/ml-multi-cloud/ml_export.csv")
+    dc2 = DataContainerResource(
+        config=DataContainer(
+            tabularData={"entities": TabularData.from_dataframe(df)},
+        )
+    )
+    sql_store.addResourceWithRelationships(dc2, relatedIdentifiers=[op2.identifier])
+
+    return {
+        "store": sql_store,
+        "ss_id": ss.identifier,
+        "ds_id": ds.identifier,
+        "op1_id": op1.identifier,
+        "op2_id": op2.identifier,
+        "dc1_id": data_container_resource.identifier,
+        "dc2_id": dc2.identifier,
+    }
+
+
+@requires_sqlite_3_38
+def test_multi_start_returns_per_origin_grouping(
+    two_op_hierarchy: dict,
+) -> None:
+    """Multi-start identifier mode returns dict keyed by origin identifier."""
+    store: SQLStore = two_op_hierarchy["store"]
+    op1_id = two_op_hierarchy["op1_id"]
+    op2_id = two_op_hierarchy["op2_id"]
+    dc1_id = two_op_hierarchy["dc1_id"]
+    dc2_id = two_op_hierarchy["dc2_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier={op1_id, op2_id},
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+
+    # Top-level keys are the origin identifiers
+    assert op1_id in result
+    assert op2_id in result
+
+    # Each origin bucket contains the correct datacontainer
+    assert dc1_id in result[op1_id][CoreResourceKinds.DATACONTAINER]
+    assert dc2_id in result[op2_id][CoreResourceKinds.DATACONTAINER]
+
+    # dc2 should not appear under op1 and vice-versa
+    assert dc2_id not in result[op1_id][CoreResourceKinds.DATACONTAINER]
+    assert dc1_id not in result[op2_id][CoreResourceKinds.DATACONTAINER]
+
+
+@requires_sqlite_3_38
+def test_multi_start_shared_resource_appears_under_each_origin(
+    two_op_hierarchy: dict,
+) -> None:
+    """Shared discovered resources appear under every origin that reaches them."""
+    store: SQLStore = two_op_hierarchy["store"]
+    op1_id = two_op_hierarchy["op1_id"]
+    op2_id = two_op_hierarchy["op2_id"]
+    ds_id = two_op_hierarchy["ds_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier={op1_id, op2_id},
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    # Both operations share the same discoveryspace
+    assert ds_id in result[op1_id][CoreResourceKinds.DISCOVERYSPACE]
+    assert ds_id in result[op2_id][CoreResourceKinds.DISCOVERYSPACE]
+
+
+# ---------------------------------------------------------------------------
+# identifier=None (all resources of start kind)
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_identifier_none_seeds_from_all_resources_of_kind(
+    resource_hierarchy: dict,
+) -> None:
+    """identifier=None seeds from all resources of the given kind and returns multi-start shape."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    ds_id = resource_hierarchy["discoveryspace_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=None,
+        hierarchy_direction="up",
+        identifiers_only=True,
+    )
+
+    # Result shape is dict[origin_id → dict[kind → list[str]]]
+    assert isinstance(result, dict)
+    # The operation we created must appear as an origin key
+    assert op_id in result
+    assert ds_id in result[op_id][CoreResourceKinds.DISCOVERYSPACE]
+
+
+# ---------------------------------------------------------------------------
+# hydrated mode
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_hydrated_single_start_returns_resources(
+    resource_hierarchy: dict,
+) -> None:
+    """Single-start hydrated mode returns ADOResource objects, no outer origin key."""
+    from orchestrator.core.resources import ADOResource
+
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+    dc_id = resource_hierarchy["datacontainer_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="down",
+        identifiers_only=False,
+    )
+
+    # Top-level keys are CoreResourceKinds, not origin identifiers
+    assert CoreResourceKinds.DATACONTAINER in result
+    # Values are dicts of identifier → ADOResource
+    dc_bucket = result[CoreResourceKinds.DATACONTAINER]
+    assert dc_id in dc_bucket
+    assert isinstance(dc_bucket[dc_id], ADOResource)
+
+
+@requires_sqlite_3_38
+def test_hydrated_multi_start_grouping_matches_identifier_mode(
+    two_op_hierarchy: dict,
+) -> None:
+    """Hydrated multi-start grouping matches identifier-only grouping."""
+    store: SQLStore = two_op_hierarchy["store"]
+    op1_id = two_op_hierarchy["op1_id"]
+    op2_id = two_op_hierarchy["op2_id"]
+    dc1_id = two_op_hierarchy["dc1_id"]
+    dc2_id = two_op_hierarchy["dc2_id"]
+
+    result_ids = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier={op1_id, op2_id},
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+    result_hydrated = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier={op1_id, op2_id},
+        hierarchy_direction="down",
+        identifiers_only=False,
+    )
+
+    for origin in [op1_id, op2_id]:
+        for kind in result_ids[origin]:
+            assert set(result_ids[origin][kind]) == set(
+                result_hydrated[origin][kind].keys()
+            )
+
+    # Spot-check actual resource objects
+    from orchestrator.core.resources import ADOResource
+
+    assert isinstance(
+        result_hydrated[op1_id][CoreResourceKinds.DATACONTAINER][dc1_id], ADOResource
+    )
+    assert isinstance(
+        result_hydrated[op2_id][CoreResourceKinds.DATACONTAINER][dc2_id], ADOResource
+    )
+
+
+@requires_sqlite_3_38
+def test_hydrated_start_identifier_excluded(
+    resource_hierarchy: dict,
+) -> None:
+    """Start identifiers are excluded from hydrated results."""
+    store: SQLStore = resource_hierarchy["store"]
+    op_id = resource_hierarchy["operation_id"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_id,
+        hierarchy_direction="down",
+        identifiers_only=False,
+    )
+
+    all_returned_identifiers = {
+        ident for kind_bucket in result.values() for ident in kind_bucket
+    }
+    assert op_id not in all_returned_identifiers
+
+
+# ---------------------------------------------------------------------------
+# invalid input
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_direction_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """Unsupported hierarchy_direction raises ValueError."""
+    store: SQLStore = resource_hierarchy["store"]
+    with pytest.raises(ValueError, match="hierarchy_direction must be 'up' or 'down'"):
+        store.get_related_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier="any",
+            hierarchy_direction="sideways",  # type: ignore[arg-type]
+        )
+
+
+def test_invalid_kind_direction_combo_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """Unsupported (kind, direction) combination raises ValueError."""
+    store: SQLStore = resource_hierarchy["store"]
+    with pytest.raises(ValueError, match="Unsupported traversal family"):
+        store.get_related_resources_by_relationship(
+            kind=CoreResourceKinds.SAMPLESTORE,
+            identifier="any",
+            hierarchy_direction="up",
+        )
+
+
+def test_invalid_max_target_kind_raises_value_error(
+    resource_hierarchy: dict,
+) -> None:
+    """max_target_kind not reachable in selected family raises ValueError."""
+    store: SQLStore = resource_hierarchy["store"]
+    with pytest.raises(ValueError, match="stop_at_resource_kind="):
+        store.get_related_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier="any",
+            hierarchy_direction="up",
+            stop_at_resource_kind=CoreResourceKinds.DATACONTAINER,
+        )
+
+
+def test_empty_identifier_set_returns_empty(
+    resource_hierarchy: dict,
+) -> None:
+    """Empty identifier set returns an empty result immediately."""
+    store: SQLStore = resource_hierarchy["store"]
+
+    result = store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=set(),
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# no-results: valid traversal but no related resources
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_valid_traversal_with_no_related_resources(
+    sql_store: SQLStore,
+    random_space_resource_from_file: Callable[[str | None], DiscoverySpaceResource],
+) -> None:
+    """A valid traversal that simply finds no related resources returns an empty dict."""
+    from orchestrator.core import SampleStoreResource
+    from orchestrator.core.samplestore.config import (
+        SampleStoreConfiguration,
+        SampleStoreModuleConf,
+        SampleStoreSpecification,
+    )
+
+    # samplestore with no children
+    ss = SampleStoreResource(
+        config=SampleStoreConfiguration(
+            specification=SampleStoreSpecification(
+                module=SampleStoreModuleConf(
+                    moduleClass="SQLSampleStore",
+                    moduleName="orchestrator.core.samplestore.sql",
+                )
+            )
+        )
+    )
+    sql_store.addResource(ss)
+
+    result = sql_store.get_related_resources_by_relationship(
+        kind=CoreResourceKinds.SAMPLESTORE,
+        identifier=ss.identifier,
+        hierarchy_direction="down",
+        identifiers_only=True,
+    )
+
+    assert result == {}

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -719,7 +719,9 @@ def resource_hierarchy(
         relatedIdentifiers=[operation_resource.identifier],
     )
 
-    # 5. actuatorconfiguration (child of operation)
+    # 5. actuatorconfiguration — stored as subject, operation as object,
+    #    matching the production path in addResourceWithRelationships(operation,
+    #    relatedIdentifiers=[..., actconf_id]).
     import yaml
 
     ac_config = orchestrator.core.actuatorconfiguration.config.ActuatorConfiguration.model_validate(
@@ -732,8 +734,10 @@ def resource_hierarchy(
         )
     )
     ac = ActuatorConfigurationResource(config=ac_config)
-    sql_store.addResourceWithRelationships(
-        ac, relatedIdentifiers=[operation_resource.identifier]
+    sql_store.addResource(ac)
+    sql_store.addRelationship(
+        subjectIdentifier=ac.identifier,
+        objectIdentifier=operation_resource.identifier,
     )
 
     return {


### PR DESCRIPTION
## Add graph-based resource traversal and retrieval to the metastore

Introduces a `get_resources_by_relationship` method that lets callers walk the ado resource hierarchy (samplestore → discoveryspace → operation → datacontainer / actuatorconfiguration) in any direction from any starting point.

**Key capabilities:**
- Traverse `up`, `down`, or `both` directions from a given resource (or set of resources)
- Cap traversal depth with `max_hops`
- Return either resource identifiers or fully hydrated `ADOResource` objects
- Optionally include the start resources in the result
- Seed from an entire resource kind when no specific identifier is given, returning per-origin grouped results

**Implementation:** a recursive CTE SQL query normalises the stored relationship rows into directed edges and walks them efficiently within the database, bounded by the 4-level hierarchy depth. All parameters are safely bound to prevent SQL injection.

The change is fully covered by a new test suite exercising all traversal directions, hop limits, sibling exclusion, multi-start grouping, hydrated mode, and invalid-input handling.