### PR TITLE
feat(core): calculate statistics for spaces

### DIFF
--- a/orchestrator/cli/models/space.py
+++ b/orchestrator/cli/models/space.py
@@ -11,7 +11,6 @@ import orchestrator.schema.property
 from orchestrator.cli.utils.output.prints import console_print
 from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.core.resources import CoreResourceKinds
-from orchestrator.schema.entityspace import EntitySpaceRepresentation
 
 if typing.TYPE_CHECKING:
     import pandas as pd
@@ -54,10 +53,15 @@ class SpaceDetails:
 
     @classmethod
     def from_space(cls, space: DiscoverySpace) -> "SpaceDetails":
-
         import pandas as pd
 
-        # Entities sampled in the space
+        # Delegate most fields to space_statistics(lightweight_only=False).
+        # The two "all/partial measurements" fields are not tracked in
+        # DiscoverySpaceStatistics, so we keep a targeted pandas iteration for
+        # those only.
+        stats = space.space_statistics(lightweight_only=False)
+
+        # Entities sampled in the space — needed only to compute all/partial split
         measured_entities_table = space.measuredEntitiesTable(property_type="target")
         if (
             measured_entities_table.empty
@@ -65,38 +69,18 @@ class SpaceDetails:
         ):
             measured_entities_table["identifier"] = pd.Series(dtype="str")
 
-        # Entities sampled from space with all measurements applied
         experiments_in_measurement_space = len(space.measurementSpace.experiments)
         entities_sampled_from_space_with_all_measurements_applied = 0
         for _, group in measured_entities_table.groupby("identifier"):
             if group.shape[0] == experiments_in_measurement_space:
                 entities_sampled_from_space_with_all_measurements_applied += 1
 
-        # Entities sampled from space with partial measurements applied
         entities_sampled_from_space_with_partial_measurements_applied = (
             len(measured_entities_table["identifier"].unique())
             - entities_sampled_from_space_with_all_measurements_applied
         )
 
-        # Unmeasured entities
-        if space.entitySpace is None or not isinstance(
-            space.entitySpace,
-            EntitySpaceRepresentation,
-        ):
-            entities_yet_to_be_sampled_and_measured_from_space = math.nan
-        elif not space.entitySpace.isDiscreteSpace:
-            entities_yet_to_be_sampled_and_measured_from_space = math.inf
-        else:
-            entities_yet_to_be_sampled_and_measured_from_space = (
-                space.entitySpace.size
-                - entities_sampled_from_space_with_partial_measurements_applied
-                - entities_sampled_from_space_with_all_measurements_applied
-            )
-
-        # Entities matching the space
-        entities_matching_the_space = len(space.matchingEntities())
-
-        # Matching entities in the sample store with measurement space applied
+        # Matching entities with measurement space applied — targeted pandas iteration
         matching_entities_table = space.matchingEntitiesTable(property_type="target")
         if (
             matching_entities_table.empty
@@ -109,24 +93,13 @@ class SpaceDetails:
             if group.shape[0] == experiments_in_measurement_space:
                 matching_entities_in_sample_store_with_measurement_space_applied += 1
 
-        # Size of the entity space
-        size_of_entity_space = None
-        if (
-            isinstance(
-                space.entitySpace,
-                EntitySpaceRepresentation,
-            )
-            and space.entitySpace.isDiscreteSpace
-        ):
-            size_of_entity_space = space.entitySpace.size
-
         return cls(
             entities_sampled_from_space_with_all_measurements_applied=entities_sampled_from_space_with_all_measurements_applied,
             entities_sampled_from_space_with_partial_measurements_applied=entities_sampled_from_space_with_partial_measurements_applied,
-            entities_yet_to_be_sampled_and_measured_from_space=entities_yet_to_be_sampled_and_measured_from_space,
-            entities_matching_the_space=entities_matching_the_space,
+            entities_yet_to_be_sampled_and_measured_from_space=stats.number_unmeasured_entities,
+            entities_matching_the_space=stats.number_matching_entities,
             matching_entities_in_sample_store_with_measurement_space_applied=matching_entities_in_sample_store_with_measurement_space_applied,
-            size_of_entity_space=size_of_entity_space,
+            size_of_entity_space=stats.size_of_entity_space,
         )
 
     def to_rich_table(self) -> rich.table.Table:

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -1207,3 +1207,25 @@ class DiscoverySpace:
             )
 
         return result_list
+
+    def space_statistics(
+        self, lightweight_only: bool = False
+    ) -> "orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics":
+        """Compute statistics for this discovery space.
+
+        Delegates to
+        :func:`~orchestrator.core.discoveryspace.stats.space_statistics_for_spaces`
+        for a single space.
+
+        Args:
+            lightweight_only: When ``True`` skip all Python-side computation
+                and return ``None`` for the heavy fields.
+
+        Returns:
+            :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`
+        """
+        from orchestrator.core.discoveryspace.stats import space_statistics_for_spaces
+
+        return space_statistics_for_spaces([self], lightweight_only=lightweight_only)[
+            self.uri
+        ]

