### PR TITLE
feat(cli): support -o stats in ado get datacontainer

### DIFF
--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -97,6 +97,14 @@ Goal: volume of work, recency, and which spaces attract the most operations.
 
    Adds `ENTITIES`, `RESULTS`, and `EXPERIMENTS` columns.
 
+6. **Data Containers (with statistics)**
+
+   ```bash
+   uv run ado get datacontainers -o stats --output-file datacontainers-stats.txt
+   ```
+
+   Adds `TABLES`, `LOCATIONS`, `KEY_VALUES`, and `DATA_BYTES` columns.
+
 **Synthesis:** cluster mentally (or in notes) by **creation time** to see bursts
 of activity; count operations **per space** from the operations listing to see
 which spaces are busiest.

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -84,7 +84,8 @@ type.
 ### Resource Statistics
 
 `-o stats` adds statistics columns to the table without fetching full resource
-data. Supported for **operations**, **discovery spaces**, and **sample stores**.
+data. Supported for **operations**, **discovery spaces**, **sample stores**, and
+**data containers**.
 
 ```bash
 # Operations
@@ -98,6 +99,10 @@ uv run ado get space SPACE_ID -o stats --no-trunc
 # Sample Stores
 uv run ado get samplestores -o stats --output-file samplestores-stats.txt
 uv run ado get samplestore SAMPLESTORE_ID -o stats --no-trunc
+
+# Data Containers
+uv run ado get datacontainers -o stats --output-file datacontainers-stats.txt
+uv run ado get datacontainer DATACONTAINER_ID -o stats --no-trunc
 ```
 
 **Operations** extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
@@ -108,6 +113,9 @@ result).
 `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
 
 **Sample Stores** extra columns: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
+
+**Data Containers** extra columns: `TABLES`, `LOCATIONS`, `KEY_VALUES`,
+`DATA_BYTES`.
 
 ### Filtering Resources
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -130,6 +130,10 @@ uv run ado get space SPACE_ID -o stats --no-trunc
 # Get statistics for all sample stores
 uv run ado get samplestores -o stats --output-file samplestores-stats.txt
 uv run ado get samplestore SAMPLESTORE_ID -o stats --no-trunc
+
+# Get statistics for all data containers
+uv run ado get datacontainers -o stats --output-file datacontainers-stats.txt
+uv run ado get datacontainer DATACONTAINER_ID -o stats --no-trunc
 ```
 
 `-o stats` extends the table with statistics columns:
