### PR TITLE
feat(cli): add -o stats option to ado get operation

### DIFF
--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -76,9 +76,9 @@ Goal: volume of work, recency, and which spaces attract the most operations.
    ```
 
    Adds `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`, and
-   `MEASURED_ENTITIES` columns. Use `--output-file` or `--no-trunc` to avoid
-   terminal truncation. For explore operations, compare `MEASURED_ENTITIES`
-   against the operator's `numberEntities` to check sampling completeness.
+   `MEASURED_ENTITIES` columns. For explore operations, compare
+   `MEASURED_ENTITIES` against the operator's `numberEntities` to check sampling
+   completeness.
 
 **Synthesis:** cluster mentally (or in notes) by **creation time** to see bursts
 of activity; count operations **per space** from the operations listing to see
@@ -183,9 +183,9 @@ Write a concise markdown report
      report, there has been new activity — proceed to write a new report.
   3. If not, ask the user whether they want to replace it.
   4. If finer-grained confirmation is needed, fetch the YAML of the most recent
-     space or operation (`uv run ado get space SPACE_ID -o yaml --output-file
-     SPACE_ID.yaml`, or the same pattern for `operation`) and read its
-     `creationTimestamp` field.
+     space or operation
+     (`uv run ado get space SPACE_ID -o yaml --output-file SPACE_ID.yaml`, or
+     the same pattern for `operation`) and read its `creationTimestamp` field.
 
 ### Project summary
 
@@ -207,10 +207,9 @@ Write a concise markdown report
 
 - Operator mix and whether **parameters** or **operator choice** evolve over
   time.
-- Which operations **submitted** the most entities (from operation YAML/config).
+- Which operations **submitted** the most entities (from operation YAML/config)
+  and which produced the most results (from the stats).
 - What **analysis**-style operations ran (infer from operator names and
   parameters).
-- **Measurement outcomes**: run `ado get operations -o stats --output-file
-  operations-stats.txt` to see result counts and measured-entity totals per
-  operation (`TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
-  `MEASURED_ENTITIES`).
+- Make a note of operations with failed measurements and highlight ones with
+  abnormal failure rates (from the stats).

--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -69,6 +69,17 @@ Goal: volume of work, recency, and which spaces attract the most operations.
    together with `uv run ado get operator --details` to understand more about
    the operators used.
 
+3. **Operations (with measurement statistics)**
+
+   ```bash
+   uv run ado get operations -o stats --output-file operations-stats.txt
+   ```
+
+   Adds `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`, and
+   `MEASURED_ENTITIES` columns. Use `--output-file` or `--no-trunc` to avoid
+   terminal truncation. For explore operations, compare `MEASURED_ENTITIES`
+   against the operator's `numberEntities` to check sampling completeness.
+
 **Synthesis:** cluster mentally (or in notes) by **creation time** to see bursts
 of activity; count operations **per space** from the operations listing to see
 which spaces are busiest.
@@ -199,3 +210,7 @@ Write a concise markdown report
 - Which operations **submitted** the most entities (from operation YAML/config).
 - What **analysis**-style operations ran (infer from operator names and
   parameters).