--- a/orchestrator/core/discoveryspace/stats.py
+++ b/orchestrator/core/discoveryspace/stats.py
@@ -1,0 +1,280 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import math
+from typing import TYPE_CHECKING, Annotated
+
+import pydantic
+
+if TYPE_CHECKING:
+    from orchestrator.core.discoveryspace.space import DiscoverySpace
+    from orchestrator.core.samplestore.base import SampleStore
+    from orchestrator.metastore.base import ResourceStore
+
+
+class DiscoverySpaceStatistics(pydantic.BaseModel):
+    """Aggregated statistics for a single discovery space.
+
+    Lightweight fields are always populated.  Heavy fields (those that require
+    Python-side computation) are ``None`` when ``lightweight_only=True`` was
+    requested or when the field is not applicable (e.g. the entity space is
+    continuous or not defined).
+
+    Attributes:
+        number_of_experiments: Number of experiments configured in the space's
+            measurement space.
+        number_of_operations: Total number of operations linked to this space.
+        number_of_explore_operations: Number of operations whose ``operationType``
+            is ``search``.
+        number_measured_entities: DISTINCT entity IDs that appear in at least one
+            measurement result across all operations on this space.
+        size_of_entity_space: Total number of points in the entity space when the
+            space is discrete.  ``None`` if the space is continuous, not defined,
+            or ``lightweight_only=True``.
+        number_unmeasured_entities: ``size_of_entity_space`` minus
+            ``number_measured_entities``.  ``None`` when ``lightweight_only=True``.
+            May be ``math.inf`` for continuous spaces or ``math.nan`` when
+            ``size_of_entity_space`` could not be determined.
+        number_matching_entities: Count of entities in the sample store that
+            satisfy ``isEntityInSpace`` for this space.  ``None`` when
+            ``lightweight_only=True``.
+        number_matching_entities_with_measurements: Subset of
+            ``number_matching_entities`` that have at least one measurement whose
+            experiment reference is in the space's measurement space.  ``None``
+            when ``lightweight_only=True``.
+    """
+
+    # --- Lightweight fields (always populated) ---
+    number_of_experiments: Annotated[
+        int,
+        pydantic.Field(
+            description=(
+                "Number of experiments configured in the space's measurement space."
+            )
+        ),
+    ]
+    number_of_operations: Annotated[
+        int,
+        pydantic.Field(description="Total number of operations linked to this space."),
+    ]
+    number_of_explore_operations: Annotated[
+        int,
+        pydantic.Field(
+            description=("Number of operations whose operationType is 'search'.")
+        ),
+    ]
+    number_measured_entities: Annotated[
+        int,
+        pydantic.Field(
+            description=(
+                "DISTINCT entity IDs that appear in at least one measurement result "
+                "across all operations on this space."
+            )
+        ),
+    ]
+
+    # --- Heavy fields (None when lightweight_only=True or not applicable) ---
+    size_of_entity_space: Annotated[
+        int | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Total number of points in the entity space when discrete. "
+                "None if the space is continuous, not defined, or lightweight_only=True."
+            ),
+        ),
+    ]
+    number_unmeasured_entities: Annotated[
+        int | float | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "size_of_entity_space minus number_measured_entities. "
+                "None when lightweight_only=True. "
+                "math.inf for continuous spaces; math.nan when size_of_entity_space "
+                "could not be determined."
+            ),
+        ),
+    ]
+    number_matching_entities: Annotated[
+        int | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Count of entities in the sample store satisfying isEntityInSpace. "
+                "None when lightweight_only=True."
+            ),
+        ),
+    ]
+    number_matching_entities_with_measurements: Annotated[
+        int | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Subset of number_matching_entities that have at least one measurement "
+                "whose experiment reference is in the space's measurement space. "
+                "None when lightweight_only=True."
+            ),
+        ),
+    ]
+
+
+def lightweight_space_statistics(
+    space_ids: set[str],
+    space_ids_to_operation_ids: dict[str, set[str]],
+    metastore: "ResourceStore",
+    sample_store: "SampleStore",
+) -> "dict[str, DiscoverySpaceStatistics]":
+    """Compute lightweight statistics for spaces given only their IDs and stores.
+
+    Unlike :func:`space_statistics_for_spaces`, this function does not require
+    :class:`~orchestrator.core.discoveryspace.space.DiscoverySpace` instances —
+    it only needs the space IDs, the operation-ID mapping, and the two stores.
+    Heavy fields (``size_of_entity_space``, ``number_unmeasured_entities``,
+    ``number_matching_entities``, ``number_matching_entities_with_measurements``)
+    are always ``None``.
+
+    Args:
+        space_ids: Set of space URIs to compute statistics for.
+        space_ids_to_operation_ids: Mapping from each space URI to the set of
+            operation IDs that belong to that space.
+        metastore: The :class:`~orchestrator.metastore.base.ResourceStore` to
+            query for operation/experiment counts.
+        sample_store: The :class:`~orchestrator.core.samplestore.base.SampleStore`
+            to query for measured-entity counts.
+
+    Returns:
+        ``dict[space_id, DiscoverySpaceStatistics]`` keyed by space URI.
+    """
+    if not space_ids:
+        return {}
+
+    metastore_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
+        metastore.get_space_metastore_stats(space_ids)
+    )
+    sample_store_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
+        sample_store.space_entity_statistics(
+            space_ids_to_operation_ids=space_ids_to_operation_ids,
+        )
+    )
+
+    return {
+        space_id: DiscoverySpaceStatistics(
+            number_of_experiments=metastore_stats_by_space_id[
+                space_id
+            ].number_of_experiments,
+            number_of_operations=metastore_stats_by_space_id[
+                space_id
+            ].number_of_operations,
+            number_of_explore_operations=metastore_stats_by_space_id[
+                space_id
+            ].number_of_explore_operations,
+            number_measured_entities=sample_store_stats_by_space_id[
+                space_id
+            ].number_measured_entities,
+            size_of_entity_space=None,
+            number_unmeasured_entities=None,
+            number_matching_entities=None,
+            number_matching_entities_with_measurements=None,
+        )
+        for space_id in space_ids
+    }
+
+
+def space_statistics_for_spaces(
+    spaces: "list[DiscoverySpace]",
+    lightweight_only: bool = False,
+) -> "dict[str, DiscoverySpaceStatistics]":
+    """Compute statistics for multiple discovery spaces with minimal DB round-trips.
+
+    Issues a single batched metastore query for all spaces (assumes all spaces
+    share the same metastore), then one sample-store query per space.
+
+    Args:
+        spaces: List of :class:`~orchestrator.core.discoveryspace.space.DiscoverySpace`
+            instances to summarise.
+        lightweight_only: When ``True`` skip all Python-side computation and
+            return ``None`` for the heavy fields in every space's statistics.
+
+    Returns:
+        ``dict[space_id, DiscoverySpaceStatistics]`` keyed by
+        :attr:`~orchestrator.core.discoveryspace.space.DiscoverySpace.uri`.
+    """
+    from orchestrator.schema.entityspace import EntitySpaceRepresentation
+
+    if not spaces:
+        return {}
+
+    space_ids = {s.uri for s in spaces}
+    space_ids_to_operation_ids = {s.uri: set(s.operations) for s in spaces}
+    metastore = spaces[0].metadataStore
+    sample_store = spaces[0].sample_store
+
+    if lightweight_only:
+        return lightweight_space_statistics(
+            space_ids=space_ids,
+            space_ids_to_operation_ids=space_ids_to_operation_ids,
+            metastore=metastore,
+            sample_store=sample_store,
+        )
+
+    # ------------------------------------------------------------------
+    # Heavy path — requires DiscoverySpace instances for Python-side work
+    # ------------------------------------------------------------------
+    metastore_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
+        metastore.get_space_metastore_stats(space_ids)
+    )
+    sample_store_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
+        sample_store.space_entity_statistics(
+            space_ids_to_operation_ids=space_ids_to_operation_ids,
+        )
+    )
+
+    result: dict[str, DiscoverySpaceStatistics] = {}
+
+    for space in spaces:
+        metastore_stats = metastore_stats_by_space_id[space.uri]
+        sample_stats = sample_store_stats_by_space_id[space.uri]
+        number_measured = sample_stats.number_measured_entities
+
+        # Heavy path
+        size_of_entity_space: int | None = None
+        if (
+            space.entitySpace is not None
+            and isinstance(space.entitySpace, EntitySpaceRepresentation)
+            and space.entitySpace.isDiscreteSpace
+        ):
+            size_of_entity_space = space.entitySpace.size
+
+        if space.entitySpace is None or not isinstance(
+            space.entitySpace, EntitySpaceRepresentation
+        ):
+            number_unmeasured: int | float | None = math.nan
+        elif not space.entitySpace.isDiscreteSpace:
+            number_unmeasured = math.inf
+        else:
+            number_unmeasured = size_of_entity_space - number_measured
+
+        matching_entities = space.matchingEntities()
+        number_matching = len(matching_entities)
+
+        measurement_exp_refs = set(space.measurementSpace.experimentReferences)
+        number_matching_with_measurements = sum(
+            1
+            for e in matching_entities
+            if len(e.observedPropertyValues) > 0
+            and not measurement_exp_refs.isdisjoint(set(e.experimentReferences))
+        )
+
+        result[space.uri] = DiscoverySpaceStatistics(
+            number_of_experiments=metastore_stats.number_of_experiments,
+            number_of_operations=metastore_stats.number_of_operations,
+            number_of_explore_operations=metastore_stats.number_of_explore_operations,
+            number_measured_entities=number_measured,
+            size_of_entity_space=size_of_entity_space,
+            number_unmeasured_entities=number_unmeasured,
+            number_matching_entities=number_matching,
+            number_matching_entities_with_measurements=number_matching_with_measurements,
+        )
+
+    return result

