### PR TITLE
feat(core): calculate datacontainer stats

### DIFF
--- a/orchestrator/core/datacontainer/stats.py
+++ b/orchestrator/core/datacontainer/stats.py
@@ -1,0 +1,58 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+from typing import Annotated
+
+import pydantic
+
+
+class DataContainerStatistics(pydantic.BaseModel):
+    """Aggregated statistics for a single data container.
+
+    Attributes:
+        number_of_tables: Number of named tabular-data objects stored in the
+            container (``config.tabularData`` entries).
+        number_of_locations: Number of named location references stored in the
+            container (``config.locationData`` entries).
+        number_of_key_values: Number of named key-value entries stored in the
+            container (``config.data`` entries).
+        total_data_bytes: Approximate serialised size of ``tabularData``,
+            ``locationData``, and ``data``, excluding the ``metadata`` section.
+    """
+
+    number_of_tables: Annotated[
+        int,
+        pydantic.Field(
+            description=(
+                "Number of named tabular-data objects stored in the container "
+                "(config.tabularData entries)."
+            )
+        ),
+    ]
+    number_of_locations: Annotated[
+        int,
+        pydantic.Field(
+            description=(
+                "Number of named location references stored in the container "
+                "(config.locationData entries)."
+            )
+        ),
+    ]
+    number_of_key_values: Annotated[
+        int,
+        pydantic.Field(
+            description=(
+                "Number of named key-value entries stored in the container "
+                "(config.data entries)."
+            )
+        ),
+    ]
+    total_data_bytes: Annotated[
+        int,
+        pydantic.Field(
+            description=(
+                "Approximate serialised size of the three data fields "
+                "(tabularData, locationData, data), excluding the metadata section."
+            )
+        ),
+    ]

--- a/orchestrator/metastore/base.py
+++ b/orchestrator/metastore/base.py
@@ -9,6 +9,7 @@ import pydantic
 if TYPE_CHECKING:
     import pandas as pd
 
+    from orchestrator.core.datacontainer.stats import DataContainerStatistics
     from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
 
 from orchestrator.core.resources import ADOResource, CoreResourceKinds
@@ -355,6 +356,24 @@ class ResourceStore(abc.ABC):
             mapping each to its
             :class:`~orchestrator.core.discoveryspace.stats.DiscoverySpaceStatistics`.
             Space IDs that have no operations are included with zero counts.
