### PR TITLE
refactor(core): replace getRelatedResourceIdentifiers and getRelatedResources with get_resources_by_relationship

### DIFF
--- a/orchestrator/cli/commands/show_related.py
+++ b/orchestrator/cli/commands/show_related.py
@@ -34,6 +34,7 @@ from orchestrator.metastore.base import (
     NoRelatedResourcesError,
     ResourceDoesNotExistError,
 )
+from orchestrator.metastore.sql.statements import _MAX_HIERARCHY_HOPS
 
 if typing.TYPE_CHECKING:
     from orchestrator.cli.core.config import AdoConfiguration
@@ -67,9 +68,23 @@ def show_related_for_resources(
             show_default=False,
         ),
     ] = False,
+    max_hops: Annotated[
+        int | None,
+        typer.Option(
+            "--max-hops",
+            help=f"Maximum number of relationship hops to follow from the start resource "
+            f"(1-{_MAX_HIERARCHY_HOPS}). Defaults to the full hierarchy depth.",
+            show_default=False,
+            min=1,
+            max=_MAX_HIERARCHY_HOPS,
+        ),
+    ] = None,
 ) -> None:
     """
-    Show resources directly (one-hop) related to the requested resource, grouped by type.
+    Show resources related to the requested resource, grouped by type.
+
+    By default the full resource hierarchy is traversed in both directions.
+    Use --max-hops to limit the traversal depth.
 
     See https://ibm.github.io/ado/getting-started/ado/#ado-show-related
     for detailed documentation and examples.
@@ -81,6 +96,9 @@ def show_related_for_resources(
 
     # Show the resources related to the latest space
     ado show related space --use-latest
+
+    # Show only directly linked (1-hop) resources
+    ado show related space <space-id> --max-hops 1
     """
     ado_configuration: AdoConfiguration = ctx.obj
 