--- a/orchestrator/core/discoveryspace/stats.py
+++ b/orchestrator/core/discoveryspace/stats.py
@@ -8,7 +8,7 @@ import pydantic
 
 if TYPE_CHECKING:
     from orchestrator.core.discoveryspace.space import DiscoverySpace
-    from orchestrator.core.samplestore.base import SampleStore
+    from orchestrator.core.samplestore.base import ActiveSampleStore
     from orchestrator.metastore.base import ResourceStore
 
 
@@ -123,7 +123,7 @@ def lightweight_space_statistics(
     space_ids: set[str],
     space_ids_to_operation_ids: dict[str, set[str]],
     metastore: "ResourceStore",
-    sample_store: "SampleStore",
+    sample_store: "ActiveSampleStore",
 ) -> "dict[str, DiscoverySpaceStatistics]":
     """Compute lightweight statistics for spaces given only their IDs and stores.
 
@@ -134,13 +134,18 @@ def lightweight_space_statistics(
     ``number_matching_entities``, ``number_matching_entities_with_measurements``)
     are always ``None``.
 
+    .. note::
+        All ``space_ids`` must belong to the **same** sample store instance that
+        is passed in.  Mixing spaces from different sample stores will produce
+        incorrect results.
+
     Args:
         space_ids: Set of space URIs to compute statistics for.
         space_ids_to_operation_ids: Mapping from each space URI to the set of
             operation IDs that belong to that space.
         metastore: The :class:`~orchestrator.metastore.base.ResourceStore` to
             query for operation/experiment counts.
-        sample_store: The :class:`~orchestrator.core.samplestore.base.SampleStore`
+        sample_store: The :class:`~orchestrator.core.samplestore.base.ActiveSampleStore`
             to query for measured-entity counts.
 
     Returns:
@@ -157,6 +162,13 @@ def lightweight_space_statistics(
             space_ids_to_operation_ids=space_ids_to_operation_ids,
         )
     )
+
+    missing = space_ids - metastore_stats_by_space_id.keys()
+    if missing:
+        raise KeyError(f"Metastore returned no statistics for space(s): {missing}")
+    missing = space_ids - sample_store_stats_by_space_id.keys()
+    if missing:
+        raise KeyError(f"Sample store returned no statistics for space(s): {missing}")
 
     return {
         space_id: DiscoverySpaceStatistics(
@@ -187,12 +199,18 @@ def space_statistics_for_spaces(
 ) -> "dict[str, DiscoverySpaceStatistics]":
     """Compute statistics for multiple discovery spaces with minimal DB round-trips.
 
-    Issues a single batched metastore query for all spaces (assumes all spaces
-    share the same metastore), then one sample-store query per space.
+    Issues a single batched metastore query for all spaces, then one batched
+    sample-store query for all spaces.
+
+    .. note::
+        All spaces in the list **must** share the same sample store instance
+        (i.e. ``spaces[0].sample_store`` is used for every space).  Mixing
+        spaces from different sample stores will produce incorrect results.
+        There is only one metastore, so no constraint applies there.
 
     Args:
         spaces: List of :class:`~orchestrator.core.discoveryspace.space.DiscoverySpace`
-            instances to summarise.
+            instances to summarise.  All spaces must share the same sample store.
         lightweight_only: When ``True`` skip all Python-side computation and
             return ``None`` for the heavy fields in every space's statistics.
 
