### PR TITLE
perf(test): cap object store RAM usage for ray clusters in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ def initialize_ray() -> Generator[None, None, None]:
     """
     ray.init(
         ignore_reinit_error=True,
+        object_store_memory=200 * 1024 * 1024,  # 200 MB per xdist worker
     )
     yield
     ray.shutdown()


### PR DESCRIPTION
## Problem

When running `pytest -n auto`, each pytest-xdist worker is a separate process with its own session, so the `initialize_ray` fixture calls `ray.init()` independently in every worker. Ray's default object store allocation is a fraction of total system RAM — on a 10-core machine this means 10 concurrent Ray clusters each claiming that fraction, leading to very high aggregate RAM consumption.

## Fix

Pass `object_store_memory=200 * 1024 * 1024` to `ray.init()` in [`tests/conftest.py`](tests/conftest.py). The tests only put small objects into the Ray object store, so 200 MB per worker is more than sufficient.

## Measured impact

Profiled using the attached script, which runs the Ray-heavy subset of the test suite (`test_discovery_space_manager`, `test_executor_supervision_integration`, `test_run_random_walk_operation`, `test_run_ray_tune_operation`) twice — with and without the cap — sampling total RSS (parent + all child processes) every 500 ms:

| | Peak RSS | Median RSS |
|---|---|---|
| Without cap (Ray default) | 18.94 GB | 14.08 GB |
| With 200 MB cap | 16.50 GB | 13.59 GB |
| **Reduction** | **−2.44 GB (−12.9%)** | **−0.49 GB** |

All 18 tests pass in both runs.

### Test script

<details>
<summary>Open to see the test script</summary>
```python
#!/usr/bin/env python
# Copyright IBM Corporation 2025, 2026
# SPDX-License-Identifier: MIT
"""
Measure peak RAM of the test suite with and without the object_store_memory cap.

Usage:
    uv run python scripts/profile_test_memory.py

The script runs pytest twice:
  - WITH the cap    (current conftest.py)
  - WITHOUT the cap (patches conftest.py temporarily)

For each run it samples total RSS (parent + all children) every SAMPLE_INTERVAL_S
seconds and reports peak, median, and a time-series summary.

