### PR TITLE
feat(core): support multiple operation ids in measurement_requests_for_operation

### DIFF
--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -1063,8 +1063,8 @@ class DiscoverySpace:
 
     @_perform_preflight_checks_for_sample_store_methods
     def measurement_requests_for_operation(
-        self, operation_id: str
-    ) -> list[MeasurementRequest]:
+        self, operation_id: str | set[str]
+    ) -> list[MeasurementRequest] | dict[str, list[MeasurementRequest]]:
         return self.sample_store.measurement_requests_for_operation(
             operation_id=operation_id
         )

--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -1607,21 +1607,22 @@ class SQLSampleStore(ActiveSampleStore):
 
     def measurement_requests_for_operation(
         self,
-        operation_id: str,
+        operation_id: str | set[str],
         filters: list[dict[str, str]] | None = None,
-    ) -> list[MeasurementRequest]:
+    ) -> list[MeasurementRequest] | dict[str, list[MeasurementRequest]]:
         """
-        Fetch measurement requests for an operation, optionally filtered.
+        Fetch measurement requests for one or more operations, optionally filtered.
 
         Args:
-            operation_id: The operation identifier
+            operation_id: The operation identifier, or a set of operation identifiers
             filters: Optional DB-level filters from prepare_query_filters_for_db()
                      Format: [{"$.path": "value"}, ...]
                      Supports filtering on request fields (status, requestIndex, etc.)
                      and nested JSON fields (metadata.*, experimentReference.*)
 
         Returns:
-            List of MeasurementRequest objects matching the filters
+            A list of MeasurementRequest objects when passed a single operation ID,
+            or a dict keyed by operation ID when passed a set of operation IDs
         """
         from sqlalchemy import and_, select
 
@@ -1630,12 +1631,10 @@ class SQLSampleStore(ActiveSampleStore):
         )
 
         try:
-            # Use cached table metadata from initialization
             req_table = self._request_table
             reqres_table = self._request_result_table
             res_table = self._result_table
 
-            # Build query using SQLAlchemy
             stmt = (
                 select(
                     req_table.c.uid,
@@ -1653,10 +1652,13 @@ class SQLSampleStore(ActiveSampleStore):
                 .select_from(req_table)
                 .join(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
                 .join(res_table, reqres_table.c.result_uid == res_table.c.uid)
-                .where(req_table.c.operation_id == operation_id)
             )
 
-            # Apply filters if provided
+            if isinstance(operation_id, set):
+                stmt = stmt.where(req_table.c.operation_id.in_(operation_id))
+            else:
+                stmt = stmt.where(req_table.c.operation_id == operation_id)
+
             if filters:
                 filter_builder = MeasurementFilterBuilder(
                     dialect=self.engine.dialect.name
@@ -1669,7 +1671,6 @@ class SQLSampleStore(ActiveSampleStore):
                 if filter_conditions:
                     stmt = stmt.where(and_(*filter_conditions))
 
-            # Add ordering
             stmt = stmt.order_by(
                 req_table.c.request_index,
                 req_table.c.insert_id,
@@ -1680,11 +1681,25 @@ class SQLSampleStore(ActiveSampleStore):
             with self.engine.begin() as connectable:
                 cur = connectable.execute(stmt)
         except SQLAlchemyError as error:
-            msg = f"Unable to get the measurement results for operation {operation_id}"
+            msg = (
+                f"Unable to get the measurement requests for operations {operation_id}"
+                if isinstance(operation_id, set)
+                else f"Unable to get the measurement requests for operation {operation_id}"
+            )
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 
-        return self._measurement_requests_cursor_to_pydantic(db_cursor=cur)
+        requests = self._measurement_requests_cursor_to_pydantic(db_cursor=cur)
+        if not isinstance(operation_id, set):
+            return requests
+
+        requests_by_operation_id: dict[str, list[MeasurementRequest]] = {
+            requested_operation_id: [] for requested_operation_id in operation_id
+        }
+        for request in requests:
+            requests_by_operation_id[request.operation_id].append(request)
+
+        return requests_by_operation_id
 
     def measurement_request_by_id(
         self, measurement_request_id: str

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -427,6 +427,54 @@ def test_measurement_requests_for_operation(
                 )
 
 
+def test_measurement_requests_for_operation_multi_id(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    number_entities = 3
+    number_requests = 3
+    measurements_per_result = 2
+    operation_id_1 = random_identifier()
+    operation_id_2 = random_identifier()
+
+    sample_store, requests_1, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_1,
+    )
+    sample_store, requests_2, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_2,
+    )
+
+    retrieved_requests = sample_store.measurement_requests_for_operation(
+        operation_id={operation_id_1, operation_id_2}
+    )
+
+    assert isinstance(retrieved_requests, dict)
+    assert set(retrieved_requests) == {operation_id_1, operation_id_2}
+
+    expected_requests = {
+        operation_id_1: sorted(requests_1, key=lambda request: request.requestIndex),
+        operation_id_2: sorted(requests_2, key=lambda request: request.requestIndex),
+    }
+
+    for operation_id, requests in expected_requests.items():
+        assert len(retrieved_requests[operation_id]) == len(requests)
+        assert [
+            request.operation_id for request in retrieved_requests[operation_id]
+        ] == [operation_id] * len(requests)
+        assert [
+            request.requestIndex for request in retrieved_requests[operation_id]
+        ] == [request.requestIndex for request in requests]
+
+
 def test_measurement_request_by_id(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[


### PR DESCRIPTION
## Support multiple operation IDs in measurement requests

### What changed

`measurement_requests_for_operation` (on both `SQLSampleStore` and `DiscoverySpace`) now accepts either a **single operation ID** (`str`) or a **set of operation IDs** (`set[str]`).

- **Single ID** → behaviour unchanged; returns `list[MeasurementRequest]` as before.
- **Set of IDs** → issues a single `IN (...)` SQL query and returns `dict[str, list[MeasurementRequest]]`, keyed by operation ID. Each key is initialised (even if no requests exist for that ID), so callers can always expect every requested ID to be present.

Closes #1061

### Files touched

| File | Change |
|---|---|
| `orchestrator/core/samplestore/sql.py` | Core logic — overloaded signature, `IN` query, dict grouping |
| `orchestrator/core/discoveryspace/space.py` | Pass-through signature updated to match |
| `tests/samplestore/get/test_get.py` | New test covering the multi-ID path |