@@ -210,32 +228,30 @@ def space_statistics_for_spaces(
     metastore = spaces[0].metadataStore
     sample_store = spaces[0].sample_store
 
-    if lightweight_only:
-        return lightweight_space_statistics(
-            space_ids=space_ids,
-            space_ids_to_operation_ids=space_ids_to_operation_ids,
-            metastore=metastore,
-            sample_store=sample_store,
+    if not all(s.sample_store is sample_store for s in spaces):
+        raise ValueError(
+            "All spaces passed to space_statistics_for_spaces must share the same sample store."
         )
 
-    # ------------------------------------------------------------------
-    # Heavy path — requires DiscoverySpace instances for Python-side work
-    # ------------------------------------------------------------------
-    metastore_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
-        metastore.get_space_metastore_stats(space_ids)
+    lightweight_stats = lightweight_space_statistics(
+        space_ids=space_ids,
+        space_ids_to_operation_ids=space_ids_to_operation_ids,
+        metastore=metastore,
+        sample_store=sample_store,
     )
-    sample_store_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
-        sample_store.space_entity_statistics(
-            space_ids_to_operation_ids=space_ids_to_operation_ids,
-        )
-    )
+
+    if lightweight_only:
+        return lightweight_stats
+
+    # ------------------------------------------------------------------
+    # Heavy path — requires DiscoverySpace instances for Python-side work.
+    # ------------------------------------------------------------------
 
     result: dict[str, DiscoverySpaceStatistics] = {}
 
     for space in spaces:
-        metastore_stats = metastore_stats_by_space_id[space.uri]
-        sample_stats = sample_store_stats_by_space_id[space.uri]
-        number_measured = sample_stats.number_measured_entities
+        base = lightweight_stats[space.uri]
+        number_measured = base.number_measured_entities
 
         # Heavy path
         size_of_entity_space: int | None = None
@@ -267,9 +283,9 @@ def space_statistics_for_spaces(
         )
 
         result[space.uri] = DiscoverySpaceStatistics(
-            number_of_experiments=metastore_stats.number_of_experiments,
-            number_of_operations=metastore_stats.number_of_operations,
-            number_of_explore_operations=metastore_stats.number_of_explore_operations,
+            number_of_experiments=base.number_of_experiments,
+            number_of_operations=base.number_of_operations,
+            number_of_explore_operations=base.number_of_explore_operations,
             number_measured_entities=number_measured,
             size_of_entity_space=size_of_entity_space,
             number_unmeasured_entities=number_unmeasured,

--- a/orchestrator/core/samplestore/base.py
+++ b/orchestrator/core/samplestore/base.py
@@ -22,6 +22,7 @@ from orchestrator.schema.property_value import PropertyValue
 from orchestrator.schema.request import MeasurementRequest
 
 if typing.TYPE_CHECKING:
+    from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
     from orchestrator.core.operation.stats import OperationMeasurementStatistics
     from orchestrator.core.samplestore.config import (
         SampleStoreConfiguration,
@@ -517,6 +518,37 @@ class ActiveSampleStore(SampleStore, ABC):
 
         Raises:
             ValueError: If ``operation_ids`` is an empty set.
+        """
+
+    @abc.abstractmethod
+    def space_entity_statistics(
+        self,
+        space_ids_to_operation_ids: dict[str, set[str]],
+    ) -> "dict[str, DiscoverySpaceStatistics]":
+        """Compute entity-level statistics for one or more discovery spaces.
+
+        Issues a single SQL query for all spaces at once, then groups results
+        by space ID in Python.
+
+        The ``number_matching_entities`` and
+        ``number_matching_entities_with_measurements`` fields require
+        Python-side ``isEntityInSpace`` evaluation and are not computed here;
+        they are always returned as ``None``.
+
+        Args:
+            space_ids_to_operation_ids: Mapping of space ID to the set of
+                operation IDs that belong to that space.  Spaces with an empty
+                operation-ID set are returned with ``number_measured_entities``
+                equal to ``0``.  An empty mapping returns an empty dict.
+
+        Returns:
+            A ``dict`` keyed by space ID.  Each value is a
+            :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`
+            with ``number_measured_entities`` populated and all other fields at
+            their defaults (``None``).
+
+        Raises:
+            SystemError: If the underlying SQL query fails.
         """
 
 

--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import InvalidRequestError, SQLAlchemyError
 import orchestrator.core.samplestore.config
 import orchestrator.core.samplestore.csv
 import orchestrator.metastore.sql.statements
+from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
 from orchestrator.core.samplestore.base import (
     ActiveSampleStore,
     FailedToDecodeStoredEntityError,
@@ -1614,6 +1615,126 @@ class SQLSampleStore(ActiveSampleStore):
             msg = f"Unable to get measurement statistics for operation IDs {operation_ids}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
+
+    def space_entity_statistics(
+        self,
+        space_ids_to_operation_ids: dict[str, set[str]],
+    ) -> "dict[str, DiscoverySpaceStatistics]":
+        """Compute entity-level statistics for one or more discovery spaces.
+
+        Issues a single SQL query that fetches all distinct
+        ``(operation_id, entity_id)`` pairs across every operation referenced
+        in *space_ids_to_operation_ids*, then groups the results by space ID
+        in Python.  This approach is portable across all supported backends
+        (SQLite, MySQL, PostgreSQL).
+
+        ``number_matching_entities`` and
+        ``number_matching_entities_with_measurements`` are not computed here
+        (they require Python-side ``isEntityInSpace`` evaluation) and are
+        always ``None`` in the returned models.
+
+        Args:
+            space_ids_to_operation_ids: Mapping of space ID to the set of
+                operation IDs that belong to that space.  Spaces with an empty
+                operation-ID set are returned with ``number_measured_entities``
+                equal to ``0``.  An empty mapping returns an empty dict.
+
+        Returns:
+            A ``dict`` keyed by space ID.  Each value is a
+            :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`
+            with ``number_measured_entities`` populated and all other fields at
+            their defaults (``None``).
+
+        Raises:
+            SystemError: If the underlying SQL query fails.
+        """
+        if not space_ids_to_operation_ids:
+            return {}
+
+        # Separate spaces that have no operations (return 0 immediately) from
+        # those that need a DB query.
+        empty_space_ids = {
+            space_id
+            for space_id, operation_ids in space_ids_to_operation_ids.items()
+            if not operation_ids
+        }
+        spaces_to_query = {
+            space_id: operation_ids
+            for space_id, operation_ids in space_ids_to_operation_ids.items()
+            if operation_ids
+        }
+
+        result: dict[str, DiscoverySpaceStatistics] = {
+            space_id: DiscoverySpaceStatistics(
+                number_of_experiments=0,
+                number_of_operations=0,
+                number_of_explore_operations=0,
+                number_measured_entities=0,
+            )
+            for space_id in empty_space_ids
+        }
+
+        if not spaces_to_query:
+            return result
+
+        # Flat set of all operation IDs across all queried spaces.
+        operation_ids = {
+            operation_id
+            for operation_ids in spaces_to_query.values()
+            for operation_id in operation_ids
+        }
+        # Reverse map: operation_id → space_id (each operation belongs to one space).
+        operation_id_to_space_id: dict[str, str] = {
+            operation_id: space_id
+            for space_id, operation_ids in spaces_to_query.items()
+            for operation_id in operation_ids
+        }
+
+        try:
+            from sqlalchemy import select
+
+            req_table = self._request_table
+            reqres_table = self._request_result_table
+            res_table = self._result_table
+
+            # Fetch all distinct (operation_id, entity_id) pairs in one query.
+            stmt = (
+                select(
+                    req_table.c.operation_id,
+                    res_table.c.entity_id,
+                )
+                .select_from(req_table)
+                .join(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
+                .join(res_table, reqres_table.c.result_uid == res_table.c.uid)
+                .where(req_table.c.operation_id.in_(operation_ids))
+                .distinct()
+            )
+
+            with self.engine.begin() as connectable:
+                rows = connectable.execute(stmt).fetchall()
+
+            # Group distinct entity IDs per space in Python.
+            entity_ids_by_space_id: dict[str, set[str]] = {
+                space_id: set() for space_id in spaces_to_query
+            }
+            for row in rows:
+                space_id = operation_id_to_space_id[row.operation_id]
+                entity_ids_by_space_id[space_id].add(row.entity_id)
+
+            for space_id, entity_ids in entity_ids_by_space_id.items():
+                result[space_id] = DiscoverySpaceStatistics(
+                    number_of_experiments=0,
+                    number_of_operations=0,
+                    number_of_explore_operations=0,
+                    number_measured_entities=len(entity_ids),
+                )
+
+        except SQLAlchemyError as error:
+            msg = f"Unable to get entity statistics for spaces {set(spaces_to_query)}"
+            self.log.critical(f"{msg}. Error: {error}")
+            raise SystemError(f"{msg}. Error: {error}") from error
+
+        return result
 
     def measurement_requests_for_operation(
         self,

--- a/orchestrator/core/samplestore/sql.py
+++ b/orchestrator/core/samplestore/sql.py
@@ -1626,7 +1626,7 @@ class SQLSampleStore(ActiveSampleStore):
         ``(operation_id, entity_id)`` pairs across every operation referenced
         in *space_ids_to_operation_ids*, then groups the results by space ID
         in Python.  This approach is portable across all supported backends
-        (SQLite, MySQL, PostgreSQL).
+        (SQLite, MySQL).
 
         ``number_matching_entities`` and
         ``number_matching_entities_with_measurements`` are not computed here

--- a/orchestrator/metastore/base.py
+++ b/orchestrator/metastore/base.py
@@ -9,6 +9,8 @@ import pydantic
 if TYPE_CHECKING:
     import pandas as pd
 
+    from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
+
 from orchestrator.core.resources import ADOResource, CoreResourceKinds
 from orchestrator.core.samplestore.resource import SampleStoreResource
 from orchestrator.utilities.location import (
@@ -325,6 +327,34 @@ class ResourceStore(abc.ABC):
 
         Raises:
             ValueError: If arguments are invalid or incompatible.
+        """
+
+    @abc.abstractmethod
+    def get_space_metastore_stats(
+        self,
+        space_ids: str | set[str],
+    ) -> "DiscoverySpaceStatistics | dict[str, DiscoverySpaceStatistics]":
+        """Return lightweight metastore-level statistics for one or many spaces.
+
+        All counts are computed with pure SQL against the ``resources`` and
+        ``resource_relationships`` tables — no sample store access is needed.
+        The returned :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`
+        objects only have ``number_of_experiments``, ``number_of_operations``,
+        and ``number_of_explore_operations`` populated; all other fields are
+        ``None`` or ``0`` as appropriate.
+
+        Args:
+            space_ids: A single space identifier (``str``) or a set of space
+                identifiers (``set[str]``).
+
+        Returns:
+            When ``space_ids`` is a ``str``: a
+            :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`
+            for that space.
+            When ``space_ids`` is a ``set[str]``: a ``dict`` keyed by space ID
+            mapping each to its
+            :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`.
+            Space IDs that have no operations are included with zero counts.
         """
 
 

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -13,6 +13,8 @@ import orchestrator.core
 import orchestrator.metastore
 import orchestrator.metastore.sql.statements
 import orchestrator.utilities
+from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
+from orchestrator.core.operation.config import DiscoveryOperationEnum
 from orchestrator.core.resources import ADOResourceEventEnum, CoreResourceKinds
 from orchestrator.metastore.base import (
     DeleteFromDatabaseError,
@@ -1722,3 +1724,102 @@ class SQLResourceStore(ResourceStore):
             return hydrated.get(next(iter(_identifiers_requested)), {})
 
         return hydrated
+
+    # ---------------------------------------------------------------------------
+    # Space statistics
+    # ---------------------------------------------------------------------------
+
+    def get_space_metastore_stats(
+        self,
+        space_ids: str | set[str],
+    ) -> "DiscoverySpaceStatistics | dict[str, DiscoverySpaceStatistics]":
+        """Return lightweight metastore-level statistics for one or many spaces.
+
+        Issues a single SQL query that anchors on each space's ``resources``
+        row and left-joins to ``resource_relationships`` / ``resources`` to
+        count operations.  The experiment count and operation counts are
+        therefore fetched in one round-trip.
+
+        Args:
+            space_ids: A single space identifier (``str``) or a set of space
+                identifiers (``set[str]``).
+
+        Returns:
+            :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`
+            for a single ``str`` input, or a
+            ``dict[str, DiscoverySpaceStatistics]`` for a ``set[str]`` input.
+
+        Raises:
+            SystemError: If the underlying SQL query fails.
+        """
+        single = isinstance(space_ids, str)
+        _space_ids: set[str] = {space_ids} if single else set(space_ids)
+
+        if not _space_ids:
+            return {}  # type: ignore[return-value]
+
+        # ------------------------------------------------------------------
+        # Single query: anchor on the space row so every requested space is
+        # returned even when it has no operations (LEFT JOIN).
+        # The experiment list lives at $.config.experiments.experiments inside
+        # the space's own resources.data column.
+        # MySQL uses JSON_LENGTH(); SQLite uses json_array_length().
+        # ------------------------------------------------------------------
+        is_sqlite = self.engine.dialect.name == "sqlite"
+        array_length_fn = "json_array_length" if is_sqlite else "JSON_LENGTH"
+
+        query_text = f"""
+            SELECT
+                sp.identifier AS space_id,
+                {array_length_fn}(
+                    JSON_EXTRACT(sp.data, '$.config.experiments.experiments')
+                ) AS num_experiments,
+                COUNT(op.identifier) AS total_operations,
+                COUNT(
+                    CASE
+                        WHEN JSON_EXTRACT(op.data, '$.operationType') = :explore_type
+                        THEN 1
+                    END
+                ) AS explore_operations
+            FROM resources sp
+            LEFT JOIN resource_relationships rr
+                ON rr.subject_identifier = sp.identifier
+            LEFT JOIN resources op
+                ON op.identifier = rr.object_identifier
+                AND op.kind = :op_kind
+            WHERE sp.identifier IN :space_ids
+            GROUP BY sp.identifier, sp.data
+        """  # noqa: S608 - identifier is an internal column name, not untrusted input
+
+        try:
+            with self.engine.begin() as conn:
+                query = sqlalchemy.text(query_text).bindparams(
+                    sqlalchemy.bindparam("space_ids", expanding=True),
+                    space_ids=list(_space_ids),
+                    explore_type=DiscoveryOperationEnum.SEARCH.value,
+                    op_kind=CoreResourceKinds.OPERATION.value,
+                )
+
+                rows = {row.space_id: row for row in conn.execute(query)}
+
+        except Exception as error:
+            msg = f"Unable to get statistics for space(s) {space_ids}"
+            self.log.critical(f"{msg}. Error: {error}")
+            raise SystemError(f"{msg}. Error: {error}") from error
+
+        result: dict[str, DiscoverySpaceStatistics] = {
+            sid: DiscoverySpaceStatistics(
+                number_of_experiments=rows[sid].num_experiments if sid in rows else 0,
+                number_of_operations=rows[sid].total_operations if sid in rows else 0,
+                number_of_explore_operations=(
+                    rows[sid].explore_operations if sid in rows else 0
+                ),
+                number_measured_entities=0,
+            )
+            for sid in _space_ids
+        }
+
+        if single:
+            return result[space_ids]  # type: ignore[index,arg-type]
+
+        return result

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1771,9 +1771,9 @@ class SQLResourceStore(ResourceStore):
         query_text = f"""
             SELECT
                 sp.identifier AS space_id,
-                {array_length_fn}(
+                COALESCE({array_length_fn}(
                     JSON_EXTRACT(sp.data, '$.config.experiments.experiments')
-                ) AS num_experiments,
+                ), 0) AS num_experiments,
                 COUNT(op.identifier) AS total_operations,
                 COUNT(
                     CASE

--- a/tests/core/test_space_statistics.py
+++ b/tests/core/test_space_statistics.py
@@ -1,0 +1,176 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import math
+from collections.abc import Callable
+
+from orchestrator.core.discoveryspace.space import DiscoverySpace
+from orchestrator.core.discoveryspace.stats import (
+    DiscoverySpaceStatistics,
+    space_statistics_for_spaces,
+)
+from orchestrator.core.samplestore.sql import SQLSampleStore
+from orchestrator.schema.request import MeasurementRequest
+from tests.conftest import requires_sqlite_3_38
+
+# ---------------------------------------------------------------------------
+# Unit tests for DiscoverySpaceStatistics model
+# ---------------------------------------------------------------------------
+
+
+def test_heavy_fields_default_to_none() -> None:
+    """Heavy fields are optional and default to None."""
+    stats = DiscoverySpaceStatistics(
+        number_of_experiments=1,
+        number_of_operations=2,
+        number_of_explore_operations=1,
+        number_measured_entities=5,
+    )
+    assert stats.size_of_entity_space is None
+    assert stats.number_unmeasured_entities is None
+    assert stats.number_matching_entities is None
+    assert stats.number_matching_entities_with_measurements is None
+
+
+def test_nan_unmeasured_entities_round_trip() -> None:
+    """math.nan in number_unmeasured_entities survives a model_dump/model_validate cycle."""
+    stats = DiscoverySpaceStatistics(
+        number_of_experiments=1,
+        number_of_operations=2,
+        number_of_explore_operations=1,
+        number_measured_entities=5,
+        size_of_entity_space=None,
+        number_unmeasured_entities=math.nan,
+        number_matching_entities=None,
+        number_matching_entities_with_measurements=None,
+    )
+    restored = DiscoverySpaceStatistics.model_validate(stats.model_dump())
+    assert restored.size_of_entity_space is None
+    assert math.isnan(restored.number_unmeasured_entities)
+
+
+def test_inf_unmeasured_entities_round_trip() -> None:
+    """math.inf in number_unmeasured_entities survives a model_dump/model_validate cycle."""
+    stats = DiscoverySpaceStatistics(
+        number_of_experiments=1,
+        number_of_operations=0,
+        number_of_explore_operations=0,
+        number_measured_entities=0,
+        size_of_entity_space=None,
+        number_unmeasured_entities=math.inf,
+        number_matching_entities=None,
+        number_matching_entities_with_measurements=None,
+    )
+    restored = DiscoverySpaceStatistics.model_validate(stats.model_dump())
+    assert math.isinf(restored.number_unmeasured_entities)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for DiscoverySpace.space_statistics()
+#
+# The ml_multi_cloud_space fixture uses examples/ml-multi-cloud/ml_multicloud_space.yaml:
+#   entity space: provider (3) x cpu_family (2) x vcpu_size (2) x nodes (4) = 48 points
+#   experiments:  1  (benchmark_performance / replay)
+#   CSV sample store: 42 distinct entities, all matching the entity space
+# ---------------------------------------------------------------------------
+
+# Expected constants for the ml_multi_cloud space
+_ENTITY_SPACE_SIZE = 48
+_NUMBER_OF_EXPERIMENTS = 1
+_NUMBER_OF_MATCHING_ENTITIES = 42  # all CSV entities satisfy isEntityInSpace
+
+
+@requires_sqlite_3_38
+def test_space_statistics_lightweight_only(
+    ml_multi_cloud_space: DiscoverySpace,
+) -> None:
+    """lightweight_only=True returns correct lightweight fields and None for heavy fields."""
+    stats = ml_multi_cloud_space.space_statistics(lightweight_only=True)
+
+    assert isinstance(stats, DiscoverySpaceStatistics)
+    assert stats.number_of_experiments == _NUMBER_OF_EXPERIMENTS
+    assert stats.number_of_operations == 0
+    assert stats.number_of_explore_operations == 0
+    assert stats.number_measured_entities == 0
+    # Heavy fields must be None when lightweight_only=True
+    assert stats.size_of_entity_space is None
+    assert stats.number_unmeasured_entities is None
+    assert stats.number_matching_entities is None
+    assert stats.number_matching_entities_with_measurements is None
+
+
+@requires_sqlite_3_38
+def test_space_statistics_full_no_operations(
+    ml_multi_cloud_space: DiscoverySpace,
+) -> None:
+    """Full stats on a space with no operations: entity space and matching counts are exact."""
+    stats = ml_multi_cloud_space.space_statistics(lightweight_only=False)
+
+    assert isinstance(stats, DiscoverySpaceStatistics)
+    assert stats.number_of_experiments == _NUMBER_OF_EXPERIMENTS
+    assert stats.number_of_operations == 0
+    assert stats.number_of_explore_operations == 0
+    assert stats.number_measured_entities == 0
+    assert stats.size_of_entity_space == _ENTITY_SPACE_SIZE
+    assert stats.number_unmeasured_entities == _ENTITY_SPACE_SIZE
+    assert stats.number_matching_entities == _NUMBER_OF_MATCHING_ENTITIES
+    # The CSV sample store already carries observed property values for the
+    # benchmark_performance experiment, so all matching entities have measurements
+    assert (
+        stats.number_matching_entities_with_measurements == _NUMBER_OF_MATCHING_ENTITIES
+    )
+
+
+@requires_sqlite_3_38
+def test_space_statistics_full_with_operation(
+    ml_multi_cloud_space: DiscoverySpace,
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Full stats reflect exact measured-entity counts after a single operation."""
+    number_entities = 3
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=1,
+    )
+
+    stats = ml_multi_cloud_space.space_statistics(lightweight_only=False)
+
+    assert stats.number_of_experiments == _NUMBER_OF_EXPERIMENTS
+    assert stats.number_of_operations == 1
+    # The simulated operation uses operationType="search", which counts as explore
+    assert stats.number_of_explore_operations == 1
+    assert stats.number_measured_entities == number_entities
+    assert stats.size_of_entity_space == _ENTITY_SPACE_SIZE
+    assert stats.number_unmeasured_entities == _ENTITY_SPACE_SIZE - number_entities
+    assert stats.number_matching_entities == _NUMBER_OF_MATCHING_ENTITIES
+    # The CSV sample store already carries observed property values for all entities,
+    # so all matching entities have measurements regardless of the simulated operation
+    assert (
+        stats.number_matching_entities_with_measurements == _NUMBER_OF_MATCHING_ENTITIES
+    )
+
+
+def test_space_statistics_for_spaces_empty() -> None:
+    """An empty list returns an empty dict without any DB access."""
+    result = space_statistics_for_spaces([])
+    assert result == {}
+
+
+@requires_sqlite_3_38
+def test_space_statistics_for_spaces_single(
+    ml_multi_cloud_space: DiscoverySpace,
+) -> None:
+    """Single-space helper matches per-space method."""
+    stats_direct = ml_multi_cloud_space.space_statistics(lightweight_only=True)
+    stats_batch = space_statistics_for_spaces(
+        [ml_multi_cloud_space], lightweight_only=True
+    )
+
+    assert ml_multi_cloud_space.uri in stats_batch
+    batch_stats = stats_batch[ml_multi_cloud_space.uri]
+    assert batch_stats.number_of_experiments == stats_direct.number_of_experiments
+    assert batch_stats.number_of_operations == stats_direct.number_of_operations
+    assert batch_stats.number_measured_entities == stats_direct.number_measured_entities

--- a/tests/metastore/test_space_statistics_from_db.py
+++ b/tests/metastore/test_space_statistics_from_db.py
@@ -1,0 +1,126 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from orchestrator.core import ADOResource, DiscoverySpaceResource, OperationResource
+from orchestrator.core.operation.config import DiscoveryOperationEnum
+from tests.conftest import requires_sqlite_3_38
+
+if TYPE_CHECKING:
+    from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
+    from orchestrator.metastore.sqlstore import SQLStore
+
+
+@requires_sqlite_3_38
+def test_get_space_metastore_stats_single_no_operations(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    sql_store: "SQLStore",
+) -> None:
+    """A space with no operations returns zero counts for all op fields."""
+    space = random_space_resource_from_db()
+
+    stats: DiscoverySpaceStatistics = sql_store.get_space_metastore_stats(
+        space.identifier
+    )
+
+    assert stats.number_of_experiments == 1
+    assert stats.number_of_operations == 0
+    assert stats.number_of_explore_operations == 0
+
+
+@requires_sqlite_3_38
+def test_get_space_metastore_stats_single_with_search_operation(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    ml_multi_cloud_operation_resource: Callable[[str | None], OperationResource],
+    create_resource_with_related_identifiers: Callable[[ADOResource, list[str]], None],
+    sql_store: "SQLStore",
+) -> None:
+    """A space with one SEARCH operation has correct counts."""
+    space = random_space_resource_from_db()
+    op = ml_multi_cloud_operation_resource(space_id=space.identifier)
+    create_resource_with_related_identifiers(op, [space.identifier])
+
+    stats: DiscoverySpaceStatistics = sql_store.get_space_metastore_stats(
+        space.identifier
+    )
+
+    assert stats.number_of_experiments == 1
+    assert stats.number_of_operations == 1
+    assert stats.number_of_explore_operations == 1
+
+
+@requires_sqlite_3_38
+def test_get_space_metastore_stats_single_with_non_search_operation(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    ml_multi_cloud_operation_resource: Callable[[str | None], OperationResource],
+    create_resource_with_related_identifiers: Callable[[ADOResource, list[str]], None],
+    sql_store: "SQLStore",
+) -> None:
+    """A non-SEARCH operation is counted in total but not in explore."""
+    space = random_space_resource_from_db()
+    op = ml_multi_cloud_operation_resource(space_id=space.identifier)
+    op.operationType = DiscoveryOperationEnum.CHARACTERIZE
+    create_resource_with_related_identifiers(op, [space.identifier])
+
+    stats: DiscoverySpaceStatistics = sql_store.get_space_metastore_stats(
+        space.identifier
+    )
+
+    assert stats.number_of_operations == 1
+    assert stats.number_of_explore_operations == 0
+
+
+@requires_sqlite_3_38
+def test_get_space_metastore_stats_single_mixed_operations(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    ml_multi_cloud_operation_resource: Callable[[str | None], OperationResource],
+    create_resource_with_related_identifiers: Callable[[ADOResource, list[str]], None],
+    sql_store: "SQLStore",
+) -> None:
+    """Mixed operation types: total and explore counts are both correct."""
+    space = random_space_resource_from_db()
+
+    search_op = ml_multi_cloud_operation_resource(space_id=space.identifier)
+    create_resource_with_related_identifiers(search_op, [space.identifier])
+
+    characterize_op = ml_multi_cloud_operation_resource(space_id=space.identifier)
+    characterize_op.operationType = DiscoveryOperationEnum.CHARACTERIZE
+    create_resource_with_related_identifiers(characterize_op, [space.identifier])
+
+    stats: DiscoverySpaceStatistics = sql_store.get_space_metastore_stats(
+        space.identifier
+    )
+
+    assert stats.number_of_operations == 2
+    assert stats.number_of_explore_operations == 1
+
+
+@requires_sqlite_3_38
+def test_get_space_metastore_stats_multiple_spaces(
+    random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
+    ml_multi_cloud_operation_resource: Callable[[str | None], OperationResource],
+    create_resource_with_related_identifiers: Callable[[ADOResource, list[str]], None],
+    sql_store: "SQLStore",
+) -> None:
+    """Multiple space IDs are returned in a dict keyed by space ID."""
+    space_a = random_space_resource_from_db()
+    space_b = random_space_resource_from_db()
+
+    op_a = ml_multi_cloud_operation_resource(space_id=space_a.identifier)
+    create_resource_with_related_identifiers(op_a, [space_a.identifier])
+    # space_b has no operations
+
+    stats = sql_store.get_space_metastore_stats(
+        {space_a.identifier, space_b.identifier}
+    )
+
+    assert isinstance(stats, dict)
+    assert space_a.identifier in stats
+    assert space_b.identifier in stats
+
+    assert stats[space_a.identifier].number_of_operations == 1
+    assert stats[space_a.identifier].number_of_explore_operations == 1
+    assert stats[space_b.identifier].number_of_operations == 0
+    assert stats[space_b.identifier].number_of_explore_operations == 0

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -1272,3 +1272,148 @@ def test_operation_measurement_statistics_empty_set(
         ValueError, match="operation_ids must be a non-empty set or None"
     ):
         sample_store.operation_measurement_statistics(operation_ids=set())
+
+
+def test_space_entity_statistics_empty_mapping(
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """An empty mapping returns an empty dict."""
+    sample_store, _requests, _ids = simulate_ml_multi_cloud_random_walk_operation()
+
+    result = sample_store.space_entity_statistics(space_ids_to_operation_ids={})
+
+    assert result == {}
+
+
+def test_space_entity_statistics_empty_operations_for_space(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """A space mapped to an empty operation set returns 0 measured entities."""
+    space_id = random_identifier()
+    sample_store, _requests, _ids = simulate_ml_multi_cloud_random_walk_operation()
+
+    result = sample_store.space_entity_statistics(
+        space_ids_to_operation_ids={space_id: set()},
+    )
+
+    assert result[space_id].number_measured_entities == 0
+    assert result[space_id].number_matching_entities is None
+    assert result[space_id].number_matching_entities_with_measurements is None
+
+
+def test_space_entity_statistics_single_operation(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """A single space/operation returns the correct distinct entity count."""
+    space_id = random_identifier()
+    operation_id = random_identifier()
+    number_entities = 3
+    number_requests = 2
+
+    sample_store, requests, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        operation_id=operation_id,
+    )
+
+    expected_entities = {
+        result.entityIdentifier
+        for request in requests
+        for result in request.measurements
+    }
+
+    result = sample_store.space_entity_statistics(
+        space_ids_to_operation_ids={space_id: {operation_id}},
+    )
+
+    assert result[space_id].number_measured_entities == len(expected_entities)
+    assert result[space_id].number_matching_entities is None
+    assert result[space_id].number_matching_entities_with_measurements is None
+
+
+def test_space_entity_statistics_multiple_operations(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Multiple operations in one space: entities counted distinctly across all ops."""
+    space_id = random_identifier()
+    op_id_a = random_identifier()
+    op_id_b = random_identifier()
+
+    sample_store, requests_a, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=1,
+        operation_id=op_id_a,
+    )
+    _, requests_b, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=1,
+        operation_id=op_id_b,
+    )
+
+    all_entity_ids = {
+        result.entityIdentifier
+        for requests in (requests_a, requests_b)
+        for request in requests
+        for result in request.measurements
+    }
+
+    result = sample_store.space_entity_statistics(
+        space_ids_to_operation_ids={space_id: {op_id_a, op_id_b}},
+    )
+
+    assert result[space_id].number_measured_entities == len(all_entity_ids)
+    assert result[space_id].number_matching_entities is None
+    assert result[space_id].number_matching_entities_with_measurements is None
+
+
+def test_space_entity_statistics_multiple_spaces(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Multiple spaces in one call each get correct independent entity counts."""
+    space_id_a = random_identifier()
+    space_id_b = random_identifier()
+    op_id_a = random_identifier()
+    op_id_b = random_identifier()
+
+    sample_store, requests_a, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=3,
+        number_requests=1,
+        operation_id=op_id_a,
+    )
+    _, requests_b, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=1,
+        operation_id=op_id_b,
+    )
+
+    expected_a = {r.entityIdentifier for req in requests_a for r in req.measurements}
+    expected_b = {r.entityIdentifier for req in requests_b for r in req.measurements}
+
+    result = sample_store.space_entity_statistics(
+        space_ids_to_operation_ids={
+            space_id_a: {op_id_a},
+            space_id_b: {op_id_b},
+        },
+    )
+
+    assert result[space_id_a].number_measured_entities == len(expected_a)
+    assert result[space_id_b].number_measured_entities == len(expected_b)


### PR DESCRIPTION
## Summary

Adds a `DiscoverySpaceStatistics` model and a batch statistics computation layer for discovery spaces.

### What changed

**New file: `orchestrator/core/discoveryspace/stats.py`**
- Introduces the `DiscoverySpaceStatistics` Pydantic model, which captures per-space metrics:
  - Operation/experiment counts (lightweight, always populated)
  - Measured/unmeasured entity counts
  - Matching entity counts (heavier, optional)
- Adds two functions:
  - `lightweight_space_statistics()` — queries the metastore and sample store in **one batch round-trip each**, returning only the lightweight fields
  - `space_statistics_for_spaces()` — extends the lightweight path with Python-side heavy computation (entity-space size, matching entity counts); accepts a `lightweight_only` flag to skip the heavy work

**`DiscoverySpace.space_statistics()` (space.py)**
- New convenience method on `DiscoverySpace` that calls `space_statistics_for_spaces` for a single space

**`SQLSampleStore.space_entity_statistics()` (samplestore/sql.py)**
- New SQL method that counts **distinct measured entities per space** using a single JOIN query across all relevant operations, grouping results in Python

**`SQLResourceStore.get_space_metastore_stats()` (metastore/sqlstore.py)**
- New SQL method that fetches experiment count, total operation count, and explore-operation count for a batch of spaces in a single LEFT JOIN query

**`SpaceDetails.from_space()` (cli/models/space.py)**
- Refactored to delegate to `space.space_statistics()` for most fields, removing ~40 lines of duplicated inline logic; retains only the pandas-based all/partial measurement split which is not covered by `DiscoverySpaceStatistics`

**New tests**
- `tests/core/test_space_statistics.py` — unit tests for the statistics model and computation functions
- `tests/metastore/test_space_statistics_from_db.py` — integration tests for the metastore SQL query
- `tests/samplestore/get/test_get.py` — extended samplestore tests covering entity statistics queries