The test subset is deliberately kept to tests that exercise Ray so the
comparison is meaningful without running the full suite (~minutes).
"""

import subprocess
import sys
import threading
import time
from pathlib import Path

import psutil

# ---------------------------------------------------------------------------
# Configuration
# ---------------------------------------------------------------------------
REPO_ROOT = Path(__file__).resolve().parent.parent
CONFTEST = REPO_ROOT / "tests" / "conftest.py"

# Tests that exercise Ray and the operator stack — representative but not exhaustive.
TEST_TARGETS = [
    "tests/operators/test_discovery_space_manager.py",
    "tests/actuators/test_executor_supervision_integration.py",
    "tests/operators/test_operators.py::test_run_random_walk_operation",
    "tests/operators/test_operators.py::test_run_ray_tune_operation",
]

PYTEST_CMD = [
    sys.executable, "-m", "pytest",
    "-n", "auto",
    "--dist", "loadgroup",
    "-q", "--no-header",
    "--timeout=120",
    *TEST_TARGETS,
]

SAMPLE_INTERVAL_S = 0.5

# ---------------------------------------------------------------------------
# Helpers
# ---------------------------------------------------------------------------

CAPPED_SNIPPET = "object_store_memory=200 * 1024 * 1024,  # 200 MB per xdist worker"
UNCAPPED_SNIPPET = "ignore_reinit_error=True,"


def _patch_conftest(*, cap: bool) -> None:
    """Toggle the object_store_memory line in conftest.py."""
    text = CONFTEST.read_text()
    if cap:
        # Ensure the cap line is present
        if CAPPED_SNIPPET not in text:
            text = text.replace(
                "        ignore_reinit_error=True,",
                "        ignore_reinit_error=True,\n        " + CAPPED_SNIPPET,
            )
            CONFTEST.write_text(text)
    else:
        # Remove the cap line
        text = text.replace("\n        " + CAPPED_SNIPPET, "")
        CONFTEST.write_text(text)


def _sample_memory(proc: subprocess.Popen, samples: list[float], stop_event: threading.Event) -> None:
    """Background thread: record total RSS of proc and all its children."""
    while not stop_event.is_set():
        try:
            parent = psutil.Process(proc.pid)
            children = parent.children(recursive=True)
            total_rss = sum(
                p.memory_info().rss
                for p in [parent, *children]
                if p.is_running()
            )
            samples.append(total_rss)
        except (psutil.NoSuchProcess, psutil.AccessDenied):
            pass
        time.sleep(SAMPLE_INTERVAL_S)


def _run_and_profile(label: str) -> dict:
    """Run pytest, sample memory throughout, return stats dict."""
    print(f"\n{'='*60}")
    print(f"  {label}")
    print(f"{'='*60}")
    print(f"  Command: {' '.join(PYTEST_CMD[2:])}\n")

    samples: list[float] = []
    stop_event = threading.Event()

    proc = subprocess.Popen(
        PYTEST_CMD,
        cwd=REPO_ROOT,
        stdout=subprocess.PIPE,
        stderr=subprocess.STDOUT,
        text=True,
    )

    sampler = threading.Thread(target=_sample_memory, args=(proc, samples, stop_event), daemon=True)
    sampler.start()

    # Stream output
    assert proc.stdout is not None
    for line in proc.stdout:
        print(line, end="")

    proc.wait()
    stop_event.set()
    sampler.join()

    if not samples:
        return {"label": label, "peak_gb": 0, "median_gb": 0, "returncode": proc.returncode, "samples": []}

    peak = max(samples)
    median = sorted(samples)[len(samples) // 2]

    print(f"\n  --- Memory summary ({len(samples)} samples @ {SAMPLE_INTERVAL_S}s interval) ---")
    print(f"  Peak RSS  : {peak / 1e9:.2f} GB")
    print(f"  Median RSS: {median / 1e9:.2f} GB")
    print(f"  Exit code : {proc.returncode}")

    return {
        "label": label,
        "peak_gb": peak / 1e9,
        "median_gb": median / 1e9,
        "returncode": proc.returncode,
        "samples": [s / 1e9 for s in samples],
    }


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------

def main() -> None:
    print("Profiling test RAM usage: capped vs uncapped Ray object store")
    print(f"Test targets: {TEST_TARGETS}")
    print(f"Sampling every {SAMPLE_INTERVAL_S}s\n")

    # Run 1: WITH cap (current state)
    _patch_conftest(cap=True)
    result_capped = _run_and_profile("WITH object_store_memory=200MB cap")

    # Brief pause so Ray ports are freed
    print("\nWaiting 10s between runs...")
    time.sleep(10)

    # Run 2: WITHOUT cap
    _patch_conftest(cap=False)
    try:
        result_uncapped = _run_and_profile("WITHOUT object_store_memory cap (Ray default)")
    finally:
        # Always restore the cap
        _patch_conftest(cap=True)

    # ---------------------------------------------------------------------------
    # Comparison
    # ---------------------------------------------------------------------------
    print(f"\n{'='*60}")
    print("  COMPARISON")
    print(f"{'='*60}")
    print(f"  {'':30s}  {'Peak (GB)':>10}  {'Median (GB)':>12}")
    print(f"  {'-'*56}")
    for r in [result_capped, result_uncapped]:
        print(f"  {r['label']:30s}  {r['peak_gb']:>10.2f}  {r['median_gb']:>12.2f}")

    if result_uncapped["peak_gb"] > 0 and result_capped["peak_gb"] > 0:
        reduction = (result_uncapped["peak_gb"] - result_capped["peak_gb"]) / result_uncapped["peak_gb"] * 100
        print(f"\n  Peak RAM reduction: {reduction:.1f}%")
        print(f"  ({result_uncapped['peak_gb']:.2f} GB → {result_capped['peak_gb']:.2f} GB)")

    # Print a simple ASCII time-series for each run
    for r in [result_capped, result_uncapped]:
        _print_timeseries(r)


def _print_timeseries(result: dict) -> None:
    samples = result["samples"]
    if not samples:
        return
    height = 8
    width = min(len(samples), 80)
    # Downsample to width
    step = max(1, len(samples) // width)
    downsampled = samples[::step][:width]
    max_val = max(downsampled) if downsampled else 1
    print(f"\n  Time-series: {result['label']}")
    print(f"  {'':4s} {max_val:.2f} GB ┐")
    for row in range(height, 0, -1):
        threshold = max_val * row / height
        line = "".join("█" if s >= threshold else " " for s in downsampled)
        print(f"  {'':10s}│{line}")
    print(f"  {'':10s}└{'─' * len(downsampled)}")
    print(f"  {'0 GB':>10s}  time →")


if __name__ == "__main__":
    main()
```
</details>