+        """
+
+    @abc.abstractmethod
+    def get_datacontainer_stats(
+        self,
+        datacontainer_ids: set[str],
+    ) -> "dict[str, DataContainerStatistics]":
+        """Return lightweight statistics for a set of DataContainer IDs.
+
+        Args:
+            datacontainer_ids: A set of DataContainer identifiers to query.
+
+        Returns:
+            A ``dict`` keyed by DataContainer ID mapping each to its
+            :class:`~orchestrator.core.datacontainer.stats.DataContainerStatistics`.
+            IDs that are not present in the database are returned with all-zero
+            stats.  An empty input set returns an empty dict immediately
+            (no query issued).
         """
 
 

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -13,6 +13,7 @@ import orchestrator.core
 import orchestrator.metastore
 import orchestrator.metastore.sql.statements
 import orchestrator.utilities
+from orchestrator.core.datacontainer.stats import DataContainerStatistics
 from orchestrator.core.discoveryspace.stats import DiscoverySpaceStatistics
 from orchestrator.core.operation.config import DiscoveryOperationEnum
 from orchestrator.core.resources import ADOResourceEventEnum, CoreResourceKinds
@@ -1823,3 +1824,119 @@ class SQLResourceStore(ResourceStore):
             return result[space_ids]  # type: ignore[index,arg-type]
 
         return result
+
+    # ---------------------------------------------------------------------------
+    # DataContainer statistics
+    # ---------------------------------------------------------------------------
+
+    def get_datacontainer_stats(
+        self,
+        datacontainer_ids: set[str],
+    ) -> dict[str, DataContainerStatistics]:
+        """Return lightweight statistics for a set of DataContainer IDs.
+
+        Args:
+            datacontainer_ids: A set of DataContainer identifiers to query.
+
+        Returns:
+            A ``dict`` keyed by DataContainer ID mapping each to its
+            :class:`~orchestrator.core.datacontainer.stats.DataContainerStatistics`.
+            IDs that are not present in the database are returned with all-zero
+            stats.  An empty input set returns an empty dict immediately (no
+            query issued).
+
+        Raises:
+            SystemError: If the underlying SQL query fails.
+        """
+        if not datacontainer_ids:
+            return {}
+
+        # MySQL uses JSON_LENGTH() which counts object members correctly.
+        # SQLite's json_array_length() only counts array elements and returns 0
+        # for objects, so we use correlated subqueries with json_each() instead.
+        is_sqlite = self.engine.dialect.name == "sqlite"
+
+        if is_sqlite:
+            query_text = """
+                SELECT
+                    identifier,
+                    (SELECT count(*)
+                     FROM json_each(json_extract(data, '$.config.tabularData'))
+                    ) AS num_tables,
+                    (SELECT count(*)
+                     FROM json_each(json_extract(data, '$.config.locationData'))
+                    ) AS num_locations,
+                    (SELECT count(*)
+                     FROM json_each(json_extract(data, '$.config.data'))
+                    ) AS num_key_values,
+                    COALESCE(
+                        LENGTH(JSON_EXTRACT(data, '$.config'))
+                        - LENGTH(JSON_EXTRACT(data, '$.config.metadata')),
+                        0
+                    ) AS data_bytes
+                FROM resources
+                WHERE identifier IN :ids
+            """
+        else:
+            # On MySQL, JSON_LENGTH of a JSON null scalar returns 1 (scalar
+            # length is 1 per the spec).  We must guard with JSON_TYPE to
+            # return 0 for absent/null fields.
+            # For byte count, JSON_STORAGE_SIZE returns the actual binary
+            # storage size of the JSON value, which is more accurate than
+            # LENGTH(JSON_EXTRACT(...)) (text representation length).
+            query_text = """
+                SELECT
+                    identifier,
+                    IF(JSON_TYPE(data->'$.config.tabularData') = 'NULL',
+                       0, COALESCE(JSON_LENGTH(
+                           data->'$.config.tabularData'
+                       ), 0)) AS num_tables,
+                    IF(JSON_TYPE(data->'$.config.locationData') = 'NULL',
+                       0, COALESCE(JSON_LENGTH(
+                           data->'$.config.locationData'
+                       ), 0)) AS num_locations,
+                    IF(JSON_TYPE(data->'$.config.data') = 'NULL',
+                       0, COALESCE(JSON_LENGTH(
+                           data->'$.config.data'
+                       ), 0)) AS num_key_values,
+                    COALESCE(
+                        JSON_STORAGE_SIZE(JSON_EXTRACT(data, '$.config'))
+                        - JSON_STORAGE_SIZE(JSON_EXTRACT(data, '$.config.metadata')),
+                        0
+                    ) AS data_bytes
+                FROM resources
+                WHERE identifier IN :ids
+            """
+
+        try:
+            with self.engine.begin() as conn:
+                query = sqlalchemy.text(query_text).bindparams(
+                    sqlalchemy.bindparam("ids", expanding=True),
+                    ids=list(datacontainer_ids),
+                )
+                rows_by_id = {row.identifier: row for row in conn.execute(query)}
+        except Exception as error:
+            msg = f"Unable to get statistics for datacontainer(s) {datacontainer_ids}"
+            self.log.critical(f"{msg}. Error: {error}")
+            raise SystemError(f"{msg}. Error: {error}") from error
+
+        empty_stats = DataContainerStatistics(
+            number_of_tables=0,
+            number_of_locations=0,
+            number_of_key_values=0,
+            total_data_bytes=0,
+        )
+
+        return {
+            container_id: (
+                DataContainerStatistics(
+                    number_of_tables=row.num_tables,
+                    number_of_locations=row.num_locations,
+                    number_of_key_values=row.num_key_values,
+                    total_data_bytes=row.data_bytes,
+                )
+                if (row := rows_by_id.get(container_id)) is not None
+                else empty_stats
+            )
+            for container_id in datacontainer_ids
+        }

--- a/tests/core/test_datacontainer_statistics.py
+++ b/tests/core/test_datacontainer_statistics.py
@@ -1,0 +1,116 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Tests for DataContainerStatistics and SQLResourceStore.get_datacontainer_stats."""
+
+from collections.abc import Callable
+
+from orchestrator.core import DataContainerResource
+from orchestrator.core.datacontainer.resource import DataContainer, TabularData
+from orchestrator.core.resources import ADOResource
+from orchestrator.metastore.sqlstore import SQLStore
+from orchestrator.utilities.location import SQLStoreConfiguration
+
+# ---------------------------------------------------------------------------
+# Integration tests for SQLResourceStore.get_datacontainer_stats
+# ---------------------------------------------------------------------------
+
+
+def test_get_datacontainer_stats_empty_set_returns_empty_dict(
+    sql_store: SQLStore,
+) -> None:
+    """Passing an empty set returns {} immediately without any DB query."""
+    result = sql_store.get_datacontainer_stats(set())
+    assert result == {}
+
+
+def test_get_datacontainer_stats_all_fields(
+    sql_store: SQLStore,
+    create_resources: Callable[[list[ADOResource]], None],
+    testTabularDataString: TabularData,
+    test_sample_store_location: SQLStoreConfiguration,
+    random_identifier: Callable[[], str],
+) -> None:
+    """Container with tabularData, locationData, and data: all four counts match."""
+    data = {"key1": {"nested": "value"}, "key2": [1, 2, 3]}
+    dc = DataContainerResource(
+        config=DataContainer(
+            tabularData={"t1": testTabularDataString},
+            locationData={"loc1": test_sample_store_location},
+            data=data,
+        )
+    )
+    create_resources([dc])
+
+    result = sql_store.get_datacontainer_stats({dc.identifier})
+
+    assert dc.identifier in result
+    stats = result[dc.identifier]
+    assert stats.number_of_tables == 1
+    assert stats.number_of_locations == 1
+    assert stats.number_of_key_values == 2
+    assert stats.total_data_bytes > 0
+
+
+def test_get_datacontainer_stats_partial_fields(
+    sql_store: SQLStore,
+    create_resources: Callable[[list[ADOResource]], None],
+    random_identifier: Callable[[], str],
+) -> None:
+    """Container with only data set: tables and locations report 0."""
+    dc = DataContainerResource(
+        config=DataContainer(
+            data={"only_key": "only_value"},
+        )
+    )
+    create_resources([dc])
+
+    result = sql_store.get_datacontainer_stats({dc.identifier})
+
+    assert dc.identifier in result
+    stats = result[dc.identifier]
+    assert stats.number_of_tables == 0
+    assert stats.number_of_locations == 0
+    assert stats.number_of_key_values == 1
+    assert stats.total_data_bytes > 0
+
+
+def test_get_datacontainer_stats_total_data_bytes_excludes_metadata(
+    sql_store: SQLStore,
+    create_resources: Callable[[list[ADOResource]], None],
+    random_identifier: Callable[[], str],
+) -> None:
+    """total_data_bytes excludes the metadata field from the byte count."""
+    dc = DataContainerResource(
+        config=DataContainer(
+            data={"x": "y"},
+        )
+    )
+    create_resources([dc])
+
+    result = sql_store.get_datacontainer_stats({dc.identifier})
+    stats = result[dc.identifier]
+
+    # The reported bytes must exclude the metadata section.
+    # Verify by computing the full config size vs reported bytes:
+    # config JSON (all fields) > total_data_bytes because metadata is stripped.
+    import json
+
+    full_config_json = json.dumps(dc.config.model_dump())
+    full_config_bytes = len(full_config_json)
+    assert stats.total_data_bytes < full_config_bytes
+
+
+def test_get_datacontainer_stats_unknown_id_returns_zeros(
+    sql_store: SQLStore,
+) -> None:
+    """An ID not in the store is returned with all-zero stats."""
+    unknown_id = "datacontainer-does-not-exist"
+    result = sql_store.get_datacontainer_stats({unknown_id})
+
+    assert unknown_id in result
+    stats = result[unknown_id]
+    assert stats.number_of_tables == 0
+    assert stats.number_of_locations == 0
+    assert stats.number_of_key_values == 0
+    assert stats.total_data_bytes == 0


