### PR TITLE
feat(cli): add ado get space -o stats

### DIFF
--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -80,6 +80,15 @@ Goal: volume of work, recency, and which spaces attract the most operations.
    `MEASURED_ENTITIES` against the operator's `numberEntities` to check sampling
    completeness.
 
+4. **Discovery Spaces (with statistics)**
+
+   ```bash
+   uv run ado get spaces -o stats --output-file spaces-stats.txt
+   ```
+
+   Adds `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`, and
+   `MEASURED_ENTITIES` columns.
+
 **Synthesis:** cluster mentally (or in notes) by **creation time** to see bursts
 of activity; count operations **per space** from the operations listing to see
 which spaces are busiest.

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -81,18 +81,27 @@ type.
 `samplestores` (`store`), `datacontainers` (`dcr`), `actuatorconfigurations`
 (`ac`)
 
-### Operation Measurement Statistics
+### Resource Statistics
 
-`-o stats` adds result-count columns to the operations table without fetching
-full measurement data. Only supported for operations.
+`-o stats` adds statistics columns to the table without fetching full resource
+data. Supported for **operations** and **discovery spaces**.
 
 ```bash
+# Operations
 uv run ado get operations -o stats --output-file operations-stats.txt
 uv run ado get operation OPERATION_ID -o stats --no-trunc
+
+# Discovery Spaces
+uv run ado get spaces -o stats --output-file spaces-stats.txt
+uv run ado get space SPACE_ID -o stats --no-trunc
 ```
 
-Extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
-`MEASURED_ENTITIES` (distinct entities with at least one result).
+**Operations** extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
+`FAILED_RESULTS`, `MEASURED_ENTITIES` (distinct entities with at least one
+result).
+
+**Discovery Spaces** extra columns: `EXPERIMENTS`, `OPERATIONS`,
+`EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
 
 ### Filtering Resources
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -119,13 +119,21 @@ uv run ado get space --use-latest -o yaml
 # Get the latest operation as YAML
 uv run ado get operation --use-latest -o yaml
 
-# Get measurement statistics for all operations (operations only)
+# Get measurement statistics for all operations
 uv run ado get operations -o stats --output-file operations-stats.txt
 uv run ado get operation OPERATION_ID -o stats --no-trunc
+
+# Get statistics for all discovery spaces
+uv run ado get spaces -o stats --output-file spaces-stats.txt
+uv run ado get space SPACE_ID -o stats --no-trunc
 ```
 