+- **Measurement outcomes**: run `ado get operations -o stats --output-file
+  operations-stats.txt` to see result counts and measured-entity totals per
+  operation (`TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
+  `MEASURED_ENTITIES`).

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -88,12 +88,11 @@ full measurement data. Only supported for operations.
 
 ```bash
 uv run ado get operations -o stats --output-file operations-stats.txt
-uv run ado get operation OPERATION_ID -o stats
+uv run ado get operation OPERATION_ID -o stats --no-trunc
 ```
 
-Use `--output-file` or `--no-trunc` to avoid terminal truncation. Extra columns:
-`TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`, `MEASURED_ENTITIES`
-(distinct entities with at least one result).
+Extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
+`MEASURED_ENTITIES` (distinct entities with at least one result).
 
 ### Filtering Resources
 

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -81,6 +81,20 @@ type.
 `samplestores` (`store`), `datacontainers` (`dcr`), `actuatorconfigurations`
 (`ac`)
 
+### Operation Measurement Statistics
+
+`-o stats` adds result-count columns to the operations table without fetching
+full measurement data. Only supported for operations.
+
+```bash
+uv run ado get operations -o stats --output-file operations-stats.txt
+uv run ado get operation OPERATION_ID -o stats
+```
+
+Use `--output-file` or `--no-trunc` to avoid terminal truncation. Extra columns:
+`TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`, `MEASURED_ENTITIES`
+(distinct entities with at least one result).
+
 ### Filtering Resources
 
 Filter resources based on metadata fields using MySQL JSON Path queries:

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -118,9 +118,14 @@ uv run ado get space --use-latest -o yaml
 # Get the latest operation as YAML
 uv run ado get operation --use-latest -o yaml
 
-# Get measurement statistics for all operations (stats format, operations only)
-uv run ado get operations -o stats
+# Get measurement statistics for all operations (operations only)
+uv run ado get operations -o stats --output-file operations-stats.txt
+uv run ado get operation OPERATION_ID -o stats
 ```
+
+`-o stats` extends the table with `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
+`FAILED_RESULTS`, and `MEASURED_ENTITIES`. Use `--output-file` or `--no-trunc`
+to avoid terminal truncation of the wider table.
 
 ### ado create
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -37,7 +37,7 @@ uv run ado [COMMAND] [SUBCOMMAND1] [SUBCOMMAND2] --help
 For `ado get` and `ado show` subcommands:
 
 - `-o` / `--output` selects the **output format** (for example `yaml`, `table`,
-  `csv`, or `json`; allowed values depend on the command — use `--help`).
+  `csv`, `json`, or `stats`; allowed values depend on the command — use `--help`).
 - `--output-file PATH` writes formatted output to **PATH** instead of stdout.
 
 Shell redirects (`>`) work for simple cases. Prefer `--output-file` when:
@@ -103,7 +103,7 @@ needed beyond a local Ray instance (started automatically).
 Lists resources of a given type and gets resource YAML
 
 ```bash
-#List all spaces
+# List all spaces
 uv run ado get spaces
 
 # Get the YAML for a space (console)
@@ -117,6 +117,9 @@ uv run ado get space --use-latest -o yaml
 
 # Get the latest operation as YAML
 uv run ado get operation --use-latest -o yaml
+
+# Get measurement statistics for all operations (stats format, operations only)
+uv run ado get operations -o stats
 ```
 
 ### ado create

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -37,7 +37,8 @@ uv run ado [COMMAND] [SUBCOMMAND1] [SUBCOMMAND2] --help
 For `ado get` and `ado show` subcommands:
 
 - `-o` / `--output` selects the **output format** (for example `yaml`, `table`,
-  `csv`, `json`, or `stats`; allowed values depend on the command — use `--help`).
+  `csv`, `json`, or `stats`; allowed values depend on the command — use
+  `--help`).
 - `--output-file PATH` writes formatted output to **PATH** instead of stdout.
 
 Shell redirects (`>`) work for simple cases. Prefer `--output-file` when:
@@ -120,12 +121,11 @@ uv run ado get operation --use-latest -o yaml
 
 # Get measurement statistics for all operations (operations only)
 uv run ado get operations -o stats --output-file operations-stats.txt
-uv run ado get operation OPERATION_ID -o stats
+uv run ado get operation OPERATION_ID -o stats --no-trunc
 ```
 
 `-o stats` extends the table with `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-`FAILED_RESULTS`, and `MEASURED_ENTITIES`. Use `--output-file` or `--no-trunc`
-to avoid terminal truncation of the wider table.
+`FAILED_RESULTS`, and `MEASURED_ENTITIES`.
 
 ### ado create
 

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -130,7 +130,7 @@ def get_resource(
             "--output",
             "-o",
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
-            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). Not all formats may be supported by all resources.",
+            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with measurement statistics columns (operations only). Not all formats may be supported by all resources.",
         ),
     ] = AdoGetSupportedOutputFormats.TABLE.value,
     exclude_default: Annotated[

--- a/orchestrator/cli/models/types.py
+++ b/orchestrator/cli/models/types.py
@@ -26,6 +26,7 @@ _MARKDOWN_REPORT = "md-report"
 _MARKDOWN_TABLE = "md-table"
 _NAME = "name"
 _RAW = "raw"
+_STATS = "stats"
 _TABLE = "table"
 _YAML = "yaml"
 
@@ -95,6 +96,7 @@ class AdoGetSupportedOutputFormats(Enum):
     JSON = _JSON
     NAME = _NAME
     RAW = _RAW
+    STATS = _STATS
     TABLE = _TABLE
     YAML = _YAML
 

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -48,8 +48,10 @@ from orchestrator.utilities.pandas import reorder_dataframe_columns
 
 if typing.TYPE_CHECKING:
     import pandas as pd
+    from rich.status import Status
 
     from orchestrator.cli.models.parameters import AdoGetCommandParameters
+    from orchestrator.metastore.sqlstore import SQLStore
 
 
 def format_default_ado_get_single_resource(
@@ -155,6 +157,97 @@ def format_default_ado_get_multiple_resources(
         )
 
     return resources[columns]
+
+
+def format_ado_get_stats_for_operations(
+    df: "pd.DataFrame",
+    sql_store: "SQLStore",
+    spinner: "Status | None" = None,
+) -> "pd.DataFrame":
+    """Append 4 measurement-statistics columns to an operations DataFrame.
+
+    Issues two queries regardless of the number of operations:
+    one recursive-CTE query to resolve operation→samplestore relationships,
+    then one aggregation query per distinct samplestore (grouped by
+    operation_id) to fetch all stats in bulk.
+
+    Args:
+        df: DataFrame with at least an ``IDENTIFIER`` column (one row per
+            operation).
+        sql_store: The ``SQLStore`` to use for relationship and samplestore
+            queries.
+        spinner: Optional rich status spinner to update with progress messages.
+
+    Returns:
+        The same DataFrame with four extra columns appended:
+        ``TOTAL_RESULTS``, ``SUCCESSFUL_RESULTS``, ``FAILED_RESULTS``,
+        ``MEASURED_ENTITIES``. Operations with no recorded measurements show
+        ``0`` in all stats columns.
+    """
+
+    from orchestrator.core.resources import CoreResourceKinds
+    from orchestrator.core.samplestore.base import SampleStore
+
+    _STATS_COLUMNS = [
+        "TOTAL_RESULTS",
+        "SUCCESSFUL_RESULTS",
+        "FAILED_RESULTS",
+        "MEASURED_ENTITIES",
+    ]
+
+    operation_ids: set[str] = set(df["IDENTIFIER"])
+
+    # Round-trip 2: one recursive-CTE query for all operations at once.
+    # Returns {operation_id: {CoreResourceKinds.SAMPLESTORE: {samplestore_id, ...}, ...}}
+    relationships: dict[str, dict[CoreResourceKinds, set[str]]] = (
+        sql_store.get_resources_by_relationship(
+            kind=CoreResourceKinds.OPERATION,
+            identifier=operation_ids,
+            hierarchy_direction="up",
+            max_hops=2,
+            identifiers_only=True,
+        )
+    )
+
+    # Invert to {samplestore_id: set_of_operation_ids}
+    samplestore_to_operation_ids: dict[str, set[str]] = {}
+    for operation_id, kind_map in relationships.items():
+        samplestore_ids = kind_map.get(CoreResourceKinds.SAMPLESTORE, set())
+        for samplestore_id in samplestore_ids:
+            samplestore_to_operation_ids.setdefault(samplestore_id, set()).add(
+                operation_id
+            )
+
+    # Round-trips 3…K+2: one load + one batched stats query per unique samplestore.
+    stats_lookup: dict[str, dict[str, int]] = {}
+    total_samplestores = len(samplestore_to_operation_ids)
+    for index, (
+        samplestore_id,
+        operation_ids_in_store,
+    ) in enumerate(samplestore_to_operation_ids.items(), start=1):
+        if spinner is not None:
+            spinner.update(
+                f"Handling samplestore {index}/{total_samplestores}: {samplestore_id}"
+            )
+        sample_store = SampleStore.from_identifier(samplestore_id, sql_store)
+        for stat in sample_store.operation_measurement_statistics(
+            operation_ids=operation_ids_in_store
+        ):
+            stats_lookup[stat.operation_id] = {
+                "TOTAL_RESULTS": stat.total_results,
+                "SUCCESSFUL_RESULTS": stat.successful_results,
+                "FAILED_RESULTS": stat.failed_results,
+                "MEASURED_ENTITIES": stat.measured_entities,
+            }
+
+    # Attach stats columns; operations with no samplestore mapping show 0.
+    zeros = dict.fromkeys(_STATS_COLUMNS, 0)
+    for col in _STATS_COLUMNS:
+        df[col] = df["IDENTIFIER"].apply(
+            lambda operation_id, c=col: stats_lookup.get(operation_id, zeros)[c]
+        )
+
+    return df
 
 
 def format_resource_for_ado_get_custom_format(

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -31,6 +31,7 @@ from orchestrator.cli.utils.output.prints import (
     cyan,
 )
 from orchestrator.cli.utils.resources.formatters import (
+    format_ado_get_stats_for_operations,
     format_default_ado_get_multiple_resources,
     format_default_ado_get_single_resource,
     format_resource_for_ado_get_custom_format,
@@ -53,6 +54,102 @@ if typing.TYPE_CHECKING:
     from orchestrator.core import ADOResource, CoreResourceKinds
     from orchestrator.metastore.project import ProjectContext
     from orchestrator.metastore.sqlstore import SQLStore
+
+
+def _render_dataframe_table_output(
+    df: "pd.DataFrame", parameters: "AdoGetCommandParameters"
+) -> None:
+    """Render a DataFrame as a rich table or print the empty-data message."""
+    import rich.box
+
+    if df.empty:
+        console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
+        return
+
+    if parameters.output_file:
+        do_not_truncate = True
+    else:
+        do_not_truncate = (
+            ["IDENTIFIER"] if not parameters.no_trunc else parameters.no_trunc
+        )
+
+    table = dataframe_to_rich_table(
+        df,
+        box=rich.box.SQUARE,
+        show_index=True,
+        show_edge=True,
+        do_not_truncate_columns=do_not_truncate,
+    )
+    _write_or_print_output(table, parameters.output_file)
+
+
+def _build_table_output_dataframe(
+    parameters: "AdoGetCommandParameters",
+    resource_type: "CoreResourceKinds | None",
+    dataframe: "pd.DataFrame | None",
+    resources: "list[ADOResource] | ADOResource | None",
+) -> "pd.DataFrame":
+    """Build the DataFrame used by table-like get output formats."""
+    import pandas as pd
+
+    if dataframe is not None:
+        return dataframe
+
+    if resources is not None:
+        if isinstance(resources, list):
+            if not resources:
+                return pd.DataFrame()
+            return pd.concat(
+                [
+                    format_default_ado_get_single_resource(
+                        resource=resource, show_details=parameters.show_details
+                    )
+                    for resource in resources
+                ],
+                ignore_index=True,
+            )
+
+        return format_default_ado_get_single_resource(
+            resource=resources, show_details=parameters.show_details
+        )
+
+    if resource_type is None:
+        console_print(
+            f"{ERROR}resource_type must be provided when dataframe and resources are None",
+            stderr=True,
+        )
+        raise typer.Exit(1)
+
+    sql_store = get_sql_store(
+        project_context=parameters.ado_configuration.project_context
+    )
+    with Status(ADO_SPINNER_QUERYING_DB) as status:
+        if not parameters.resource_id:
+            resources_df = sql_store.getResourceIdentifiersOfKind(
+                kind=resource_type.value,
+                field_selectors=parameters.field_selectors,
+                details=parameters.show_details,
+            )
+
+            status.update(ADO_SPINNER_GETTING_OUTPUT_READY)
+            return format_default_ado_get_multiple_resources(
+                resources=resources_df,
+                resource_kind=resource_type,
+            )
+
+        resource = sql_store.getResource(
+            identifier=parameters.resource_id, kind=resource_type
+        )
+
+        if not resource:
+            status.stop()
+            raise ResourceDoesNotExistError(
+                resource_id=parameters.resource_id, kind=resource_type
+            )
+
+        return format_default_ado_get_single_resource(
+            resource=resource, show_details=parameters.show_details
+        )
 
 
 def handle_ado_get(
@@ -82,6 +179,8 @@ def handle_ado_get(
             _handle_name_format(parameters, resource_type, dataframe, resources)
         case AdoGetSupportedOutputFormats.TABLE:
             _handle_table_format(parameters, resource_type, dataframe, resources)
+        case AdoGetSupportedOutputFormats.STATS:
+            _handle_stats_format(parameters, resource_type, dataframe, resources)
         case AdoGetSupportedOutputFormats.RAW:
             _handle_raw_format(parameters, resource_type)
         case (
@@ -190,104 +289,58 @@ def _handle_table_format(
     resources: "list[ADOResource] | ADOResource | None",
 ) -> None:
     """Handle TABLE output format - render DataFrame as table."""
-    import pandas as pd
-    import rich.box
+    output_df = _build_table_output_dataframe(
+        parameters=parameters,
+        resource_type=resource_type,
+        dataframe=dataframe,
+        resources=resources,
+    )
+    return _render_dataframe_table_output(output_df, parameters)
 
-    def _handle_df_output_for_table_format(df: "pd.DataFrame") -> None:
-        if df.empty:
-            console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
-            return
 
-        # When writing to file, avoid truncating columns by default
-        if parameters.output_file:
-            do_not_truncate = True
-        else:
-            do_not_truncate = (
-                ["IDENTIFIER"] if not parameters.no_trunc else parameters.no_trunc
-            )
+def _handle_stats_format(
+    parameters: "AdoGetCommandParameters",
+    resource_type: "CoreResourceKinds | None",
+    dataframe: "pd.DataFrame | None",
+    resources: "list[ADOResource] | ADOResource | None",
+) -> None:
+    """Handle STATS output format - TABLE columns plus 7 measurement stats columns.
 
-        table = dataframe_to_rich_table(
-            df,
-            box=rich.box.SQUARE,
-            show_index=True,
-            show_edge=True,
-            do_not_truncate_columns=do_not_truncate,
-        )
-        _write_or_print_output(table, parameters.output_file)
-        return
+    Only supported for operations.  For any other resource type the handler
+    prints an error message and exits with code 1.
+    """
+    from orchestrator.core import CoreResourceKinds
 
-    # If dataframe provided, use it directly
-    if dataframe is not None:
-        return _handle_df_output_for_table_format(dataframe)
-
-    # If resources provided, convert to DataFrame
-    if resources is not None:
-        if isinstance(resources, list):
-            # Multiple resources: build DataFrame manually
-            if not resources:
-                console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
-                return None
-            # Build DataFrame from resources
-            output_df = pd.concat(
-                [
-                    format_default_ado_get_single_resource(
-                        resource=resource, show_details=parameters.show_details
-                    )
-                    for resource in resources
-                ],
-                ignore_index=True,
-            )
-        else:
-            # Single resource
-            output_df = format_default_ado_get_single_resource(
-                resource=resources, show_details=parameters.show_details
-            )
-
-        return _handle_df_output_for_table_format(output_df)
-
-    # Otherwise use DB query
-    if resource_type is None:
+    if resource_type is not None and resource_type != CoreResourceKinds.OPERATION:
         console_print(
-            f"{ERROR}resource_type must be provided when dataframe and resources are None",
+            f"{ERROR}The 'stats' output format is only supported for operations.",
             stderr=True,
         )
         raise typer.Exit(1)
 
-    sql_store = get_sql_store(
+    base_df = _build_table_output_dataframe(
+        parameters=parameters,
+        resource_type=resource_type,
+        dataframe=dataframe,
+        resources=resources,
+    )
+
+    if base_df.empty:
+        _render_dataframe_table_output(base_df, parameters)
+        return
+
+    # Append stats columns.
+    sql_store_for_stats = get_sql_store(
         project_context=parameters.ado_configuration.project_context
     )
-    with Status(ADO_SPINNER_QUERYING_DB) as status:
-        if not parameters.resource_id:
-            # Multiple resources
-            resources_df = sql_store.getResourceIdentifiersOfKind(
-                kind=resource_type.value,
-                field_selectors=parameters.field_selectors,
-                details=parameters.show_details,
-            )
+    with Status(ADO_SPINNER_GETTING_OUTPUT_READY) as status:
+        enriched_df = format_ado_get_stats_for_operations(
+            base_df,
+            sql_store_for_stats,
+            spinner=status,
+        )
 
-            status.update(ADO_SPINNER_GETTING_OUTPUT_READY)
-            output_df = format_default_ado_get_multiple_resources(
-                resources=resources_df,
-                resource_kind=resource_type,
-            )
-
-        else:
-            # Single resource
-            resource = sql_store.getResource(
-                identifier=parameters.resource_id, kind=resource_type
-            )
-
-            if not resource:
-                status.stop()
-                raise ResourceDoesNotExistError(
-                    resource_id=parameters.resource_id, kind=resource_type
-                )
-
-            output_df = format_default_ado_get_single_resource(
-                resource=resource, show_details=parameters.show_details
-            )
-
-    return _handle_df_output_for_table_format(output_df)
+    _render_dataframe_table_output(enriched_df, parameters)
 
 
 def _handle_raw_format(

--- a/tests/ado/get/test_ado_get_stats.py
+++ b/tests/ado/get/test_ado_get_stats.py
@@ -1,0 +1,198 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+import os
+import pathlib
+from collections.abc import Callable
+
+import pytest
+from testcontainers.mysql import MySqlContainer
+from typer.testing import CliRunner
+
+from orchestrator.cli.core.cli import app as ado
+from orchestrator.core.samplestore.sql import SQLSampleStore
+from orchestrator.metastore.project import ProjectContext
+from orchestrator.metastore.sqlstore import SQLStore
+from orchestrator.schema.request import MeasurementRequest
+from tests.conftest import requires_sqlite_3_38
+
+
+@requires_sqlite_3_38
+def test_ado_get_operations_stats_columns_present(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """ado get operations -o stats exits 0 and shows result stats column headers."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create one operation with known measurements.
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=3,
+        measurements_per_result=1,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operations",
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        for col in [
+            "TOTAL_RESULTS",
+            "SUCCESSFUL_RESULTS",
+            "FAILED_RESULTS",
+            "MEASURED_ENTITIES",
+        ]:
+            assert col in result.output, f"Column {col!r} missing from output"
+
+
+@requires_sqlite_3_38
+def test_ado_get_operations_stats_values(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Stats values for a known operation match expected counts."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_entities = 3
+    number_requests = 4
+    operation_id = "op-stats-test-abc123"
+
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operation",
+            operation_id,
+            "-o",
+            "stats",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        # TOTAL_RESULTS == number_requests * number_entities
+        assert str(number_requests * number_entities) in result.output
+
+
+@requires_sqlite_3_38
+def test_ado_get_operation_stats_single_resource(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """ado get operation <id> -o stats exits 0 and shows result stats columns."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    operation_id = "op-stats-single-xyz789"
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=2,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operation",
+            operation_id,
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        assert operation_id in result.output
+        assert "TOTAL_RESULTS" in result.output
+
+
+@requires_sqlite_3_38
+@pytest.mark.parametrize("resource_kind", ["spaces", "samplestores"])
+def test_ado_get_stats_unsupported_resource_type_exits_1(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    resource_kind: str,
+) -> None:
+    """ado get <non-operation> -o stats exits 1 with an error message."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            resource_kind,
+            "-o",
+            "stats",
+        ],
+    )
+
+    assert result.exit_code == 1
+    if os.environ.get("CI", "false") != "true":
+        assert "stats" in result.output.lower()
+        assert "operation" in result.output.lower()

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -475,7 +475,7 @@ The complete syntax of the `ado get` command is as follows:
 <!-- markdownlint-disable line-length -->
 
 ```shell
-ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <default | yaml | json | config | raw>] \
+ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <default | yaml | json | config | raw | stats>] \
                                     [--output-file <path>] \
                                     [--use-latest] \
                                     [--exclude-default | --no-exclude-default] \