### PR DESCRIPTION
## Add DataContainer statistics

Introduces a `get_datacontainer_stats` method that returns lightweight,
aggregated statistics for one or more DataContainers in a single DB round-trip,
without loading full resource payloads.

### What changed

- **`orchestrator/core/datacontainer/stats.py`** *(new)* — `DataContainerStatistics`
  Pydantic model with four fields:
  - `number_of_tables` — count of `config.tabularData` entries
  - `number_of_locations` — count of `config.locationData` entries
  - `number_of_key_values` — count of `config.data` entries
  - `total_data_bytes` — approximate serialised size of those three fields,
    **excluding** the `metadata` section

- **`orchestrator/metastore/base.py`** — adds `get_datacontainer_stats` as an
  abstract method on `ResourceStore`, establishing the contract for all store
  implementations

- **`orchestrator/metastore/sqlstore.py`** — concrete SQL implementation;
  issues a single `SELECT` with inline JSON aggregation, with separate query
  paths for **SQLite** (`json_each`) and **MySQL** (`JSON_LENGTH` /
  `JSON_STORAGE_SIZE`); unknown IDs are returned with all-zero stats rather
  than raising

- **`tests/core/test_datacontainer_statistics.py`** *(new)* — integration
  tests covering: empty input, all-fields container, partial-fields container,
  byte-count excludes metadata, and unknown-ID zero-fallback