### PR TITLE
fix(vllm_performance): prevent TypeError when parsing renderer_num_workers

### DIFF
--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
@@ -265,6 +265,7 @@ def _create_environment(
                             f"Threadpool requested but not supported by image {image_name}"
                         )
 
+                    renderer_num_workers = int(values.get("renderer_num_workers", 0))
                     create_test_environment(
                         k8s_name=env.k8s_name,
                         model=model,
@@ -293,11 +294,7 @@ def _create_environment(
                         enforce_eager=values.get("enforce_eager", 0) == 1,
                         io_processor_plugin=values.get("io_processor_plugin"),
                         otlp_traces_endpoint=otlp_traces_endpoint,
-                        renderer_num_workers=(
-                            int(values.get("renderer_num_workers"))
-                            if int(values.get("renderer_num_workers"), 0) > 0
-                            else None
-                        ),
+                        renderer_num_workers=renderer_num_workers,
                         check_interval=check_interval,
                         timeout=timeout,
                     )

--- a/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
+++ b/plugins/actuators/vllm_performance/ado_actuators/vllm_performance/experiment_executor.py
@@ -294,7 +294,9 @@ def _create_environment(
                         enforce_eager=values.get("enforce_eager", 0) == 1,
                         io_processor_plugin=values.get("io_processor_plugin"),
                         otlp_traces_endpoint=otlp_traces_endpoint,
-                        renderer_num_workers=renderer_num_workers,
+                        renderer_num_workers=(
+                            renderer_num_workers if renderer_num_workers > 0 else None
+                        ),
                         check_interval=check_interval,
                         timeout=timeout,
                     )


### PR DESCRIPTION
## Problem

A `TypeError` was occurring during remote execution in the vllm_performance actuator when processing the `renderer_num_workers` parameter:

```
TypeError: int() can't convert non-string with explicit base
```

**Error Location:** The error occurred at line 298 in `experiment_executor.py`:

```python
# BEFORE - caused TypeError
renderer_num_workers=(
    int(values.get("renderer_num_workers"))
    if int(values.get("renderer_num_workers"), 0) > 0  # ← typo: ", 0" in wrong position
    else None
),
```

**Root Cause:** A typo placed `, 0` as the second argument to `int()` instead of as the default argument to `values.get()`. When `int()` receives a second argument, it interprets it as a numeric base (for string conversion), so passing a non-string as the first argument causes the `TypeError`. The fix is simply moving `, 0` to the correct position:

```python
# WRONG: int(values.get("renderer_num_workers"), 0)  — passes 0 as base to int()
# RIGHT: int(values.get("renderer_num_workers", 0))   — passes 0 as default to .get()
```

## Solution

Define `renderer_num_workers` before the `create_test_environment` call with the correct default:

```python
renderer_num_workers = int(values.get("renderer_num_workers", 0))
create_test_environment(
    ...
    renderer_num_workers=renderer_num_workers,
    ...
)
```

This is safe because `_is_threadpool_requested()` (called just before) already validates that `renderer_num_workers`, if specified, is a non-negative number.