### PR TITLE
feat(cli): support samplestores in ado get -o stats

### DIFF
--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -89,6 +89,14 @@ Goal: volume of work, recency, and which spaces attract the most operations.
    Adds `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`, and
    `MEASURED_ENTITIES` columns.
 
+5. **Sample Stores (with statistics)**
+
+   ```bash
+   uv run ado get samplestores -o stats --output-file samplestores-stats.txt
+   ```
+
+   Adds `ENTITIES`, `RESULTS`, and `EXPERIMENTS` columns.
+
 **Synthesis:** cluster mentally (or in notes) by **creation time** to see bursts
 of activity; count operations **per space** from the operations listing to see
 which spaces are busiest.

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -84,7 +84,7 @@ type.
 ### Resource Statistics
 
 `-o stats` adds statistics columns to the table without fetching full resource
-data. Supported for **operations** and **discovery spaces**.
+data. Supported for **operations**, **discovery spaces**, and **sample stores**.
 
 ```bash
 # Operations
@@ -94,6 +94,10 @@ uv run ado get operation OPERATION_ID -o stats --no-trunc
 # Discovery Spaces
 uv run ado get spaces -o stats --output-file spaces-stats.txt
 uv run ado get space SPACE_ID -o stats --no-trunc
+
+# Sample Stores
+uv run ado get samplestores -o stats --output-file samplestores-stats.txt
+uv run ado get samplestore SAMPLESTORE_ID -o stats --no-trunc
 ```
 
 **Operations** extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
@@ -102,6 +106,8 @@ result).
 
 **Discovery Spaces** extra columns: `EXPERIMENTS`, `OPERATIONS`,
 `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
+
+**Sample Stores** extra columns: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
 
 ### Filtering Resources
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -126,6 +126,10 @@ uv run ado get operation OPERATION_ID -o stats --no-trunc
 # Get statistics for all discovery spaces
 uv run ado get spaces -o stats --output-file spaces-stats.txt
 uv run ado get space SPACE_ID -o stats --no-trunc
+
+# Get statistics for all sample stores
+uv run ado get samplestores -o stats --output-file samplestores-stats.txt
+uv run ado get samplestore SAMPLESTORE_ID -o stats --no-trunc
 ```
 
 `-o stats` extends the table with statistics columns:
@@ -134,6 +138,7 @@ uv run ado get space SPACE_ID -o stats --no-trunc
   `MEASURED_ENTITIES`.
 - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`,
   `MEASURED_ENTITIES`.
+- **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
 
 ### ado create
 

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -197,7 +197,7 @@ def format_ado_get_stats_for_operations(
 
     operation_ids: set[str] = set(df["IDENTIFIER"])
 
-    # Round-trip 2: one recursive-CTE query for all operations at once.
+    # Round-trip 2: one recursive-CTE query for all operations at once
     # Returns {operation_id: {CoreResourceKinds.SAMPLESTORE: {samplestore_id, ...}, ...}}
     relationships: dict[str, dict[CoreResourceKinds, set[str]]] = (
         sql_store.get_resources_by_relationship(
@@ -209,16 +209,21 @@ def format_ado_get_stats_for_operations(
         )
     )
 
-    # Invert to {samplestore_id: set_of_operation_ids}
+    # Invert to {samplestore_id: set_of_operation_ids}.
     samplestore_to_operation_ids: dict[str, set[str]] = {}
     for operation_id, kind_map in relationships.items():
-        samplestore_ids = kind_map.get(CoreResourceKinds.SAMPLESTORE, set())
-        for samplestore_id in samplestore_ids:
+        for samplestore_id in kind_map.get(CoreResourceKinds.SAMPLESTORE, set()):
             samplestore_to_operation_ids.setdefault(samplestore_id, set()).add(
                 operation_id
             )
 
-    # Round-trips 3…K+2: one load + one batched stats query per unique samplestore.
+    # Round-trip 3: fetch all distinct samplestore resources in one batch query.
+    samplestore_id_to_resource: dict[str, ADOResource] = sql_store.getResources(
+        list(samplestore_to_operation_ids.keys())
+    )
+
+    # Round-trips 4…K+3: one batched stats query per unique samplestore.
+    # SampleStore is instantiated from the already-fetched resource — no extra DB round-trip.
     stats_lookup: dict[str, dict[str, int]] = {}
     total_samplestores = len(samplestore_to_operation_ids)
     for index, (
@@ -229,7 +234,9 @@ def format_ado_get_stats_for_operations(
             spinner.update(
                 f"Calculating stats for operations in samplestore {index}/{total_samplestores}: {samplestore_id}"
             )
-        sample_store = SampleStore.from_identifier(samplestore_id, sql_store)
+        sample_store = SampleStore.from_resource(
+            samplestore_id_to_resource[samplestore_id]
+        )
         for stat in sample_store.operation_measurement_statistics(
             operation_ids=operation_ids_in_store
         ):
@@ -373,6 +380,61 @@ def format_ado_get_stats_for_spaces(
     )
     df["MEASURED_ENTITIES"] = df["IDENTIFIER"].apply(
         lambda space_id: space_id_to_measured_entity_count.get(space_id, 0)
+    )
+
+    return df
+
+
+def format_ado_get_stats_for_samplestores(
+    df: "pd.DataFrame",
+    sql_store: "SQLStore",
+    spinner: "Status | None" = None,
+) -> "pd.DataFrame":
+    """Append 3 statistics columns to a sample stores DataFrame.
+
+    Iterates over each store, updating the spinner with progress, and collects
+    entity, result, and experiment counts.
+
+    Args:
+        df: DataFrame with at least an ``IDENTIFIER`` column (one row per
+            sample store).
+        sql_store: The ``SQLStore`` to use for loading each sample store.
+        spinner: Optional rich status spinner to update with progress messages.
+
+    Returns:
+        The same DataFrame with three extra columns appended:
+        ``ENTITIES``, ``RESULTS``, ``EXPERIMENTS``.
+        Stores with no recorded data show ``0`` in all stats columns.
+    """
+    from orchestrator.core.samplestore.base import SampleStore
+
+    samplestore_ids: list[str] = list(df["IDENTIFIER"])
+    total_samplestores = len(samplestore_ids)
+
+    # Fetch all samplestore resources in a single batch query, then instantiate
+    # SampleStore objects from the hydrated resources — no per-store round-trip.
+    resources: dict[str, ADOResource] = sql_store.getResources(samplestore_ids)
+
+    stats_by_id = {}
+    for index, samplestore_id in enumerate(samplestore_ids, start=1):
+        if samplestore_id not in resources:
+            continue
+        if spinner is not None:
+            spinner.update(
+                f"Calculating stats for samplestore {index}/{total_samplestores}: {samplestore_id}"
+            )
+        store = SampleStore.from_resource(resources[samplestore_id])
+        stats_by_id[samplestore_id] = store.samplestore_statistics()
+
+    # Attach stats columns; stores with no data show 0.
+    df["ENTITIES"] = df["IDENTIFIER"].apply(
+        lambda sid: stats_by_id[sid].number_of_entities if sid in stats_by_id else 0
+    )
+    df["RESULTS"] = df["IDENTIFIER"].apply(
+        lambda sid: stats_by_id[sid].number_of_results if sid in stats_by_id else 0
+    )
+    df["EXPERIMENTS"] = df["IDENTIFIER"].apply(
+        lambda sid: stats_by_id[sid].number_of_experiments if sid in stats_by_id else 0
     )
 
     return df

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -32,6 +32,7 @@ from orchestrator.cli.utils.output.prints import (
 )
 from orchestrator.cli.utils.resources.formatters import (
     format_ado_get_stats_for_operations,
+    format_ado_get_stats_for_samplestores,
     format_ado_get_stats_for_spaces,
     format_default_ado_get_multiple_resources,
     format_default_ado_get_single_resource,
@@ -307,18 +308,27 @@ def _handle_stats_format(
 ) -> None:
     """Handle STATS output format - TABLE columns plus measurement/space stats columns.
 
-    Supported for operations (columns: TOTAL_RESULTS, SUCCESSFUL_RESULTS,
-    FAILED_RESULTS, MEASURED_ENTITIES) and discovery spaces (columns:
-    EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES).  For any
-    other resource type the handler prints an error message and exits with code 1.
+    Supported for:
+    - operations (columns: TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS,
+      MEASURED_ENTITIES)
+    - discovery spaces (columns: EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS,
+      MEASURED_ENTITIES)
+    - sample stores (columns: ENTITIES, RESULTS, EXPERIMENTS)
+
+    For any other resource type the handler prints an error message and exits
+    with code 1.
     """
     from orchestrator.core import CoreResourceKinds
 
-    _SUPPORTED = {CoreResourceKinds.OPERATION, CoreResourceKinds.DISCOVERYSPACE}
+    _SUPPORTED = {
+        CoreResourceKinds.OPERATION,
+        CoreResourceKinds.DISCOVERYSPACE,
+        CoreResourceKinds.SAMPLESTORE,
+    }
     if resource_type is not None and resource_type not in _SUPPORTED:
         console_print(
-            f"{ERROR}The 'stats' output format is only supported for operations "
-            f"and discovery spaces.",
+            f"{ERROR}The 'stats' output format is only supported for operations, "
+            f"discovery spaces, and sample stores.",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -341,6 +351,12 @@ def _handle_stats_format(
     with Status(ADO_SPINNER_GETTING_OUTPUT_READY) as status:
         if resource_type == CoreResourceKinds.DISCOVERYSPACE:
             enriched_df = format_ado_get_stats_for_spaces(
+                base_df,
+                sql_store_for_stats,
+                spinner=status,
+            )
+        elif resource_type == CoreResourceKinds.SAMPLESTORE:
+            enriched_df = format_ado_get_stats_for_samplestores(
                 base_df,
                 sql_store_for_stats,
                 spinner=status,

--- a/orchestrator/core/samplestore/stats.py
+++ b/orchestrator/core/samplestore/stats.py
@@ -1,12 +1,9 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 import pydantic
-
-if TYPE_CHECKING:
-    from orchestrator.core.samplestore.sql import SQLSampleStore
 
 
 class SampleStoreStatistics(pydantic.BaseModel):
@@ -36,26 +33,3 @@ class SampleStoreStatistics(pydantic.BaseModel):
             )
         ),
     ]
-
-
-def samplestore_statistics_for_stores(
-    stores: "SQLSampleStore | list[SQLSampleStore]",
-) -> "dict[str, SampleStoreStatistics]":
-    """Compute statistics for one or more sample stores.
-
-    Args:
-        stores: A single :class:`~orchestrator.core.samplestore.sql.SQLSampleStore`
-            instance or a list of them.  An empty list returns ``{}`` without
-            any database access.
-
-    Returns:
-        A ``dict`` mapping each store's
-        :attr:`~orchestrator.core.samplestore.sql.SQLSampleStore.identifier`
-        to its :class:`SampleStoreStatistics`.
-    """
-    store_list = stores if isinstance(stores, list) else [stores]
-
-    if not store_list:
-        return {}
-
-    return {store.identifier: store.samplestore_statistics() for store in store_list}

--- a/orchestrator/core/samplestore/stats.py
+++ b/orchestrator/core/samplestore/stats.py
@@ -49,7 +49,8 @@ def samplestore_statistics_for_stores(
             any database access.
 
     Returns:
-        A ``dict`` mapping each store's :attr:`~orchestrator.core.samplestore.base.ActiveSampleStore.uri`
+        A ``dict`` mapping each store's
+        :attr:`~orchestrator.core.samplestore.sql.SQLSampleStore.identifier`
         to its :class:`SampleStoreStatistics`.
     """
     store_list = stores if isinstance(stores, list) else [stores]
@@ -57,4 +58,4 @@ def samplestore_statistics_for_stores(
     if not store_list:
         return {}
 
-    return {store.uri: store.samplestore_statistics() for store in store_list}
+    return {store.identifier: store.samplestore_statistics() for store in store_list}

--- a/tests/ado/get/test_ado_get_stats.py
+++ b/tests/ado/get/test_ado_get_stats.py
@@ -392,7 +392,7 @@ def test_ado_get_space_stats_single_resource(
 
 
 @requires_sqlite_3_38
-@pytest.mark.parametrize("resource_kind", ["samplestores"])
+@pytest.mark.parametrize("resource_kind", ["actuatorconfigurations"])
 def test_ado_get_stats_unsupported_resource_type_exits_1(
     tmp_path: pathlib.Path,
     mysql_test_instance: MySqlContainer,
@@ -402,7 +402,7 @@ def test_ado_get_stats_unsupported_resource_type_exits_1(
     ],
     resource_kind: str,
 ) -> None:
-    """ado get <non-operation> -o stats exits 1 with an error message."""
+    """ado get <unsupported-resource> -o stats exits 1 with an error message."""
     runner = CliRunner()
     create_active_ado_context(
         runner=runner, path=tmp_path, project_context=valid_ado_project_context
@@ -424,3 +424,78 @@ def test_ado_get_stats_unsupported_resource_type_exits_1(
     if os.environ.get("CI", "false") != "true":
         assert "stats" in result.output.lower()
         assert "operation" in result.output.lower()
+
+
+@requires_sqlite_3_38
+def test_ado_get_samplestores_stats_values(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    ml_multi_cloud_sample_store: SQLSampleStore,
+    backdate_resource: Callable[[str, CoreResourceKinds, datetime.datetime], None],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Stats values for a known samplestore match expected counts in the rendered table."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_entities = 3
+    number_requests = 1
+
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=1,
+    )
+
+    after = ml_multi_cloud_sample_store.samplestore_statistics()
+    store_id = ml_multi_cloud_sample_store.identifier
+    backdate_resource(store_id, CoreResourceKinds.SAMPLESTORE, _CREATED_7_DAYS_AGO)
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "samplestores",
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        expected_output = pd.DataFrame(
+            data={
+                "IDENTIFIER": store_id,
+                "NAME": "ml_multi_cloud",
+                "AGE": _EXPECTED_AGE,
+                "ENTITIES": after.number_of_entities,
+                "RESULTS": after.number_of_results,
+                "EXPERIMENTS": after.number_of_experiments,
+            },
+            index=pd.Index([0]),
+        )
+        rendered_output = render_to_string(
+            dataframe_to_rich_table(
+                expected_output,
+                show_index=True,
+                show_edge=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            ),
+            auto_width=True,
+        )
+        assert (
+            rendered_output in result.output
+        ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"

--- a/tests/samplestore/test_samplestore_stats.py
+++ b/tests/samplestore/test_samplestore_stats.py
@@ -1,14 +1,11 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-"""Tests for SampleStoreStatistics model and samplestore_statistics_for_stores."""
+"""Tests for SampleStoreStatistics and SQLSampleStore.samplestore_statistics."""
 
 from collections.abc import Callable
 
 from orchestrator.core.samplestore.sql import SQLSampleStore
-from orchestrator.core.samplestore.stats import (
-    samplestore_statistics_for_stores,
-)
 from orchestrator.schema.request import MeasurementRequest
 
 # ---------------------------------------------------------------------------
@@ -66,59 +63,3 @@ def test_samplestore_statistics_reflect_simulation(
     experiment_refs = {str(r.experimentReference) for r in requests}
     assert len(experiment_refs) == 1
     assert after.number_of_experiments == before.number_of_experiments + 1
-
-
-# ---------------------------------------------------------------------------
-# samplestore_statistics_for_stores
-# ---------------------------------------------------------------------------
-
-
-def test_statistics_for_stores_empty_list_returns_empty_dict() -> None:
-    """An empty list returns {} without touching any database."""
-    assert samplestore_statistics_for_stores([]) == {}
-
-
-def test_statistics_for_stores_keyed_by_identifier_with_correct_counts(
-    simulate_ml_multi_cloud_random_walk_operation: Callable[
-        [int, int, int, str | None],
-        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
-    ],
-    empty_sample_store: SQLSampleStore,
-    random_identifier: Callable[[], str],
-) -> None:
-    """Returns one entry per store keyed by identifier; counts are consistent with direct calls.
-
-    Uses two stores — a populated ml_multi_cloud store and an empty store — to
-    verify that the batching wrapper delegates correctly and does not mix up results.
-    """
-    populated_store, _, _ = simulate_ml_multi_cloud_random_walk_operation(
-        number_entities=3,
-        number_requests=2,
-        measurements_per_result=1,
-        operation_id=random_identifier(),
-    )
-
-    # Sanity-check that the two stores are distinct
-    assert populated_store.identifier != empty_sample_store.identifier
-
-    result = samplestore_statistics_for_stores([populated_store, empty_sample_store])
-
-    assert set(result.keys()) == {
-        populated_store.identifier,
-        empty_sample_store.identifier,
-    }
-
-    # Results must match what direct calls return
-    assert (
-        result[populated_store.identifier] == populated_store.samplestore_statistics()
-    )
-    assert (
-        result[empty_sample_store.identifier]
-        == empty_sample_store.samplestore_statistics()
-    )
-
-    # The populated store must have more results than the empty one
-    assert (
-        result[populated_store.identifier].number_of_results
-        > result[empty_sample_store.identifier].number_of_results
-    )

--- a/tests/samplestore/test_samplestore_stats.py
+++ b/tests/samplestore/test_samplestore_stats.py
@@ -78,7 +78,7 @@ def test_statistics_for_stores_empty_list_returns_empty_dict() -> None:
     assert samplestore_statistics_for_stores([]) == {}
 
 
-def test_statistics_for_stores_keyed_by_uri_with_correct_counts(
+def test_statistics_for_stores_keyed_by_identifier_with_correct_counts(
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
@@ -86,7 +86,7 @@ def test_statistics_for_stores_keyed_by_uri_with_correct_counts(
     empty_sample_store: SQLSampleStore,
     random_identifier: Callable[[], str],
 ) -> None:
-    """Returns one entry per store keyed by uri; counts are consistent with direct calls.
+    """Returns one entry per store keyed by identifier; counts are consistent with direct calls.
 
     Uses two stores — a populated ml_multi_cloud store and an empty store — to
     verify that the batching wrapper delegates correctly and does not mix up results.
@@ -99,18 +99,26 @@ def test_statistics_for_stores_keyed_by_uri_with_correct_counts(
     )
 
     # Sanity-check that the two stores are distinct
-    assert populated_store.uri != empty_sample_store.uri
+    assert populated_store.identifier != empty_sample_store.identifier
 
     result = samplestore_statistics_for_stores([populated_store, empty_sample_store])
 
-    assert set(result.keys()) == {populated_store.uri, empty_sample_store.uri}
+    assert set(result.keys()) == {
+        populated_store.identifier,
+        empty_sample_store.identifier,
+    }
 
     # Results must match what direct calls return
-    assert result[populated_store.uri] == populated_store.samplestore_statistics()
-    assert result[empty_sample_store.uri] == empty_sample_store.samplestore_statistics()
+    assert (
+        result[populated_store.identifier] == populated_store.samplestore_statistics()
+    )
+    assert (
+        result[empty_sample_store.identifier]
+        == empty_sample_store.samplestore_statistics()
+    )
 
     # The populated store must have more results than the empty one
     assert (
-        result[populated_store.uri].number_of_results
-        > result[empty_sample_store.uri].number_of_results
+        result[populated_store.identifier].number_of_results
+        > result[empty_sample_store.identifier].number_of_results
     )

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -537,6 +537,7 @@ Where:
           `FAILED_RESULTS`, `MEASURED_ENTITIES`.
         - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`,
           `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
+        - **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
 
     <!-- prettier-ignore-end -->
 
@@ -749,6 +750,18 @@ ado get spaces -o stats
 
 ```shell
 ado get space --use-latest -o stats