@@ -99,7 +117,7 @@ def show_related_for_resources(
         )
 
     parameters = AdoShowRelatedCommandParameters(
-        ado_configuration=ado_configuration, resource_id=resource_id
+        ado_configuration=ado_configuration, resource_id=resource_id, max_hops=max_hops
     )
 
     method_mapping = {

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -108,6 +108,7 @@ class AdoShowMeasurementsCommandParameters(pydantic.BaseModel):
 class AdoShowRelatedCommandParameters(pydantic.BaseModel):
     ado_configuration: AdoConfiguration
     resource_id: str
+    max_hops: int | None = None
 
 
 class AdoShowTraceCommandParameters(pydantic.BaseModel):

--- a/orchestrator/cli/models/space.py
+++ b/orchestrator/cli/models/space.py
@@ -229,10 +229,13 @@ class SpaceSummary:
         if not space.measurementSpace.experiments:
             raise ValueError(f"There are no experiments defined in space {space_id}")
 
-        related_operations = sql.getRelatedResourceIdentifiers(
+        related_operations: set[str] = sql.get_resources_by_relationship(
+            kind=CoreResourceKinds.DISCOVERYSPACE,
             identifier=space_id,
-            kind=orchestrator.core.resources.CoreResourceKinds.OPERATION.value,
-        )
+            hierarchy_direction="down",
+            max_hops=1,
+            identifiers_only=True,
+        ).get(CoreResourceKinds.OPERATION, set())
 
         constitutive_properties = {
             p.identifier: (p.propertyDomain.values or p.propertyDomain.domainRange)
@@ -347,9 +350,9 @@ class SpaceSummary:
             )
         content.write("\n" + self.details.to_markdown() + "\n")
 
-        if len(self.related_operations["IDENTIFIER"]) > 0:
+        if self.related_operations:
             content.write(f"\n{'#'*heading_level} Related operations\n\n")
-            for o in self.related_operations["IDENTIFIER"]:
+            for o in self.related_operations:
                 content.write(f"- `{o}`\n")
 
         return content.getvalue()

--- a/orchestrator/cli/resources/actuator_configuration/show_related.py
+++ b/orchestrator/cli/resources/actuator_configuration/show_related.py
@@ -22,4 +22,5 @@ def show_resources_related_to_actuator_configuration(
         resource_type=CoreResourceKinds.ACTUATORCONFIGURATION,
         sql=sql_store,
         hide_banner=True,
+        max_hops=parameters.max_hops,
     )

--- a/orchestrator/cli/resources/data_container/show_related.py
+++ b/orchestrator/cli/resources/data_container/show_related.py
@@ -22,4 +22,5 @@ def show_resources_related_to_data_container(
         resource_type=CoreResourceKinds.DATACONTAINER,
         sql=sql_store,
         hide_banner=True,
+        max_hops=parameters.max_hops,
     )

--- a/orchestrator/cli/resources/discovery_space/show_related.py
+++ b/orchestrator/cli/resources/discovery_space/show_related.py
@@ -22,4 +22,5 @@ def show_resources_related_to_discovery_space(
         resource_type=CoreResourceKinds.DISCOVERYSPACE,
         sql=sql_store,
         hide_banner=True,
+        max_hops=parameters.max_hops,
     )

--- a/orchestrator/cli/resources/operation/show_related.py
+++ b/orchestrator/cli/resources/operation/show_related.py
@@ -22,4 +22,5 @@ def show_resources_related_to_operation(
         resource_type=CoreResourceKinds.OPERATION,
         sql=sql_store,
         hide_banner=True,
+        max_hops=parameters.max_hops,
     )

--- a/orchestrator/cli/resources/sample_store/show_related.py
+++ b/orchestrator/cli/resources/sample_store/show_related.py
@@ -22,4 +22,5 @@ def show_resources_related_to_sample_store(
         resource_type=CoreResourceKinds.SAMPLESTORE,
         sql=sql_store,
         hide_banner=True,
+        max_hops=parameters.max_hops,
     )

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -403,6 +403,7 @@ def print_related_resources(
     resource_type: "CoreResourceKinds",
     sql: "SQLStore",
     hide_banner: bool = False,
+    max_hops: int | None = None,
 ) -> None:
     with Status(ADO_SPINNER_QUERYING_DB) as status:
         if not sql.containsResourceWithIdentifier(identifier=resource_id):
@@ -414,7 +415,7 @@ def print_related_resources(
             kind=resource_type,
             identifier=resource_id,
             hierarchy_direction="both",
-            max_hops=None,
+            max_hops=max_hops,
             identifiers_only=True,
         )
 

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -410,20 +410,27 @@ def print_related_resources(
             raise ResourceDoesNotExistError(resource_id=resource_id, kind=resource_type)
 
         status.update("Finding related resources")
-        related_resources = sql.getRelatedResourceIdentifiers(resource_id)
+        related_resources = sql.get_resources_by_relationship(
+            kind=resource_type,
+            identifier=resource_id,
+            hierarchy_direction="both",
+            max_hops=None,
+            identifiers_only=True,
+        )
 
-    if related_resources.empty:
+    if not related_resources:
         console_print("There are no related resources", stderr=True)
         return
 
     if not hide_banner:
         console_print(rich.rule.Rule(title="RELATED RESOURCES"))
-    previous_resource_kind = ""
-    for _, row in related_resources.iterrows():
-        if row["TYPE"] != previous_resource_kind:
-            console_print(cyan(row["TYPE"]))
-            previous_resource_kind = row["TYPE"]
-        console_print(f"  - {row['IDENTIFIER']}")
+
+    for kind, identifiers in sorted(
+        related_resources.items(), key=lambda kv: kv[0].value
+    ):
+        console_print(cyan(kind.value))
+        for identifier in identifiers:
+            console_print(f"  - {identifier}")
 
 
 def strategic_merge_configuration_metadata(

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -610,19 +610,15 @@ class DiscoverySpace:
     def sampledEntities(self) -> list[Entity]:
         """Returns the entities sampled so far in the space"""
 
-        operation_ids_series = self.operations["IDENTIFIER"]
+        operation_ids = self.operations
 
-        # Convert pandas Series to list for easier handling
-        # Check if empty using .empty property (pandas Series can't be used in boolean context)
-        if operation_ids_series.empty:
+        if not operation_ids:
             return []
-
-        operation_ids = operation_ids_series.tolist()
 
         # Optimize for single operation: use direct query (1 query instead of 2)
         if len(operation_ids) == 1:
             sampled_entities = self.sample_store.entities_in_operation(
-                operation_id=operation_ids[0]
+                operation_id=next(iter(operation_ids))
             )
         else:
             # Multiple operations: get entity IDs first, then fetch entities
@@ -897,13 +893,16 @@ class DiscoverySpace:
         return self._metadataStore
 
     @property
-    def operations(self) -> "DataFrame":
-        """Returns a table of all the operations executed on this space"""
+    def operations(self) -> set[str]:
+        """Returns the identifiers of all operations executed on this space"""
 
-        return self._metadataStore.getRelatedResourceIdentifiers(
+        return self._metadataStore.get_resources_by_relationship(
+            kind=orchestrator.core.resources.CoreResourceKinds.DISCOVERYSPACE,
             identifier=self.uri,
-            kind=orchestrator.core.resources.CoreResourceKinds.OPERATION.value,
-        )
+            hierarchy_direction="down",
+            max_hops=1,
+            identifiers_only=True,
+        ).get(orchestrator.core.resources.CoreResourceKinds.OPERATION, set())
 
     def addOperation(self, operation: OperationResource) -> None:
         """Add information on a new operation on the space

--- a/orchestrator/metastore/base.py
+++ b/orchestrator/metastore/base.py
@@ -201,36 +201,6 @@ class ResourceStore(abc.ABC):
         """Returns identifiers of resources that have a relationship with "identifier" where "identifier" is the subject"""
 
     @abc.abstractmethod
-    def getRelatedResourceIdentifiers(
-        self, identifier: str, kind: str | None = None, version: str | None = None
-    ) -> "pd.DataFrame":
-        """Returns a DataFrame of resource identifiers related to a given resource identifier
-
-        The returned identifiers can optionally be limited to those of a given kind
-
-        Parameters:
-            identifier: A string. Identifies a resource object
-            kind: A string. A resource object type as defined by CoreResourceKinds
-            version: A version of the kind. If None all versions of the resource kind are returned
-
-        Returns:
-            A pandas DataFrame
-
-            The DataFrame has one column "IDENTIFIER" that contains the identifiers of the related resources.
-
-            If there are no related resources for the identifier this method returns an empty DataFrame
-        """
-
-    @abc.abstractmethod
-    def getRelatedResources(
-        self, identifier: str, kind: CoreResourceKinds | None = None
-    ) -> dict[str, ADOResource]:
-        """
-        Returns all resource object associated with identifier.
-        Optionally returns only resources of the provided kind.
-        """
-
-    @abc.abstractmethod
     def containsResourceWithIdentifier(
         self, identifier: str, kind: CoreResourceKinds | None = None
     ) -> bool:

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -848,9 +848,6 @@ class SQLResourceStore(ResourceStore):
             getRelatedObjectResourceIdentifiers
                 The inverse relationship: fetches subjects where the given
                 identifier is the *subject*.
-            getRelatedResourceIdentifiers
-                Convenience wrapper that returns a dataframe with both subject
-                and object relationships merged.
         """
 
         import pandas as pd
@@ -920,9 +917,6 @@ class SQLResourceStore(ResourceStore):
             getRelatedSubjectResourceIdentifiers
                 The inverse relationship: fetches subjects where the given
                 identifier is the *object*.
-            getRelatedResourceIdentifiers
-                Convenience wrapper that returns a dataframe with both subject
-                and object relationships merged.
         """
 
         import pandas as pd
@@ -951,88 +945,6 @@ class SQLResourceStore(ResourceStore):
         related_kinds = table["kind"].values
 
         return pd.DataFrame({"IDENTIFIER": related_identifiers, "TYPE": related_kinds})
-
-    def getRelatedResourceIdentifiers(
-        self, identifier: str, kind: str | None = None, version: str | None = None
-    ) -> "pd.DataFrame":
-        """
-        Retrieve identifiers of resources that are related to ``identifier`` either as a
-        subject or an object.
-
-        This method concatenates the results of
-        :meth:`getRelatedObjectResourceIdentifiers` and
-        :meth:`getRelatedSubjectResourceIdentifiers`.  The returned
-        :class:`pandas.DataFrame` has two columns:
-
-        * ``IDENTIFIER`` - the resource identifier
-        * ``TYPE``      - the resource kind
-
-        Args:
-            identifier : str
-                The resource identifier for which related resources are being
-                queried.
-            kind : str, optional
-                Filter by the resource *kind*.  If ``None`` (default) no kind
-                filtering is applied.
-            version : str, optional
-                Filter by the resource *version*.  If ``None`` (default) no
-                version filtering is applied.
-
-        Returns:
-            pandas.DataFrame
-                A DataFrame containing the identifiers of all related resources.
-                If no relationships exist an empty DataFrame is returned.
-        """
-
-        import pandas as pd
-
-        relatedAsObject = self.getRelatedObjectResourceIdentifiers(
-            identifier=identifier, kind=kind, version=version
-        )
-        relatedAsSubject = self.getRelatedSubjectResourceIdentifiers(
-            identifier=identifier, kind=kind, version=version
-        )
-
-        return pd.DataFrame(
-            {
-                "IDENTIFIER": relatedAsObject["IDENTIFIER"].values.tolist()
-                + relatedAsSubject["IDENTIFIER"].values.tolist(),
-                "TYPE": relatedAsObject["TYPE"].values.tolist()
-                + relatedAsSubject["TYPE"].values.tolist(),
-            }
-        )
-
-    def getRelatedResources(
-        self, identifier: str, kind: CoreResourceKinds | None = None
-    ) -> dict[str, orchestrator.core.resources.ADOResource]:
-        """
-        Retrieve all resources that are related to a given identifier.
-
-        Args:
-            identifier (str):
-                The identifier of the primary resource.  The method will fetch
-                every other resource that shares a relationship with this
-                identifier - either as the **subject** or **object** of a
-                relationship entry in ``resource_relationships``.
-            kind (orchestrator.core.resources.CoreResourceKinds, optional):
-                If supplied, only resources whose ``kind`` matches this value
-                are returned.  Pass ``None`` (the default) to retrieve
-                resources of any kind.
-
-        Returns:
-            dict[str, orchestrator.core.resources.ADOResource]:
-                A mapping from resource identifier to a fully deserialized
-                ``ADOResource`` instance.  The dictionary keys are the
-                identifiers of all resources that are related to
-                ``identifier``; the values are the corresponding
-                resource objects.  When ``kind`` is set, the dictionary
-                contains only resources of that kind.
-        """
-
-        identifiers = self.getRelatedResourceIdentifiers(
-            identifier=identifier, kind=kind.value
-        )
-        return self.getResources(identifiers=identifiers["IDENTIFIER"])
 
     def containsResourceWithIdentifier(
         self, identifier: str, kind: CoreResourceKinds | None = None

--- a/tests/ado/show_related/__init__.py
+++ b/tests/ado/show_related/__init__.py
@@ -1,0 +1,2 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT

--- a/tests/ado/show_related/test_show_related_max_hops.py
+++ b/tests/ado/show_related/test_show_related_max_hops.py
@@ -1,0 +1,196 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Tests for the --max-hops flag in the ado show related command."""
+
+import pathlib
+from collections.abc import Callable
+
+from typer.testing import CliRunner
+
+from orchestrator.cli.core.cli import app as ado
+from orchestrator.core import (
+    DiscoverySpaceResource,
+    OperationResource,
+    SampleStoreResource,
+)
+from orchestrator.metastore.project import ProjectContext
+from orchestrator.metastore.sql.statements import _MAX_HIERARCHY_HOPS
+from orchestrator.metastore.sqlstore import SQLStore
+from tests.conftest import requires_sqlite_3_38
+
+
+@requires_sqlite_3_38
+def test_show_related_max_hops_default_traverses_full_hierarchy(
+    tmp_path: pathlib.Path,
+    sql_store_with_resources_preloaded: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    discovery_space_resource: DiscoverySpaceResource,
+    operation_resource: OperationResource,
+    sample_store_resource: SampleStoreResource,
+    create_active_ado_context: Callable,
+) -> None:
+    """Without --max-hops the full hierarchy is returned (samplestore visible from operation)."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner,
+        path=tmp_path,
+        project_context=valid_ado_project_context,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "related",
+            "operation",
+            operation_resource.identifier,
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert discovery_space_resource.identifier in result.output
+    assert sample_store_resource.identifier in result.output
+
+
+@requires_sqlite_3_38
+def test_show_related_max_hops_1_excludes_grandparent(
+    tmp_path: pathlib.Path,
+    sql_store_with_resources_preloaded: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    discovery_space_resource: DiscoverySpaceResource,
+    operation_resource: OperationResource,
+    sample_store_resource: SampleStoreResource,
+    create_active_ado_context: Callable,
+) -> None:
+    """--max-hops 1 from an operation returns only the direct parent (discoveryspace)."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner,
+        path=tmp_path,
+        project_context=valid_ado_project_context,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "related",
+            "operation",
+            operation_resource.identifier,
+            "--max-hops",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert discovery_space_resource.identifier in result.output
+    # samplestore is 2 hops away; must be absent
+    assert sample_store_resource.identifier not in result.output
+
+
+@requires_sqlite_3_38
+def test_show_related_max_hops_2_includes_grandparent(
+    tmp_path: pathlib.Path,
+    sql_store_with_resources_preloaded: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    discovery_space_resource: DiscoverySpaceResource,
+    operation_resource: OperationResource,
+    sample_store_resource: SampleStoreResource,
+    create_active_ado_context: Callable,
+) -> None:
+    """--max-hops 2 from an operation returns both discoveryspace and samplestore."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner,
+        path=tmp_path,
+        project_context=valid_ado_project_context,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "related",
+            "operation",
+            operation_resource.identifier,
+            "--max-hops",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert discovery_space_resource.identifier in result.output
+    assert sample_store_resource.identifier in result.output
+
+
+@requires_sqlite_3_38
+def test_show_related_max_hops_zero_is_rejected(
+    tmp_path: pathlib.Path,
+    sql_store_with_resources_preloaded: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    operation_resource: OperationResource,
+    create_active_ado_context: Callable,
+) -> None:
+    """--max-hops 0 must be rejected (minimum valid value is 1)."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner,
+        path=tmp_path,
+        project_context=valid_ado_project_context,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "related",
+            "operation",
+            operation_resource.identifier,
+            "--max-hops",
+            "0",
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+@requires_sqlite_3_38
+def test_show_related_max_hops_above_maximum_is_rejected(
+    tmp_path: pathlib.Path,
+    sql_store_with_resources_preloaded: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    operation_resource: OperationResource,
+    create_active_ado_context: Callable,
+) -> None:
+    """--max-hops values above _MAX_HIERARCHY_HOPS must be rejected."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner,
+        path=tmp_path,
+        project_context=valid_ado_project_context,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "related",
+            "operation",
+            operation_resource.identifier,
+            "--max-hops",
+            str(_MAX_HIERARCHY_HOPS + 1),
+        ],
+    )
+
+    assert result.exit_code != 0

--- a/tests/core/test_space.py
+++ b/tests/core/test_space.py
@@ -366,7 +366,7 @@ def test_operation_context_success_lifecycle(pfas_space: DiscoverySpace) -> None
         kind=CoreResourceKinds.OPERATION,
     )
     assert isinstance(operation, OperationResource)
-    assert operation_id in pfas_space.operations["IDENTIFIER"].values
+    assert operation_id in pfas_space.operations
     assert isinstance(operation.config.operation.module, ScriptOperatorConf)
     assert (
         operation.config.operation.module.operationType == DiscoveryOperationEnum.SEARCH

--- a/tests/fixtures/samplestore/crud.py
+++ b/tests/fixtures/samplestore/crud.py
@@ -112,12 +112,20 @@ def get_resource_identifiers_by_resource_kind(
 @pytest.fixture
 def get_related_resource_identifiers_by_identifier(
     sql_store: SQLStore,
-) -> Callable[[str], pd.DataFrame]:
+) -> Callable[[str, CoreResourceKinds, str], dict[CoreResourceKinds, set[str]]]:
     def _get_related_resource_identifiers_by_identifier(
         identifier: str,
-    ) -> pd.DataFrame:
+        kind: CoreResourceKinds,
+        hierarchy_direction: str = "both",
+    ) -> dict[CoreResourceKinds, set[str]]:
 
-        return sql_store.getRelatedResourceIdentifiers(identifier=identifier)
+        return sql_store.get_resources_by_relationship(
+            kind=kind,
+            identifier=identifier,
+            hierarchy_direction=hierarchy_direction,
+            max_hops=None,
+            identifiers_only=True,
+        )
 
     return _get_related_resource_identifiers_by_identifier
 

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -4,7 +4,6 @@ import re
 import uuid
 from collections.abc import Callable
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -139,12 +138,11 @@ def test_get_resources_sorted_by_created_ascending(
 
 
 @requires_sqlite_3_38
-def test_get_related_resource_identifiers(
+def test_get_resources_by_relationship(
     sql_store_with_resources_preloaded: SQLStore, resource_type: CoreResourceKinds
 ) -> None:
     """
-    Tests getting the identifiers of related resources
-
+    Tests getting the identifiers of related resources via get_resources_by_relationship.
     """
 
     identifiers = sql_store_with_resources_preloaded.getResourceIdentifiersOfKind(
@@ -152,36 +150,25 @@ def test_get_related_resource_identifiers(
     )
     if identifiers.shape[0] > 0:
         identifier = identifiers["IDENTIFIER"][0]
-        for rt2 in list(CoreResourceKinds):
-            x = sql_store_with_resources_preloaded.getRelatedResourceIdentifiers(
-                identifier, kind=rt2.value
-            )
-            assert x is not None
+        result = sql_store_with_resources_preloaded.get_resources_by_relationship(
+            kind=resource_type,
+            identifier=identifier,
+            hierarchy_direction="both",
+            max_hops=None,
+            identifiers_only=True,
+        )
+        assert result is not None
 
-            # Test some relationships know to exist
-            # All operations should have related discovery space
-            # All DiscoverySpaces should have related SampleStore
-            if (
-                resource_type == CoreResourceKinds.OPERATION
-                and rt2 == CoreResourceKinds.DISCOVERYSPACE
-            ):
-                assert x.shape[0] > 0
-                assert x.columns[0] == "IDENTIFIER"
-                assert x.columns[1] == "TYPE"
-                if x.shape[0] > 0:
-                    types = np.unique(x["TYPE"].values)
-                    assert len(types) == 1
-                    assert types[0] == rt2.value
-            elif (
-                resource_type == CoreResourceKinds.DISCOVERYSPACE
-                and rt2 == CoreResourceKinds.SAMPLESTORE
-            ):
-                assert x.columns[0] == "IDENTIFIER"
-                assert x.columns[1] == "TYPE"
-                if x.shape[0] > 0:
-                    types = np.unique(x["TYPE"].values)
-                    assert len(types) == 1
-                    assert types[0] == rt2.value
+        # Test some relationships known to exist:
+        # All operations should have a related discovery space
+        if resource_type == CoreResourceKinds.OPERATION:
+            assert CoreResourceKinds.DISCOVERYSPACE in result
+            assert len(result[CoreResourceKinds.DISCOVERYSPACE]) == 1
+
+        # All DiscoverySpaces should have a related SampleStore
+        if resource_type == CoreResourceKinds.DISCOVERYSPACE:
+            assert CoreResourceKinds.SAMPLESTORE in result
+            assert len(result[CoreResourceKinds.SAMPLESTORE]) == 1
 
 
 #
@@ -241,11 +228,12 @@ def test_add_and_delete_discovery_space(
         identifier=space_resource.identifier
     )
 
-    assert (
-        sql_store.getRelatedResourceIdentifiers(
-            identifier=space_resource.identifier
-        ).shape[0]
-        == 0
+    assert not sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=space_resource.identifier,
+        hierarchy_direction="both",
+        max_hops=None,
+        identifiers_only=True,
     )
 
 
@@ -277,21 +265,23 @@ def test_add_update_and_delete_operation_related_to_discovery_space(
         )["IDENTIFIER"].values
     )
 
-    # Test the relationship to space_identifier is there
-    assert (
-        space_identifier
-        in sql_store.getRelatedResourceIdentifiers(
-            identifier=operation_resource.identifier
-        )["IDENTIFIER"].values
-    )
+    # Test the relationship to space_identifier is there (operation → space: up)
+    assert space_identifier in sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=operation_resource.identifier,
+        hierarchy_direction="up",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.DISCOVERYSPACE, set())
 
-    # Test is there in the other direction
-    assert (
-        operation_resource.identifier
-        in sql_store.getRelatedResourceIdentifiers(identifier=space_identifier)[
-            "IDENTIFIER"
-        ].values
-    )
+    # Test is there in the other direction (space → operation: down)
+    assert operation_resource.identifier in sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=space_identifier,
+        hierarchy_direction="down",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.OPERATION, set())
 
     # Update
 
@@ -331,18 +321,20 @@ def test_add_update_and_delete_operation_related_to_discovery_space(
         )["IDENTIFIER"].values
     )
 
-    assert (
-        operation_resource.identifier
-        not in sql_store.getRelatedResourceIdentifiers(identifier=space_identifier)[
-            "IDENTIFIER"
-        ].values
-    )
+    assert operation_resource.identifier not in sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=space_identifier,
+        hierarchy_direction="down",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.OPERATION, set())
 
-    assert (
-        sql_store.getRelatedResourceIdentifiers(
-            identifier=operation_resource.identifier
-        ).shape[0]
-        == 0
+    assert not sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=operation_resource.identifier,
+        hierarchy_direction="both",
+        max_hops=None,
+        identifiers_only=True,
     )
 
 
@@ -370,12 +362,16 @@ def test_add_operation_and_output(
     )
 
     # Test we can get the datacontainer
-    dcs = sql_store.getRelatedResourceIdentifiers(
-        identifier=op_resource.identifier, kind=CoreResourceKinds.DATACONTAINER.value
-    )
+    dcs = sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_resource.identifier,
+        hierarchy_direction="down",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.DATACONTAINER, set())
 
-    assert (dcs.shape[0]) == 1
-    ident = dcs["IDENTIFIER"][0]
+    assert len(dcs) == 1
+    ident = next(iter(dcs))
 
     res = sql_store.getResource(identifier=ident, kind=CoreResourceKinds.DATACONTAINER)
     assert isinstance(res, DataContainerResource)
@@ -414,12 +410,13 @@ def test_add_operation_and_output(
         )["IDENTIFIER"].values
     )
 
-    assert (
-        res.identifier
-        not in sql_store.getRelatedResourceIdentifiers(
-            identifier=op_resource.identifier
-        )["IDENTIFIER"].values
-    )
+    assert res.identifier not in sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
+        identifier=op_resource.identifier,
+        hierarchy_direction="down",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.DATACONTAINER, set())
 
     # Delete the resource
     sql_store.deleteResource(identifier=op_resource.identifier)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -461,12 +461,15 @@ def test_run_random_walk_operation(
     assert operation.status[5].event == ADOResourceEventEnum.UPDATED
 
     # Check it is related to the space
-    spaces = discoverySpace.metadataStore.getRelatedResourceIdentifiers(
+    spaces = discoverySpace.metadataStore.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
         identifier=operationOutput.operation.identifier,
-        kind=CoreResourceKinds.DISCOVERYSPACE.value,
-    )
-    assert spaces.shape[0] > 0
-    assert spaces.IDENTIFIER[0] == discoverySpace.uri
+        hierarchy_direction="up",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.DISCOVERYSPACE, set())
+    assert len(spaces) == 1
+    assert discoverySpace.uri in spaces
 
     ## CHECK THE EXPECTED NUMBER OF EXPERIMENTS HAVE BEEN RUN
     assert operationOutput.operation.metadata["entities_submitted"] == 48
@@ -587,12 +590,15 @@ def test_run_ray_tune_operation(
     assert operation.status[5].event == ADOResourceEventEnum.UPDATED
 
     # Check it is related to the space
-    spaces = discoverySpace.metadataStore.getRelatedResourceIdentifiers(
+    spaces = discoverySpace.metadataStore.get_resources_by_relationship(
+        kind=CoreResourceKinds.OPERATION,
         identifier=operationOutput.operation.identifier,
-        kind=CoreResourceKinds.DISCOVERYSPACE.value,
-    )
-    assert spaces.shape[0] > 0
-    assert spaces.IDENTIFIER[0] == discoverySpace.uri
+        hierarchy_direction="up",
+        max_hops=1,
+        identifiers_only=True,
+    ).get(CoreResourceKinds.DISCOVERYSPACE, set())
+    assert len(spaces) == 1
+    assert discoverySpace.uri in spaces
 
 
 def test_operator_default_and_validate(

--- a/tests/samplestore/create/test_create.py
+++ b/tests/samplestore/create/test_create.py
@@ -3,7 +3,6 @@
 import re
 from collections.abc import Callable
 
-import pandas as pd
 import pytest
 
 from orchestrator.core import DiscoverySpaceResource, OperationResource
@@ -69,7 +68,9 @@ def test_create_operation_with_related_space(
     get_single_resource_by_identifier: Callable[
         [str, CoreResourceKinds], ADOResource | None
     ],
-    get_related_resource_identifiers_by_identifier: Callable[[str], pd.DataFrame],
+    get_related_resource_identifiers_by_identifier: Callable[
+        [str, CoreResourceKinds, str], dict[CoreResourceKinds, set[str]]
+    ],
 ) -> None:
     quantity = 3
 
@@ -88,8 +89,10 @@ def test_create_operation_with_related_space(
         is not None
     )
     related_resource_identifiers = get_related_resource_identifiers_by_identifier(
-        identifier=operation.identifier
-    )["IDENTIFIER"].values
+        operation.identifier,
+        CoreResourceKinds.OPERATION,
+        "up",
+    ).get(CoreResourceKinds.DISCOVERYSPACE, set())
     for space_id in space_ids:
         assert space_id in related_resource_identifiers
 

--- a/tests/samplestore/delete/test_delete.py
+++ b/tests/samplestore/delete/test_delete.py
@@ -19,9 +19,12 @@ def test_resource_deletion(
     resource = request.getfixturevalue(generator)()
     delete_resource(resource.identifier)
     assert not sql_store.containsResourceWithIdentifier(identifier=resource.identifier)
-    assert (
-        sql_store.getRelatedResourceIdentifiers(identifier=resource.identifier).shape[0]
-        == 0
+    assert not sql_store.get_resources_by_relationship(
+        kind=_resource_kind,
+        identifier=resource.identifier,
+        hierarchy_direction="both",
+        max_hops=None,
+        identifiers_only=True,
     )
 
 

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -1058,12 +1058,13 @@ ado show trace operation randomwalk-0.5.0-123abc --hide metadata --hide timestam
 #### ado show related
 
 _show related_ supports displaying resources that are related to the one whose
-id is provided (e.g., operations run on a space).
+id is provided (e.g., operations run on a space). By default the full resource
+hierarchy is traversed in both directions.
 
 The complete syntax of the `ado show related` command is as follows:
 
 ```shell
-ado show related RESOURCE_TYPE [RESOURCE_ID] [--use-latest]
+ado show related RESOURCE_TYPE [RESOURCE_ID] [--use-latest] [--max-hops N]
 ```
 
 - `RESOURCE_TYPE` is one of the supported resource types. See
@@ -1085,13 +1086,21 @@ ado show related RESOURCE_TYPE [RESOURCE_ID] [--use-latest]
 - `--use-latest` will use the identifier of the latest (i.e. most recent)
   resource of RESOURCE_TYPE from the current context. It is ignored if a
   RESOURCE_ID is provided.
+- `--max-hops N` limits the traversal to at most `N` relationship hops in each
+  direction (1-3). When omitted, the full hierarchy depth is used.
 
 ##### Examples
 
 ###### Show resources related to a discovery space
 
 ```shell
- ado show related space space-abc123-456def
+ado show related space space-abc123-456def
+```
+
+###### Show only directly linked resources (1 hop)
+
+```shell
+ado show related space space-abc123-456def --max-hops 1
 ```
 
 #### ado show summary


### PR DESCRIPTION
## Replace `getRelatedResourceIdentifiers` / `getRelatedResources` with `get_resources_by_relationship`

### What changed

**Core refactor (metastore layer)**
Two legacy methods — `getRelatedResourceIdentifiers` and `getRelatedResources` — have been removed from both the abstract `ResourceStore` base class and the `SQLResourceStore` implementation. They returned flat pandas DataFrames and had no concept of traversal depth. They are replaced by the existing `get_resources_by_relationship`, which returns a typed `dict[CoreResourceKinds, set[str]]` and supports multi-hop hierarchy traversal.

**New `--max-hops` flag on `ado show related`**
The `show related` CLI command now accepts `--max-hops N` (1–3). Without it, the full resource hierarchy is traversed in both directions (previous behaviour was one-hop only). This makes the command more powerful and also more explicit about its depth.

**Call-site updates**
All callers of the removed methods (`SpaceSummary`, `DiscoverySpace.operations`, `print_related_resources`) have been updated to call `get_resources_by_relationship` directly with explicit `kind`, `hierarchy_direction`, and `max_hops` arguments. Output iteration is now over typed sets instead of DataFrame rows.

**Tests**
New test file `test_show_related_max_hops.py` covers full-hierarchy traversal (default) and `--max-hops 1` limiting. Existing tests in `test_resourcestore.py` and related fixtures have been updated to remove references to the deleted methods.

**Docs**
The `ado show related` documentation is updated to document `--max-hops` and fix a minor indentation issue in the examples.