-`-o stats` extends the table with `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-`FAILED_RESULTS`, and `MEASURED_ENTITIES`.
+`-o stats` extends the table with statistics columns:
+
+- **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
+  `MEASURED_ENTITIES`.
+- **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`,
+  `MEASURED_ENTITIES`.
 
 ### ado create
 

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -130,7 +130,7 @@ def get_resource(
             "--output",
             "-o",
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
-            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with measurement statistics columns (operations only). Not all formats may be supported by all resources.",
+            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES) and for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES). Not all formats may be supported by all resources.",
         ),
     ] = AdoGetSupportedOutputFormats.TABLE.value,
     exclude_default: Annotated[

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -227,7 +227,7 @@ def format_ado_get_stats_for_operations(
     ) in enumerate(samplestore_to_operation_ids.items(), start=1):
         if spinner is not None:
             spinner.update(
-                f"Handling samplestore {index}/{total_samplestores}: {samplestore_id}"
+                f"Calculating stats for operations in samplestore {index}/{total_samplestores}: {samplestore_id}"
             )
         sample_store = SampleStore.from_identifier(samplestore_id, sql_store)
         for stat in sample_store.operation_measurement_statistics(
@@ -246,6 +246,134 @@ def format_ado_get_stats_for_operations(
         df[col] = df["IDENTIFIER"].apply(
             lambda operation_id, c=col: stats_lookup.get(operation_id, zeros)[c]
         )
+
+    return df
+
+
+def format_ado_get_stats_for_spaces(
+    df: "pd.DataFrame",
+    sql_store: "SQLStore",
+    spinner: "Status | None" = None,
+) -> "pd.DataFrame":
+    """Append 4 space-statistics columns to a discovery spaces DataFrame.
+
+    Issues a metastore stats query for all spaces at once, then resolves each
+    space's linked operations and sample stores.  For each distinct sample
+    store a single batched :meth:`space_entity_statistics` query is issued.
+
+    Args:
+        df: DataFrame with at least an ``IDENTIFIER`` column (one row per
+            discovery space).
+        sql_store: The ``SQLStore`` to use for relationship and stats queries.
+        spinner: Optional rich status spinner to update with progress messages.
+
+    Returns:
+        The same DataFrame with four extra columns appended:
+        ``EXPERIMENTS``, ``OPERATIONS``, ``EXPLORE_OPERATIONS``,
+        ``MEASURED_ENTITIES``.
+        Spaces with no recorded operations or sample store show ``0`` in all
+        stats columns.
+    """
+    from orchestrator.core.resources import CoreResourceKinds
+    from orchestrator.core.samplestore.base import SampleStore
+
+    _STATS_COLUMNS = [
+        "EXPERIMENTS",
+        "OPERATIONS",
+        "EXPLORE_OPERATIONS",
+        "MEASURED_ENTITIES",
+    ]
+
+    space_ids: set[str] = set(df["IDENTIFIER"])
+
+    # Query 1: metastore stats (number_of_experiments, number_of_operations,
+    # number_of_explore_operations) for all spaces in one SQL query.
+    metastore_stats = sql_store.get_space_metastore_stats(space_ids)
+
+    # Query 2: for each space, get its child operations.
+    # Returns {space_id: {CoreResourceKinds.OPERATION: set[operation_id]}}
+    space_child_relationships: dict[str, dict[CoreResourceKinds, set[str]]] = (
+        sql_store.get_resources_by_relationship(
+            kind=CoreResourceKinds.DISCOVERYSPACE,
+            identifier=space_ids,
+            hierarchy_direction="down",
+            max_hops=1,
+            identifiers_only=True,
+        )
+    )
+
+    # Build space_id_to_operation_ids: {space_id: set[operation_id]}
+    space_id_to_operation_ids: dict[str, set[str]] = {}
+    for space_id in space_ids:
+        space_children_by_kind = space_child_relationships.get(space_id, {})
+        space_id_to_operation_ids[space_id] = space_children_by_kind.get(
+            CoreResourceKinds.OPERATION, set()
+        )
+
+    # Query 3: for each space, get its parent sample store(s),
+    # returning hydrated SampleStoreResource objects.
+    # Returns {space_id: {CoreResourceKinds.SAMPLESTORE: {samplestore_id: SampleStoreResource}}}
+    space_parent_relationships: dict[
+        str, dict[CoreResourceKinds, dict[str, ADOResource]]
+    ] = sql_store.get_resources_by_relationship(
+        kind=CoreResourceKinds.DISCOVERYSPACE,
+        identifier=space_ids,
+        hierarchy_direction="up",
+        max_hops=1,
+        identifiers_only=False,
+    )
+
+    # Invert to {samplestore_id: set[space_id]}, keeping the hydrated resource.
+    samplestore_id_to_resource: dict[str, ADOResource] = {}
+    samplestore_id_to_space_ids: dict[str, set[str]] = {}
+    for space_id, space_parents_by_kind in space_parent_relationships.items():
+        samplestore_resources = space_parents_by_kind.get(
+            CoreResourceKinds.SAMPLESTORE, {}
+        )
+        for samplestore_id, samplestore_resource in samplestore_resources.items():
+            samplestore_id_to_resource[samplestore_id] = samplestore_resource
+            samplestore_id_to_space_ids.setdefault(samplestore_id, set()).add(space_id)
+
+    # For each distinct sample store, issue one batched space_entity_statistics query.
+    space_id_to_measured_entity_count: dict[str, int] = {}
+    total_samplestores = len(samplestore_id_to_space_ids)
+    for index, (samplestore_id, samplestore_space_ids) in enumerate(
+        samplestore_id_to_space_ids.items(), start=1
+    ):
+        if spinner is not None:
+            spinner.update(
+                f"Calculating stats for spaces in samplestore {index}/{total_samplestores}: {samplestore_id}"
+            )
+        sample_store = SampleStore.from_resource(
+            samplestore_id_to_resource[samplestore_id]
+        )
+        operation_ids_per_space = {
+            space_id: space_id_to_operation_ids[space_id]
+            for space_id in samplestore_space_ids
+        }
+        entity_stats_per_space = sample_store.space_entity_statistics(
+            space_ids_to_operation_ids=operation_ids_per_space
+        )
+        for space_id, entity_stats in entity_stats_per_space.items():
+            space_id_to_measured_entity_count[space_id] = (
+                entity_stats.number_measured_entities or 0
+            )
+
+    # Attach stats columns; spaces with no data show 0.
+    # get_space_metastore_stats always returns an entry for every requested
+    # space_id, so direct attribute access is safe.
+    df["EXPERIMENTS"] = df["IDENTIFIER"].apply(
+        lambda space_id: metastore_stats[space_id].number_of_experiments
+    )
+    df["OPERATIONS"] = df["IDENTIFIER"].apply(
+        lambda space_id: metastore_stats[space_id].number_of_operations
+    )
+    df["EXPLORE_OPERATIONS"] = df["IDENTIFIER"].apply(
+        lambda space_id: metastore_stats[space_id].number_of_explore_operations
+    )
+    df["MEASURED_ENTITIES"] = df["IDENTIFIER"].apply(
+        lambda space_id: space_id_to_measured_entity_count.get(space_id, 0)
+    )
 
     return df
 

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -32,6 +32,7 @@ from orchestrator.cli.utils.output.prints import (
 )
 from orchestrator.cli.utils.resources.formatters import (
     format_ado_get_stats_for_operations,
+    format_ado_get_stats_for_spaces,
     format_default_ado_get_multiple_resources,
     format_default_ado_get_single_resource,
     format_resource_for_ado_get_custom_format,
@@ -304,16 +305,20 @@ def _handle_stats_format(
     dataframe: "pd.DataFrame | None",
     resources: "list[ADOResource] | ADOResource | None",
 ) -> None:
-    """Handle STATS output format - TABLE columns plus 7 measurement stats columns.
+    """Handle STATS output format - TABLE columns plus measurement/space stats columns.
 
-    Only supported for operations.  For any other resource type the handler
-    prints an error message and exits with code 1.
+    Supported for operations (columns: TOTAL_RESULTS, SUCCESSFUL_RESULTS,
+    FAILED_RESULTS, MEASURED_ENTITIES) and discovery spaces (columns:
+    EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES).  For any
+    other resource type the handler prints an error message and exits with code 1.
     """
     from orchestrator.core import CoreResourceKinds
 
-    if resource_type is not None and resource_type != CoreResourceKinds.OPERATION:
+    _SUPPORTED = {CoreResourceKinds.OPERATION, CoreResourceKinds.DISCOVERYSPACE}
+    if resource_type is not None and resource_type not in _SUPPORTED:
         console_print(
-            f"{ERROR}The 'stats' output format is only supported for operations.",
+            f"{ERROR}The 'stats' output format is only supported for operations "
+            f"and discovery spaces.",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -334,11 +339,18 @@ def _handle_stats_format(
         project_context=parameters.ado_configuration.project_context
     )
     with Status(ADO_SPINNER_GETTING_OUTPUT_READY) as status:
-        enriched_df = format_ado_get_stats_for_operations(
-            base_df,
-            sql_store_for_stats,
-            spinner=status,
-        )
+        if resource_type == CoreResourceKinds.DISCOVERYSPACE:
+            enriched_df = format_ado_get_stats_for_spaces(
+                base_df,
+                sql_store_for_stats,
+                spinner=status,
+            )
+        else:
+            enriched_df = format_ado_get_stats_for_operations(
+                base_df,
+                sql_store_for_stats,
+                spinner=status,
+            )
 
     _render_dataframe_table_output(enriched_df, parameters)
 

--- a/tests/ado/get/test_ado_get_stats.py
+++ b/tests/ado/get/test_ado_get_stats.py
@@ -1,19 +1,30 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
+import datetime
 import os
 import pathlib
 from collections.abc import Callable
 
+import pandas as pd
 import pytest
+import rich.box
 from testcontainers.mysql import MySqlContainer
 from typer.testing import CliRunner
 
 from orchestrator.cli.core.cli import app as ado
+from orchestrator.core import CoreResourceKinds
+from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.core.samplestore.sql import SQLSampleStore
 from orchestrator.metastore.project import ProjectContext
-from orchestrator.metastore.sqlstore import SQLStore
 from orchestrator.schema.request import MeasurementRequest
+from orchestrator.utilities.rich import dataframe_to_rich_table, render_to_string
 from tests.conftest import requires_sqlite_3_38
+
+# A past timestamp far enough from "now" that AGE is stable across a test run.
+_CREATED_7_DAYS_AGO = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+    days=7
+)
+_EXPECTED_AGE = "7d0h"
 
 
 @requires_sqlite_3_38
@@ -70,24 +81,25 @@ def test_ado_get_operations_stats_columns_present(
 def test_ado_get_operations_stats_values(
     tmp_path: pathlib.Path,
     mysql_test_instance: MySqlContainer,
-    sql_store: SQLStore,
     valid_ado_project_context: ProjectContext,
     create_active_ado_context: Callable[
         [CliRunner, pathlib.Path, ProjectContext], None
     ],
+    ml_multi_cloud_space: DiscoverySpace,
     simulate_ml_multi_cloud_random_walk_operation: Callable[
-        [int, int, int, str | None],
+        [int, int, int, str | None, datetime.datetime | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """Stats values for a known operation match expected counts."""
+    """Stats values for a known operation match the expected counts in the rendered table."""
     runner = CliRunner()
     create_active_ado_context(
         runner=runner, path=tmp_path, project_context=valid_ado_project_context
     )
 
     number_entities = 3
-    number_requests = 4
+    # Use 1 request so MEASURED_ENTITIES == number_entities (entities are sampled per-request)
+    number_requests = 1
     operation_id = "op-stats-test-abc123"
 
     simulate_ml_multi_cloud_random_walk_operation(
@@ -95,52 +107,7 @@ def test_ado_get_operations_stats_values(
         number_requests=number_requests,
         measurements_per_result=1,
         operation_id=operation_id,
-    )
-
-    result = runner.invoke(
-        ado,
-        [
-            "--override-ado-app-dir",
-            tmp_path,
-            "get",
-            "operation",
-            operation_id,
-            "-o",
-            "stats",
-        ],
-    )
-
-    assert result.exit_code == 0, result.output
-    if os.environ.get("CI", "false") != "true":
-        # TOTAL_RESULTS == number_requests * number_entities
-        assert str(number_requests * number_entities) in result.output
-
-
-@requires_sqlite_3_38
-def test_ado_get_operation_stats_single_resource(
-    tmp_path: pathlib.Path,
-    mysql_test_instance: MySqlContainer,
-    valid_ado_project_context: ProjectContext,
-    create_active_ado_context: Callable[
-        [CliRunner, pathlib.Path, ProjectContext], None
-    ],
-    simulate_ml_multi_cloud_random_walk_operation: Callable[
-        [int, int, int, str | None],
-        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
-    ],
-) -> None:
-    """ado get operation <id> -o stats exits 0 and shows result stats columns."""
-    runner = CliRunner()
-    create_active_ado_context(
-        runner=runner, path=tmp_path, project_context=valid_ado_project_context
-    )
-
-    operation_id = "op-stats-single-xyz789"
-    simulate_ml_multi_cloud_random_walk_operation(
-        number_entities=2,
-        number_requests=2,
-        measurements_per_result=1,
-        operation_id=operation_id,
+        created=_CREATED_7_DAYS_AGO,
     )
 
     result = runner.invoke(
@@ -159,12 +126,273 @@ def test_ado_get_operation_stats_single_resource(
 
     assert result.exit_code == 0, result.output
     if os.environ.get("CI", "false") != "true":
-        assert operation_id in result.output
-        assert "TOTAL_RESULTS" in result.output
+        expected_output = pd.DataFrame(
+            data={
+                "IDENTIFIER": operation_id,
+                "NAME": "randomwalk-all",
+                "SPACE": ml_multi_cloud_space.uri,
+                "STATUS": "added",
+                "EXIT_STATE": "N/A",
+                "AGE": _EXPECTED_AGE,
+                "TOTAL_RESULTS": number_requests * number_entities,
+                "SUCCESSFUL_RESULTS": number_requests * number_entities,
+                "FAILED_RESULTS": 0,
+                "MEASURED_ENTITIES": number_entities,
+            },
+            index=pd.Index([0]),
+        )
+        rendered_output = render_to_string(
+            dataframe_to_rich_table(
+                expected_output,
+                show_index=True,
+                show_edge=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            ),
+            auto_width=True,
+        )
+        assert (
+            rendered_output in result.output
+        ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"
 
 
 @requires_sqlite_3_38
-@pytest.mark.parametrize("resource_kind", ["spaces", "samplestores"])
+def test_ado_get_operation_stats_single_resource(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    ml_multi_cloud_space: DiscoverySpace,
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None, datetime.datetime | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """ado get operation <id> -o stats renders a table with the correct operation stats."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_entities = 2
+    # Use 1 request so MEASURED_ENTITIES == number_entities (entities are sampled per-request)
+    number_requests = 1
+    operation_id = "op-stats-single-xyz789"
+
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=1,
+        operation_id=operation_id,
+        created=_CREATED_7_DAYS_AGO,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operation",
+            operation_id,
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        expected_output = pd.DataFrame(
+            data={
+                "IDENTIFIER": operation_id,
+                "NAME": "randomwalk-all",
+                "SPACE": ml_multi_cloud_space.uri,
+                "STATUS": "added",
+                "EXIT_STATE": "N/A",
+                "AGE": _EXPECTED_AGE,
+                "TOTAL_RESULTS": number_requests * number_entities,
+                "SUCCESSFUL_RESULTS": number_requests * number_entities,
+                "FAILED_RESULTS": 0,
+                "MEASURED_ENTITIES": number_entities,
+            },
+            index=pd.Index([0]),
+        )
+        rendered_output = render_to_string(
+            dataframe_to_rich_table(
+                expected_output,
+                show_index=True,
+                show_edge=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            ),
+            auto_width=True,
+        )
+        assert (
+            rendered_output in result.output
+        ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"
+
+
+@requires_sqlite_3_38
+def test_ado_get_spaces_stats_values(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    ml_multi_cloud_space: DiscoverySpace,
+    backdate_resource: Callable[[str, CoreResourceKinds, datetime.datetime], None],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Stats values for a known space match the expected counts in the rendered table."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_entities = 3
+    # Use 1 request so MEASURED_ENTITIES == number_entities (entities are sampled per-request)
+    number_requests = 1
+    operation_id = "op-space-stats-abc123"
+
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+    space_id = ml_multi_cloud_space.uri
+    backdate_resource(space_id, CoreResourceKinds.DISCOVERYSPACE, _CREATED_7_DAYS_AGO)
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "space",
+            space_id,
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        expected_output = pd.DataFrame(
+            data={
+                "IDENTIFIER": space_id,
+                "NAME": "ml_multicloud_basic",
+                "AGE": _EXPECTED_AGE,
+                "EXPERIMENTS": 1,
+                "OPERATIONS": 1,
+                "EXPLORE_OPERATIONS": 1,
+                "MEASURED_ENTITIES": number_entities,
+            },
+            index=pd.Index([0]),
+        )
+        rendered_output = render_to_string(
+            dataframe_to_rich_table(
+                expected_output,
+                show_index=True,
+                show_edge=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            ),
+            auto_width=True,
+        )
+        assert (
+            rendered_output in result.output
+        ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"
+
+
+@requires_sqlite_3_38
+def test_ado_get_space_stats_single_resource(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    ml_multi_cloud_space: DiscoverySpace,
+    backdate_resource: Callable[[str, CoreResourceKinds, datetime.datetime], None],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """ado get space <id> -o stats renders a table with the correct space stats."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_entities = 2
+    # Use 1 request so MEASURED_ENTITIES == number_entities (entities are sampled per-request)
+    number_requests = 1
+    operation_id = "op-space-stats-single-xyz789"
+
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+    space_id = ml_multi_cloud_space.uri
+    backdate_resource(space_id, CoreResourceKinds.DISCOVERYSPACE, _CREATED_7_DAYS_AGO)
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "space",
+            space_id,
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        expected_output = pd.DataFrame(
+            data={
+                "IDENTIFIER": space_id,
+                "NAME": "ml_multicloud_basic",
+                "AGE": _EXPECTED_AGE,
+                "EXPERIMENTS": 1,
+                "OPERATIONS": 1,
+                "EXPLORE_OPERATIONS": 1,
+                "MEASURED_ENTITIES": number_entities,
+            },
+            index=pd.Index([0]),
+        )
+        rendered_output = render_to_string(
+            dataframe_to_rich_table(
+                expected_output,
+                show_index=True,
+                show_edge=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            ),
+            auto_width=True,
+        )
+        assert (
+            rendered_output in result.output
+        ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"
+
+
+@requires_sqlite_3_38
+@pytest.mark.parametrize("resource_kind", ["samplestores"])
 def test_ado_get_stats_unsupported_resource_type_exits_1(
     tmp_path: pathlib.Path,
     mysql_test_instance: MySqlContainer,

--- a/tests/fixtures/ml_multi_cloud/fixtures.py
+++ b/tests/fixtures/ml_multi_cloud/fixtures.py
@@ -1,6 +1,7 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
+import datetime
 import pathlib
 import random
 from collections.abc import Callable
@@ -12,7 +13,11 @@ import orchestrator.core.actuatorconfiguration.config
 import orchestrator.core.discoveryspace.config
 import orchestrator.core.samplestore.csv
 import orchestrator.utilities.location
-from orchestrator.core import ActuatorConfigurationResource, OperationResource
+from orchestrator.core import (
+    ActuatorConfigurationResource,
+    CoreResourceKinds,
+    OperationResource,
+)
 from orchestrator.core.discoveryspace.space import DiscoverySpace
 from orchestrator.core.operation.config import (
     DiscoveryOperationEnum,
@@ -26,7 +31,7 @@ from orchestrator.core.samplestore.config import (
 from orchestrator.core.samplestore.csv import CSVSampleStore
 from orchestrator.core.samplestore.sql import SQLSampleStore
 from orchestrator.metastore.project import ProjectContext
-from orchestrator.metastore.sqlstore import SQLResourceStore
+from orchestrator.metastore.sqlstore import SQLResourceStore, SQLStore
 from orchestrator.modules.actuators.registry import ActuatorRegistry
 from orchestrator.schema.entity import Entity
 from orchestrator.schema.experiment import Experiment
@@ -307,7 +312,7 @@ def simulate_ml_multi_cloud_random_walk_operation(
     ],
     ml_multi_cloud_benchmark_performance_experiment: Experiment,
 ) -> Callable[
-    [int, int, int, str | None],
+    [int, int, int, str | None, "datetime.datetime | None"],
     tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
 ]:
     def _simulate_ml_multi_cloud_random_walk_operation(
@@ -315,6 +320,7 @@ def simulate_ml_multi_cloud_random_walk_operation(
         number_requests: int = 3,
         measurements_per_result: int = 2,
         operation_id: str | None = None,
+        created: "datetime.datetime | None" = None,
     ) -> tuple[SQLSampleStore, list[MeasurementRequest], list[str]]:
         operation_id = operation_id or random_identifier()
         sample_store = ml_multi_cloud_sample_store
@@ -323,13 +329,16 @@ def simulate_ml_multi_cloud_random_walk_operation(
             project_context=valid_ado_project_context, ensureExists=True
         )
 
+        resource = OperationResource(
+            identifier=operation_id,
+            config=ml_multi_cloud_operation_configuration,
+            operationType=DiscoveryOperationEnum.SEARCH,
+            operatorIdentifier="doesnt-matter",
+        )
+        if created is not None:
+            resource.created = created
         sql.addResourceWithRelationships(
-            OperationResource(
-                identifier=operation_id,
-                config=ml_multi_cloud_operation_configuration,
-                operationType=DiscoveryOperationEnum.SEARCH,
-                operatorIdentifier="doesnt-matter",
-            ),
+            resource,
             relatedIdentifiers=ml_multi_cloud_operation_configuration.spaces,
         )
 
@@ -366,3 +375,28 @@ def simulate_ml_multi_cloud_random_walk_operation(
         return sample_store, requests, request_ids
 
     return _simulate_ml_multi_cloud_random_walk_operation
+
+
+@pytest.fixture
+def backdate_resource(
+    valid_ado_project_context: ProjectContext,
+) -> Callable[[str, CoreResourceKinds, datetime.datetime], None]:
+    """Return a callable that overwrites the ``created`` timestamp of any resource.
+
+    Args:
+        identifier: The resource identifier to backdate.
+        kind: The ``CoreResourceKinds`` of the resource.
+        created: The new ``created`` timestamp to set.
+    """
+
+    def _backdate_resource(
+        identifier: str,
+        kind: CoreResourceKinds,
+        created: datetime.datetime,
+    ) -> None:
+        sql = SQLStore(project_context=valid_ado_project_context)
+        resource = sql.getResource(identifier=identifier, kind=kind)
+        resource.created = created
+        sql.updateResource(resource)
+
+    return _backdate_resource

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -531,10 +531,12 @@ Where:
     - The `config` format displays the `config` field of the matching resources.
     - The `raw` format displays the raw resource as stored in the database,
       performing no validation.
-    - The `stats` format augments the default `table` output with four additional
-      measurement statistics columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-      `FAILED_RESULTS`, and `MEASURED_ENTITIES`. This format is **only supported
-      for operations**.
+    - The `stats` format augments the default `table` output with additional
+      statistics columns. Supported resource types and their columns are:
+        - **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
+          `FAILED_RESULTS`, `MEASURED_ENTITIES`.
+        - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`,
+          `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
 
     <!-- prettier-ignore-end -->
 
@@ -735,6 +737,18 @@ ado get operations -o stats
 
 ```shell
 ado get operation randomwalk-0.5.0-123abc -o stats
+```
+
+##### Getting statistics for all Discovery Spaces
+
+```shell
+ado get spaces -o stats
+```
+
+##### Getting statistics for a single Discovery Space
+
+```shell
+ado get space --use-latest -o stats
 ```
 
 ### ado show


### PR DESCRIPTION
## `ado get spaces -o stats` — extend stats output format to discovery spaces

### What changed

The `-o stats` output flag, previously only available for **operations**, now
also works for **discovery spaces** (`ado get spaces -o stats`).

When run against a discovery space, the enriched table gains four columns:

| Column | Description |
|---|---|
| `EXPERIMENTS` | Number of distinct experiments configured in the space |
| `OPERATIONS` | Total number of linked operations |
| `EXPLORE_OPERATIONS` | Number of explore-mode operations |
| `MEASURED_ENTITIES` | Number of entities that have been measured across all operations |

### Key code changes

- **`formatters.py`** — new `format_ado_get_stats_for_spaces()` function that
  issues batched metastore and sample-store queries (one per distinct sample
  store) to compute the four columns efficiently.
- **`handlers.py`** — `_handle_stats_format` now accepts both
  `OPERATION` and `DISCOVERYSPACE` resource kinds, routing to the appropriate
  formatter.
- **`sql.py` / `stats.py`** — removed the unused `samplestore_statistics()`
  method and the `SampleStoreStatistics` model that backed it; the stats
  needed here are computed via the existing `space_entity_statistics()` and a
  new `get_space_metastore_stats()` query.
- **Tests** — `test_ado_get_stats.py` greatly expanded with coverage for the
  new spaces stats path; the now-deleted `test_samplestore_stats.py` removed.
- **Docs / skills** — help text, `ado.md` getting-started guide, and three
  agent skill files updated to document the new flag.

### Example output

```
┌───────┬──────────────────────┬───────────────────────────────────────────┬──────┬─────────────┬────────────┬────────────────────┬───────────────────┐
│ INDEX │ IDENTIFIER           │ NAME                                      │ AGE  │ EXPERIMENTS │ OPERATIONS │ EXPLORE_OPERATIONS │ MEASURED_ENTITIES │
├───────┼──────────────────────┼───────────────────────────────────────────┼──────┼─────────────┼────────────┼────────────────────┼───────────────────┤
│ 0     │ space-ddde19-default │ qaoa_routing_mip_strategy_linearized_only │ 5h3m │ 1           │ 1          │ 1                  │ 1                 │
└───────┴──────────────────────┴───────────────────────────────────────────┴──────┴─────────────┴────────────┴────────────────────┴───────────────────┘
```