@@ -531,6 +531,10 @@ Where:
     - The `config` format displays the `config` field of the matching resources.
     - The `raw` format displays the raw resource as stored in the database,
       performing no validation.
+    - The `stats` format augments the default `table` output with four additional
+      measurement statistics columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
+      `FAILED_RESULTS`, and `MEASURED_ENTITIES`. This format is **only supported
+      for operations**.
 
     <!-- prettier-ignore-end -->
 
@@ -719,6 +723,18 @@ ado get spaces -o name --output-file space-ids.txt
 
 ```shell
 ado get spaces --output-file spaces-table.txt
+```
+
+##### Getting measurement statistics for all Operations
+
+```shell
+ado get operations -o stats
+```
+
+##### Getting measurement statistics for a single Operation
+
+```shell
+ado get operation randomwalk-0.5.0-123abc -o stats
 ```
 
 ### ado show


### PR DESCRIPTION
## Add `stats` output format to `ado get operation`

Adds a new `-o stats` flag to the `ado get operation` command that extends the
default table with four measurement-statistics columns:

| Column | Description |
|---|---|
| `TOTAL_RESULTS` | Total experiment results recorded |
| `SUCCESSFUL_RESULTS` | Results that completed without error |
| `FAILED_RESULTS` | Results that errored |
| `MEASURED_ENTITIES` | Distinct entities measured |