+```
+
+##### Getting statistics for all Sample Stores
+
+```shell
+ado get samplestores -o stats
+```
+
+##### Getting statistics for a single Sample Store
+
+```shell
+ado get samplestore --use-latest -o stats
 ```
 
 ### ado show


### PR DESCRIPTION
## Add `ado get samplestores -o stats` support

**What changed**

`ado get -o stats` now works for **sample stores** in addition to the already-supported operations and discovery spaces.

**New behaviour**
Running `ado get samplestores -o stats` prints a table with three extra columns for each store:

| column | meaning |
|---|---|
| `ENTITIES` | number of entities recorded in the store |
| `RESULTS` | total measurement results |
| `EXPERIMENTS` | number of distinct experiments |

**Implementation changes (3 commits)**

1. **`formatters.py`** – adds `format_ado_get_stats_for_samplestores()`, a new formatter that batch-fetches all sample store resources in a single DB query and then calls `samplestore_statistics()` on each. Also refactors the existing operations stats formatter to use the same batch-fetch pattern (one fewer DB round-trip per store).

2. **`handlers.py`** – adds `CoreResourceKinds.SAMPLESTORE` to the set of supported resource types for the `stats` output format, wires in the new formatter, and updates the error message shown for unsupported types.

3. **`stats.py`** – removes the now-unused `samplestore_statistics_for_stores()` helper function.

**Docs & tests** – updated skill docs and user-facing `ado.md` getting-started guide; test coverage added for the new `ado get samplestores -o stats` path and the removed helper.

**Example**

```terminaloutput
(ado-core) alessandropomponio@MacBook-Pro-di-Alessandro ~/D/G/p/ado (ap_1084_ado_get_samplestore_o_stats)> ado get store default -o stats
┌───────┬────────────┬──────┬─────────┬──────────┬─────────┬─────────────┐
│ INDEX │ IDENTIFIER │ NAME │ AGE     │ ENTITIES │ RESULTS │ EXPERIMENTS │
├───────┼────────────┼──────┼─────────┼──────────┼─────────┼─────────────┤
│ 0     │ default    │      │ 117d23h │ 4416     │ 4680    │ 25          │
└───────┴────────────┴──────┴─────────┴──────────┴─────────┴─────────────┘
```