### PR TITLE
feat(core): support multiple operation ids in operation_measurement_statistics

### DIFF
--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -1125,21 +1125,29 @@ class DiscoverySpace:
 
     @_perform_preflight_checks_for_sample_store_methods
     def operation_measurement_statistics(
-        self, operation_id: str
-    ) -> "orchestrator.core.operation.stats.OperationMeasurementStatistics":
-        """Compute aggregated measurement statistics for an operation.
+        self, operation_ids: set[str] | None = None
+    ) -> "list[orchestrator.core.operation.stats.OperationMeasurementStatistics]":
+        """Compute aggregated measurement statistics for one or more operations.
 
         Delegates to the SQL implementation for SQL-backed stores. For all
         other stores, falls back to a Python implementation that iterates the
-        measurement requests for the operation.
+        measurement requests per operation.
 
         Args:
-            operation_id: The operation identifier.
+            operation_ids: Set of operation identifiers to aggregate. Pass
+                ``None`` to aggregate across all operations in the store.
+                Passing an empty set raises ``ValueError``.
 
         Returns:
-            An OperationMeasurementStatistics instance with request-level,
-            result-level, and entity-level counts.
+            A list of OperationMeasurementStatistics instances, one per
+            operation found in the store.
+
+        Raises:
+            ValueError: If ``operation_ids`` is an empty set.
         """
+        if operation_ids is not None and len(operation_ids) == 0:
+            raise ValueError("operation_ids must be a non-empty set or None")
+
         import orchestrator.core.samplestore.sql
         from orchestrator.core.operation.stats import OperationMeasurementStatistics
 
@@ -1147,43 +1155,55 @@ class DiscoverySpace:
             self.sample_store, orchestrator.core.samplestore.sql.SQLSampleStore
         ):
             return self.sample_store.operation_measurement_statistics(
-                operation_id=operation_id
+                operation_ids=operation_ids
             )
 
         # Python fallback for non-SQL stores
         from orchestrator.schema.request import MeasurementRequestStateEnum
         from orchestrator.schema.result import ValidMeasurementResult
 
-        requests = self.measurement_requests_for_operation(operation_id=operation_id)
-
-        total_requests = len(requests)
-        failed_requests = sum(
-            1 for r in requests if r.status == MeasurementRequestStateEnum.FAILED
-        )
-        successful_requests = sum(
-            1 for r in requests if r.status == MeasurementRequestStateEnum.SUCCESS
+        # Determine which operation IDs to iterate
+        ids_to_process: set[str] = (
+            self.operations if operation_ids is None else operation_ids
         )
 
-        total_results = 0
-        successful_results = 0
-        failed_results = 0
-        measured_entity_ids: set[str] = set()
+        result_list: list[OperationMeasurementStatistics] = []
+        for op_id in ids_to_process:
+            requests = self.measurement_requests_for_operation(operation_id=op_id)
 
-        for request in requests:
-            for result in request.measurements:
-                total_results += 1
-                if isinstance(result, ValidMeasurementResult):
-                    successful_results += 1
-                else:
-                    failed_results += 1
-                measured_entity_ids.add(result.entityIdentifier)
+            total_requests = len(requests)
+            failed_requests = sum(
+                1 for r in requests if r.status == MeasurementRequestStateEnum.FAILED
+            )
+            successful_requests = sum(
+                1 for r in requests if r.status == MeasurementRequestStateEnum.SUCCESS
+            )
 
-        return OperationMeasurementStatistics(
-            total_requests=total_requests,
-            failed_requests=failed_requests,
-            successful_requests=successful_requests,
-            total_results=total_results,
-            successful_results=successful_results,
-            failed_results=failed_results,
-            measured_entities=len(measured_entity_ids),
-        )
+            total_results = 0
+            successful_results = 0
+            failed_results = 0
+            measured_entity_ids: set[str] = set()
+
+            for request in requests:
+                for result in request.measurements:
+                    total_results += 1
+                    if isinstance(result, ValidMeasurementResult):
+                        successful_results += 1
+                    else:
+                        failed_results += 1
+                    measured_entity_ids.add(result.entityIdentifier)
+
+            result_list.append(
+                OperationMeasurementStatistics(
+                    operation_id=op_id,
+                    total_requests=total_requests,
+                    failed_requests=failed_requests,
+                    successful_requests=successful_requests,
+                    total_results=total_results,
+                    successful_results=successful_results,
+                    failed_results=failed_results,
+                    measured_entities=len(measured_entity_ids),
+                )
+            )
+
+        return result_list

--- a/orchestrator/core/operation/stats.py
+++ b/orchestrator/core/operation/stats.py
@@ -10,6 +10,7 @@ class OperationMeasurementStatistics(pydantic.BaseModel):
     """Aggregated measurement statistics for a single operation.
 
     Attributes:
+        operation_id: The operation identifier these statistics belong to.
         total_requests: Total number of MeasurementRequests for the operation.
         failed_requests: Number of requests whose status is FAILED.
         successful_requests: Number of requests whose status is SUCCESS.
@@ -19,6 +20,12 @@ class OperationMeasurementStatistics(pydantic.BaseModel):
         measured_entities: Count of distinct entities that have at least one result.
     """
 
+    operation_id: Annotated[
+        str,
+        pydantic.Field(
+            description="The operation identifier these statistics belong to."
+        ),
+    ]
     total_requests: Annotated[
         int,
         pydantic.Field(

--- a/orchestrator/core/samplestore/base.py
+++ b/orchestrator/core/samplestore/base.py
@@ -502,16 +502,21 @@ class ActiveSampleStore(SampleStore, ABC):
 
     @abc.abstractmethod
     def operation_measurement_statistics(
-        self, operation_id: str
-    ) -> "OperationMeasurementStatistics":
-        """Compute aggregated measurement statistics for an operation.
+        self, operation_ids: set[str] | None = None
+    ) -> "list[OperationMeasurementStatistics]":
+        """Compute aggregated measurement statistics for one or more operations.
 
         Args:
-            operation_id: The operation identifier.
+            operation_ids: Set of operation identifiers to aggregate. Pass
+                ``None`` to aggregate across all operations in the store.
+                Passing an empty set raises ``ValueError``.
 
         Returns:
-            An OperationMeasurementStatistics instance with request-level,
-            result-level, and entity-level counts.
+            A list of OperationMeasurementStatistics instances, one per
+            operation found in the store.
+
+        Raises:
+            ValueError: If ``operation_ids`` is an empty set.
         """
 
 

--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -1486,20 +1486,29 @@ class SQLSampleStore(ActiveSampleStore):
             raise SystemError(f"{msg}. Error: {error}") from error
 
     def operation_measurement_statistics(
-        self, operation_id: str
-    ) -> "OperationMeasurementStatistics":
-        """Compute aggregated measurement statistics for an operation.
+        self, operation_ids: set[str] | None = None
+    ) -> "list[OperationMeasurementStatistics]":
+        """Compute aggregated measurement statistics for one or more operations.
 
-        Computes all seven statistics in a single query to avoid multiple
-        DB round-trips: request counts (total/failed/successful), result counts
-        (total/valid/invalid), and distinct measured entity count.
+        Computes all statistics in a single query grouped by operation_id to
+        avoid multiple DB round-trips: request counts (total/failed/successful),
+        result counts (total/valid/invalid), and distinct measured entity count.
 
         Args:
-            operation_id: The operation identifier.
+            operation_ids: Set of operation identifiers to aggregate. Pass
+                ``None`` to aggregate across all operations in the store.
+                Passing an empty set raises ``ValueError``.
 
         Returns:
-            An OperationMeasurementStatistics instance.
+            A list of OperationMeasurementStatistics instances, one per
+            operation found in the store.
+
+        Raises:
+            ValueError: If ``operation_ids`` is an empty set.
         """
+        if operation_ids is not None and len(operation_ids) == 0:
+            raise ValueError("operation_ids must be a non-empty set or None")
+
         from sqlalchemy import case, func, select
 
         from orchestrator.core.operation.stats import OperationMeasurementStatistics
@@ -1511,6 +1520,7 @@ class SQLSampleStore(ActiveSampleStore):
         # Equivalent SQL:
         #
         #   SELECT
+        #     req.operation_id,
         #     COUNT(DISTINCT req.uid) AS total_requests,
         #     COUNT(DISTINCT CASE WHEN req.status = 'Failed' THEN req.uid END) AS failed_requests,
         #     COUNT(DISTINCT CASE WHEN req.status = 'Success' THEN req.uid END) AS successful_requests,
@@ -1521,12 +1531,15 @@ class SQLSampleStore(ActiveSampleStore):
         #   FROM <tablename>_measurement_requests req
         #   LEFT JOIN <tablename>_measurement_requests_results reqres ON reqres.request_uid = req.uid
         #   LEFT JOIN <tablename>_measurement_results            res  ON reqres.result_uid  = res.uid
-        #   WHERE req.operation_id = :operation_id
+        #   [WHERE req.operation_id IN (...)]          -- only when operation_ids is not None
+        #   GROUP BY req.operation_id
 
         reason_is_null = func.json_extract(res_table.c.data, "$.reason").is_(None)
 
         stmt = (
             select(
+                # req.operation_id
+                req_table.c.operation_id,
                 # COUNT(DISTINCT req.uid) AS total_requests,
                 func.count(func.distinct(req_table.c.uid)).label("total_requests"),
                 # COUNT(DISTINCT CASE WHEN req.status = 'Failed' THEN req.uid END) AS failed_requests,
@@ -1574,34 +1587,31 @@ class SQLSampleStore(ActiveSampleStore):
             .outerjoin(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
             # LEFT JOIN <tablename>_measurement_results res ON reqres.result_uid = res.uid
             .outerjoin(res_table, reqres_table.c.result_uid == res_table.c.uid)
-            # WHERE req.operation_id =:operation_id
-            .where(req_table.c.operation_id == operation_id)
+            # GROUP BY req.operation_id
+            .group_by(req_table.c.operation_id)
         )
+
+        if operation_ids is not None:
+            stmt = stmt.where(req_table.c.operation_id.in_(operation_ids))
 
         try:
             with self.engine.begin() as connectable:
-                row = connectable.execute(stmt).one()
-                (
-                    total_requests,
-                    failed_requests,
-                    successful_requests,
-                    total_results,
-                    successful_results,
-                    failed_results,
-                    measured_entities,
-                ) = row
-
-                return OperationMeasurementStatistics(
-                    total_requests=total_requests or 0,
-                    failed_requests=failed_requests or 0,
-                    successful_requests=successful_requests or 0,
-                    total_results=total_results or 0,
-                    successful_results=successful_results or 0,
-                    failed_results=failed_results or 0,
-                    measured_entities=measured_entities or 0,
-                )
+                rows = connectable.execute(stmt).all()
+                return [
+                    OperationMeasurementStatistics(
+                        operation_id=row.operation_id,
+                        total_requests=row.total_requests or 0,
+                        failed_requests=row.failed_requests or 0,
+                        successful_requests=row.successful_requests or 0,
+                        total_results=row.total_results or 0,
+                        successful_results=row.successful_results or 0,
+                        failed_results=row.failed_results or 0,
+                        measured_entities=row.measured_entities or 0,
+                    )
+                    for row in rows
+                ]
         except SQLAlchemyError as error:
-            msg = f"Unable to get measurement statistics for operation {operation_id}"
+            msg = f"Unable to get measurement statistics for operation IDs {operation_ids}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -982,9 +982,12 @@ def test_operation_measurement_statistics_all_valid(
         for result in request.measurements
     }
 
-    stats = sample_store.operation_measurement_statistics(operation_id=operation_id)
+    result = sample_store.operation_measurement_statistics(operation_ids={operation_id})
 
+    assert len(result) == 1
+    stats = result[0]
     assert isinstance(stats, OperationMeasurementStatistics)
+    assert stats.operation_id == operation_id
     assert stats.total_requests == number_requests
     assert stats.failed_requests == 0
     assert stats.successful_requests == number_requests
@@ -1094,9 +1097,12 @@ def test_operation_measurement_statistics_mixed_valid_invalid(
         r.entityIdentifier for r in request1.measurements
     }
 
-    stats = sample_store.operation_measurement_statistics(operation_id=operation_id)
+    result = sample_store.operation_measurement_statistics(operation_ids={operation_id})
 
+    assert len(result) == 1
+    stats = result[0]
     assert isinstance(stats, OperationMeasurementStatistics)
+    assert stats.operation_id == operation_id
     assert stats.total_requests == 2
     assert stats.failed_requests == 1
     assert stats.successful_requests == 1
@@ -1139,11 +1145,130 @@ def test_operation_measurement_statistics_measured_entities_distinct(
         for result in request.measurements
     }
 
-    stats = sample_store.operation_measurement_statistics(operation_id=operation_id)
+    result = sample_store.operation_measurement_statistics(operation_ids={operation_id})
 
+    assert len(result) == 1
+    stats = result[0]
     assert isinstance(stats, OperationMeasurementStatistics)
+    assert stats.operation_id == operation_id
     # measured_entities is DISTINCT — repeated entities across requests count once
     assert stats.measured_entities == len(expected_entities)
     # total_results counts every result row, including repeats
     assert stats.total_results == number_requests * number_entities
     assert stats.total_results >= stats.measured_entities
+
+
+@requires_sqlite_3_38
+def test_operation_measurement_statistics_multiple_ids(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Test operation_measurement_statistics with two operation IDs returns two stats objects."""
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
+    operation_id_a = random_identifier()
+    operation_id_b = random_identifier()
+
+    number_entities = 3
+    number_requests_a = 2
+    number_requests_b = 4
+    measurements_per_result = 2
+
+    sample_store, _requests_a, _ids_a = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests_a,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_a,
+    )
+    _sample_store, _requests_b, _ids_b = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests_b,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_b,
+    )
+
+    result = sample_store.operation_measurement_statistics(
+        operation_ids={operation_id_a, operation_id_b}
+    )
+
+    assert len(result) == 2
+    stats_by_id = {s.operation_id: s for s in result}
+
+    assert operation_id_a in stats_by_id
+    assert operation_id_b in stats_by_id
+
+    for stats in result:
+        assert isinstance(stats, OperationMeasurementStatistics)
+
+    assert stats_by_id[operation_id_a].total_requests == number_requests_a
+    assert stats_by_id[operation_id_b].total_requests == number_requests_b
+    assert (
+        stats_by_id[operation_id_a].total_results == number_requests_a * number_entities
+    )
+    assert (
+        stats_by_id[operation_id_b].total_results == number_requests_b * number_entities
+    )
+
+
+@requires_sqlite_3_38
+def test_operation_measurement_statistics_no_ids(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Test operation_measurement_statistics with operation_ids=None returns all operations."""
+    from orchestrator.core.operation.stats import OperationMeasurementStatistics
+
+    operation_id_a = random_identifier()
+    operation_id_b = random_identifier()
+
+    number_entities = 3
+    number_requests = 3
+    measurements_per_result = 2
+
+    sample_store, _requests_a, _ids_a = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_a,
+    )
+    _sample_store, _requests_b, _ids_b = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_b,
+    )
+
+    result = sample_store.operation_measurement_statistics(operation_ids=None)
+
+    returned_ids = {s.operation_id for s in result}
+    assert operation_id_a in returned_ids
+    assert operation_id_b in returned_ids
+
+    for stats in result:
+        assert isinstance(stats, OperationMeasurementStatistics)
+        assert stats.total_requests == number_requests
+        assert stats.total_results == number_requests * number_entities
+
+
+@requires_sqlite_3_38
+def test_operation_measurement_statistics_empty_set(
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Test that operation_measurement_statistics raises ValueError for an empty set."""
+    import pytest
+
+    sample_store, _requests, _ids = simulate_ml_multi_cloud_random_walk_operation()
+
+    with pytest.raises(
+        ValueError, match="operation_ids must be a non-empty set or None"
+    ):
+        sample_store.operation_measurement_statistics(operation_ids=set())


### PR DESCRIPTION
## Summary

Closes #1067

### `operation_measurement_statistics` now supports multiple operations at once

Previously, `operation_measurement_statistics` accepted a single `operation_id: str` and returned one `OperationMeasurementStatistics` object. This PR generalises the API so callers can request stats for **many operations in one call**, or for **all operations in the store** at once.

### What changed

- **`OperationMeasurementStatistics`** — added an `operation_id` field so each stats object knows which operation it belongs to.
- **`ActiveSampleStore.operation_measurement_statistics`** — signature changed from `(operation_id: str) -> OperationMeasurementStatistics` to `(operation_ids: set[str] | None = None) -> list[OperationMeasurementStatistics]`. Passing `None` returns stats for every operation in the store; passing an empty set raises `ValueError`.
- **`SQLSampleStore`** — the underlying SQL query now uses `GROUP BY operation_id` (plus an optional `WHERE … IN (…)`) instead of a single `WHERE operation_id = ?`, computing all rows in one round-trip.
- **Python fallback** (`DiscoverySpace`) — updated to iterate over the requested (or all) operation IDs and build the same list result.
- **Tests** — expanded to cover the new multi-operation and "all operations" behaviour.