Closes #1070 

### What changed

- **`types.py`** — new `STATS` variant added to `AdoGetSupportedOutputFormats`
- **`get.py`** — help text updated to document the new format
- **`formatters.py`** — new `format_ado_get_stats_for_operations()` function that
  bulk-resolves samplestore relationships (one CTE query for all operations, then
  one aggregation query per samplestore) and appends the stats columns
- **`handlers.py`** — new `_handle_stats_format()` handler wired into the dispatch
  switch; table-building logic refactored into two reusable helpers
  (`_build_table_output_dataframe`, `_render_dataframe_table_output`) shared by
  both `TABLE` and `STATS` formats
- **`tests/ado/get/test_ado_get_stats.py`** — new test file covering the stats path
- **`website/docs/`** & **`.cursor/skills/using-ado-cli/SKILL.md`** — docs updated
  with usage example

### Usage

```sh
ado get operation -o stats
ado get operation <id> -o stats
```

### Sample output

```terminaloutput
(ado-core) alessandropomponio@MacBook-Pro-di-Alessandro ~/D/G/p/ado (ap_1070_ado_get_operation_stats)> ado get op random_walk-1.8.1.dev64+g245aadd0.d20260607162824.dirty-9972c3 -o stats --no-trunc
┌───────┬────────────────────────────────────────────────────────────────┬────────────────────────────────────────┬─────────────────────┬──────────┬────────────┬───────┬───────────────┬────────────────────┬────────────────┬───────────────────┐
│ INDEX │ IDENTIFIER                                                     │ NAME                                   │ SPACE               │ STATUS   │ EXIT_STATE │ AGE   │ TOTAL_RESULTS │ SUCCESSFUL_RESULTS │ FAILED_RESULTS │ MEASURED_ENTITIES │
├───────┼────────────────────────────────────────────────────────────────┼────────────────────────────────────────┼─────────────────────┼──────────┼────────────┼───────┼───────────────┼────────────────────┼────────────────┼───────────────────┤
│ 0     │ random_walk-1.8.1.dev64+g245aadd0.d20260607162824.dirty-9972c3 │ baseline_atlanta-ip_space-6b61d5_3600s │ space-6b61d5-b45edb │ finished │ success    │ 23h1m │ 1             │ 1                  │ 0              │ 1                 │
└───────┴────────────────────────────────────────────────────────────────┴────────────────────────────────────────┴─────────────────────┴──────────┴────────────┴───────┴───────────────┴────────────────────┴────────────────┴───────────────────┘
```