@@ -139,6 +143,7 @@ uv run ado get samplestore SAMPLESTORE_ID -o stats --no-trunc
 - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`,
   `MEASURED_ENTITIES`.
 - **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
+- **Data Containers**: `TABLES`, `LOCATIONS`, `KEY_VALUES`, `DATA_BYTES`.
 
 ### ado create
 

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -130,7 +130,7 @@ def get_resource(
             "--output",
             "-o",
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
-            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES) and for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES). Not all formats may be supported by all resources.",
+            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES), for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES), for sample stores (ENTITIES, RESULTS, EXPERIMENTS), and for data containers (TABLES, LOCATIONS, KEY_VALUES, DATA_BYTES). Not all formats may be supported by all resources.",
         ),
     ] = AdoGetSupportedOutputFormats.TABLE.value,
     exclude_default: Annotated[

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -440,6 +440,76 @@ def format_ado_get_stats_for_samplestores(
     return df
 
 
+def _format_bytes(n: int) -> str:
+    """Return a compact human-readable representation of a byte count.
+
+    Uses 1024-based binary units (B, KiB, MiB, GiB, TiB).  Values below
+    1 KiB are shown as ``"<n> B"``.  Larger values are shown with one
+    decimal place and the appropriate unit suffix, e.g. ``"4.9 KiB"`` or
+    ``"1.2 MiB"``.
+
+    Args:
+        n: Number of bytes (non-negative integer).
+
+    Returns:
+        A short human-readable string such as ``"512 B"`` or ``"3.7 MiB"``.
+    """
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024:
+            return f"{n} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+        n //= 1024
+    return f"{n:.1f} TiB"
+
+
+def format_ado_get_stats_for_datacontainers(
+    df: "pd.DataFrame",
+    sql_store: "SQLStore",
+    spinner: "Status | None" = None,
+) -> "pd.DataFrame":
+    """Append 4 statistics columns to a data containers DataFrame.
+
+    Issues one batched stats query for all containers at once.
+
+    Args:
+        df: DataFrame with at least an ``IDENTIFIER`` column (one row per
+            data container).
+        sql_store: The ``SQLStore`` to use for stats queries.
+        spinner: Optional rich status spinner to update with progress messages.
+
+    Returns:
+        The same DataFrame with four extra columns appended:
+        ``TABLES``, ``LOCATIONS``, ``KEY_VALUES``, ``DATA_BYTES``.
+        ``DATA_BYTES`` is formatted as a human-readable size (e.g. ``"4.9 KB"``).
+        Containers with no recorded data show ``0`` / ``"0 B"`` in all stats columns.
+    """
+    datacontainer_ids: set[str] = set(df["IDENTIFIER"])
+
+    if spinner is not None:
+        spinner.update("Calculating stats for data containers...")
+
+    stats_by_id = sql_store.get_datacontainer_stats(datacontainer_ids)
+
+    _int_columns = [
+        ("TABLES", "number_of_tables"),
+        ("LOCATIONS", "number_of_locations"),
+        ("KEY_VALUES", "number_of_key_values"),
+    ]
+    for col, attr in _int_columns:
+        df[col] = df["IDENTIFIER"].apply(
+            lambda cid, a=attr: (
+                getattr(stats_by_id[cid], a, 0) if cid in stats_by_id else 0
+            )
+        )
+
+    df["DATA_BYTES"] = df["IDENTIFIER"].apply(
+        lambda cid: _format_bytes(
+            stats_by_id[cid].total_data_bytes if cid in stats_by_id else 0
+        )
+    )
+
+    return df
+
+
 def format_resource_for_ado_get_custom_format(
     to_print: (
         ADOResource

--- a/orchestrator/cli/utils/resources/handlers.py
+++ b/orchestrator/cli/utils/resources/handlers.py
@@ -31,6 +31,7 @@ from orchestrator.cli.utils.output.prints import (
     cyan,
 )
 from orchestrator.cli.utils.resources.formatters import (
+    format_ado_get_stats_for_datacontainers,
     format_ado_get_stats_for_operations,
     format_ado_get_stats_for_samplestores,
     format_ado_get_stats_for_spaces,
@@ -314,6 +315,7 @@ def _handle_stats_format(
     - discovery spaces (columns: EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS,
       MEASURED_ENTITIES)
     - sample stores (columns: ENTITIES, RESULTS, EXPERIMENTS)
+    - data containers (columns: TABLES, LOCATIONS, KEY_VALUES, DATA_BYTES)
 
     For any other resource type the handler prints an error message and exits
     with code 1.
@@ -324,11 +326,12 @@ def _handle_stats_format(
         CoreResourceKinds.OPERATION,
         CoreResourceKinds.DISCOVERYSPACE,
         CoreResourceKinds.SAMPLESTORE,
+        CoreResourceKinds.DATACONTAINER,
     }
     if resource_type is not None and resource_type not in _SUPPORTED:
         console_print(
             f"{ERROR}The 'stats' output format is only supported for operations, "
-            f"discovery spaces, and sample stores.",
+            f"discovery spaces, sample stores, and data containers.",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -357,6 +360,12 @@ def _handle_stats_format(
             )
         elif resource_type == CoreResourceKinds.SAMPLESTORE:
             enriched_df = format_ado_get_stats_for_samplestores(
+                base_df,
+                sql_store_for_stats,
+                spinner=status,
+            )
+        elif resource_type == CoreResourceKinds.DATACONTAINER:
+            enriched_df = format_ado_get_stats_for_datacontainers(
                 base_df,
                 sql_store_for_stats,
                 spinner=status,

--- a/tests/ado/get/test_ado_get_stats.py
+++ b/tests/ado/get/test_ado_get_stats.py
@@ -3,6 +3,7 @@
 import datetime
 import os
 import pathlib
+import typing
 from collections.abc import Callable
 
 import pandas as pd
@@ -19,6 +20,9 @@ from orchestrator.metastore.project import ProjectContext
 from orchestrator.schema.request import MeasurementRequest
 from orchestrator.utilities.rich import dataframe_to_rich_table, render_to_string
 from tests.conftest import requires_sqlite_3_38
+
+if typing.TYPE_CHECKING:
+    from orchestrator.core import DataContainerResource
 
 # A past timestamp far enough from "now" that AGE is stable across a test run.
 _CREATED_7_DAYS_AGO = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
@@ -483,6 +487,121 @@ def test_ado_get_samplestores_stats_values(
                 "ENTITIES": after.number_of_entities,
                 "RESULTS": after.number_of_results,
                 "EXPERIMENTS": after.number_of_experiments,
+            },
+            index=pd.Index([0]),
+        )
+        rendered_output = render_to_string(
+            dataframe_to_rich_table(
+                expected_output,
+                show_index=True,
+                show_edge=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            ),
+            auto_width=True,
+        )
+        assert (
+            rendered_output in result.output
+        ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"
+
+
+@requires_sqlite_3_38
+def test_ado_get_datacontainers_stats_columns_present(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    data_container_resource: "DataContainerResource",
+    create_resources: Callable,
+) -> None:
+    """ado get datacontainers -o stats exits 0 and shows all four stats column headers."""
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    create_resources([data_container_resource])
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "datacontainers",
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        for col in ("TABLES", "LOCATIONS", "KEY_VALUES", "DATA_BYTES"):
+            assert col in result.output, f"Column {col!r} missing from output"
+
+
+@requires_sqlite_3_38
+def test_ado_get_datacontainers_stats_values(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    data_container_resource: "DataContainerResource",
+    create_resources: Callable,
+    backdate_resource: Callable[[str, CoreResourceKinds, "datetime.datetime"], None],
+) -> None:
+    """Stats values for a known datacontainer match expected counts in the rendered table."""
+    from orchestrator.metastore.sqlstore import SQLStore
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    create_resources([data_container_resource])
+
+    sql_store = SQLStore(project_context=valid_ado_project_context)
+    stats_by_id = sql_store.get_datacontainer_stats(
+        {data_container_resource.identifier}
+    )
+    stats = stats_by_id[data_container_resource.identifier]
+
+    container_id = data_container_resource.identifier
+    backdate_resource(
+        container_id, CoreResourceKinds.DATACONTAINER, _CREATED_7_DAYS_AGO
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "datacontainers",
+            "-o",
+            "stats",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        from orchestrator.cli.utils.resources.formatters import _format_bytes
+
+        expected_output = pd.DataFrame(
+            data={
+                "IDENTIFIER": container_id,
+                "NAME": "",
+                "AGE": _EXPECTED_AGE,
+                "TABLES": stats.number_of_tables,
+                "LOCATIONS": stats.number_of_locations,
+                "KEY_VALUES": stats.number_of_key_values,
+                "DATA_BYTES": _format_bytes(stats.total_data_bytes),
             },
             index=pd.Index([0]),
         )

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -538,6 +538,8 @@ Where:
         - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`,
           `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
         - **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
+        - **Data Containers**: `TABLES`, `LOCATIONS`, `KEY_VALUES`,
+          `DATA_BYTES`.
 
     <!-- prettier-ignore-end -->
 
@@ -762,6 +764,18 @@ ado get samplestores -o stats
 
 ```shell
 ado get samplestore --use-latest -o stats
+```
+
+##### Getting statistics for all Data Containers
+
+```shell
+ado get datacontainers -o stats
+```
+
+##### Getting statistics for a single Data Container
+
+```shell
+ado get datacontainer --use-latest -o stats
 ```
 
 ### ado show


### PR DESCRIPTION
## Add `-o stats` support for `ado get datacontainer(s)`

Closes #1090

### What changed

- **CLI**: `ado get datacontainer` and `ado get datacontainers` now accept `-o stats`, extending the existing stats pattern already supported by operations, discovery spaces, and sample stores.
- **Formatter**: New `format_ado_get_stats_for_datacontainers()` function appends four columns to the output table:
  - `TABLES` — number of tables in the container
  - `LOCATIONS` — number of locations
  - `KEY_VALUES` — number of key-value entries
  - `DATA_BYTES` — total data size, formatted as a human-readable binary unit (e.g. `4.9 KiB`)
- **Handler**: `_handle_stats_format()` now routes `DATACONTAINER` resource type to the new formatter; the unsupported-format error message is updated accordingly.
- **Help text**: The `-o` flag description in `get.py` is updated to document the new data container columns.
- **Tests**: Two new integration tests cover the stats columns being present and the values matching the store.
- **Docs & skills**: `ado.md`, `using-ado-cli`, `query-ado-data`, and `examining-ado-project` skills updated with data container stats examples and column descriptions.

#### Example output

```
(ado-core) alessandropomponio@MacBook-Pro-di-Alessandro ~/D/G/p/ado (ap_1086_datacontainers_stats)> ado get dcr datacontainer-76f32618 -o stats
┌───────┬────────────────────────┬──────┬───────┬────────┬───────────┬────────────┬────────────┐
│ INDEX │ IDENTIFIER             │ NAME │ AGE   │ TABLES │ LOCATIONS │ KEY_VALUES │ DATA_BYTES │
├───────┼────────────────────────┼──────┼───────┼────────┼───────────┼────────────┼────────────┤
│ 0     │ datacontainer-76f32618 │      │ 16d3h │ 4      │ 0         │ 0          │ 254.0 KiB  │
└───────┴────────────────────────┴──────┴───────┴────────┴───────────┴────────────┴────────────┘
```