### PR TITLE
refactor(cli): improve exception handling in ado delete

### DIFF
--- a/orchestrator/cli/commands/delete.py
+++ b/orchestrator/cli/commands/delete.py
@@ -17,17 +17,74 @@ from orchestrator.cli.resources.discovery_space.delete import delete_discovery_s
 from orchestrator.cli.resources.operation.delete import delete_operation
 from orchestrator.cli.resources.sample_store.delete import delete_sample_store
 from orchestrator.cli.utils.input.parsers import enum_choice_with_plural_parser
-from orchestrator.cli.utils.output.prints import console_print
+from orchestrator.cli.utils.output.prints import (
+    cannot_delete_resource_due_to_children_resources,
+    console_print,
+    context_not_in_available_contexts_error_str,
+    could_not_delete_resource_from_database_error_str,
+)
 from orchestrator.metastore.base import (
+    ContextDoesNotExistError,
     DeleteFromDatabaseError,
+    NonEmptySampleStorePreventingDeletionError,
     NoRelatedResourcesError,
+    NotSupportedOnSQLiteError,
     ResourceDoesNotExistError,
+    ResourceHasChildrenError,
+    RunningOperationsPreventingDeletionError,
 )
 
 if typing.TYPE_CHECKING:
     from orchestrator.cli.core.config import AdoConfiguration
 
 CONTEXT_ONLY_PANEL_NAME = "Context-only options"
+
+
+def _deletion_error_message(resource_id: str, error: Exception) -> str:
+    from orchestrator.cli.utils.output.prints import (
+        ERROR,
+        HINT,
+        cyan,
+        magenta,
+    )
+
+    if isinstance(error, ResourceDoesNotExistError):
+        return "Resource does not exist"
+    if isinstance(error, ContextDoesNotExistError):
+        return context_not_in_available_contexts_error_str(
+            requested_context=error.resource_id,
+            available_contexts=error.available_contexts,
+        )
+    if isinstance(error, NoRelatedResourcesError):
+        return "No related resources found"
+    if isinstance(error, ResourceHasChildrenError):
+        return cannot_delete_resource_due_to_children_resources(
+            resource_kind=error.kind,
+            resource_id=error.resource_id,
+            children_resources=error.children_resources,
+        )
+    if isinstance(error, NotSupportedOnSQLiteError):
+        return (
+            f"{ERROR}Checking for running operations using the same sample store as "
+            f"operation {magenta(resource_id)} is not supported on local contexts.\n"
+            f"{HINT}Make sure there are no such operations, and force the deletion by adding the "
+            f"{cyan('--force')} flag."
+        )
+    if isinstance(error, RunningOperationsPreventingDeletionError):
+        return (
+            f"{ERROR}Operation {magenta(error.operation_id)} cannot be deleted "
+            f"because the following operations have started and have not completed: "
+            f"{error.running_operations}\n"
+            f"{HINT}You can force the deletion by adding the {cyan('--force')} flag."
+        )
+    if isinstance(error, NonEmptySampleStorePreventingDeletionError):
+        return (
+            f"{ERROR}{error}\n"
+            f"{HINT}You can force the deletion by adding the {cyan('--force')} flag."
+        )
+    if isinstance(error, DeleteFromDatabaseError):
+        return could_not_delete_resource_from_database_error_str(error)
+    return str(error)
 
 
 def _report_deletion_results(
@@ -47,15 +104,22 @@ def _report_deletion_results(
     """
     from orchestrator.cli.utils.output.prints import (
         SUCCESS,
-        console_print,
         magenta,
     )
 
     total = len(successes) + len(failures)
 
-    # If only one resource and it succeeded, use simple success message
-    if total == 1 and len(successes) == 1:
-        console_print(SUCCESS)
+    # If only one resource, avoid batch-style summary output.
+    if total == 1:
+        if successes:
+            console_print(SUCCESS)
+        elif failures:
+            console_print(
+                _deletion_error_message(
+                    resource_id=failures[0][0], error=failures[0][1]
+                ),
+                stderr=True,
+            )
         return
 
     # Report individual results
@@ -65,19 +129,10 @@ def _report_deletion_results(
         )
 
     for resource_id, error in failures:
-        error_msg = str(error)
-        # Extract meaningful error message
-        if isinstance(error, ResourceDoesNotExistError):
-            error_msg = "Resource does not exist"
-        elif isinstance(error, NoRelatedResourcesError):
-            error_msg = "No related resources found"
-        elif isinstance(error, DeleteFromDatabaseError):
-            error_msg = "Failed to delete from database"
-        elif "children" in error_msg.lower():
-            error_msg = "Cannot delete due to dependent resources"
-
         console_print(
-            f":x: Failed to delete {magenta(resource_id)}: {error_msg}", stderr=True
+            f"Failed to delete {resource_id}: "
+            f"{_deletion_error_message(resource_id=resource_id, error=error)}",
+            stderr=True,
         )
 
     # Summary
@@ -186,15 +241,16 @@ def delete_resource(
             method_mapping[resource_type](parameters=single_params)
             successes.append(resource_id)
         except (
+            ContextDoesNotExistError,
             ResourceDoesNotExistError,
+            ResourceHasChildrenError,
             NoRelatedResourcesError,
+            NotSupportedOnSQLiteError,
+            RunningOperationsPreventingDeletionError,
+            NonEmptySampleStorePreventingDeletionError,
             DeleteFromDatabaseError,
         ) as e:
             failures.append((resource_id, e))
-        except typer.Exit:
-            # Resource-specific delete functions may raise typer.Exit
-            # Treat this as a failure for this resource
-            failures.append((resource_id, Exception("Deletion failed")))
         finally:
             console_print("")
 

--- a/orchestrator/cli/commands/delete.py
+++ b/orchestrator/cli/commands/delete.py
@@ -114,10 +114,10 @@ def _report_deletion_results(
         if successes:
             console_print(SUCCESS)
         elif failures:
+            resource_id, error = failures[0]
             console_print(
-                _deletion_error_message(
-                    resource_id=failures[0][0], error=failures[0][1]
-                ),
+                f"Failed to delete {resource_id}: "
+                f"{_deletion_error_message(resource_id=resource_id, error=error)}",
                 stderr=True,
             )
         return

--- a/orchestrator/cli/resources/actuator_configuration/delete.py
+++ b/orchestrator/cli/resources/actuator_configuration/delete.py
@@ -1,7 +1,6 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-import typer
 from rich.status import Status
 
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
@@ -9,19 +8,25 @@ from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.output.prints import (
     ADO_SPINNER_DELETING_FROM_DB,
     ADO_SPINNER_QUERYING_DB,
-    SUCCESS,
-    cannot_delete_resource_due_to_children_resources,
-    console_print,
 )
 from orchestrator.core import CoreResourceKinds
 from orchestrator.metastore.base import (
-    DeleteFromDatabaseError,
     ResourceDoesNotExistError,
+    ResourceHasChildrenError,
 )
 
 
 def delete_actuator_configuration(parameters: AdoDeleteCommandParameters) -> None:
-    # Extract the single resource_id from the list
+    """Delete a single actuator configuration.
+
+    Args:
+        parameters: Delete command parameters containing the actuator configuration id.
+
+    Raises:
+        ResourceDoesNotExistError: If the actuator configuration does not exist.
+        ResourceHasChildrenError: If the actuator configuration has dependent resources.
+        DeleteFromDatabaseError: If a database error occurs during deletion.
+    """
     resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
@@ -42,21 +47,15 @@ def delete_actuator_configuration(parameters: AdoDeleteCommandParameters) -> Non
 
         if not children_resources.empty:
             spinner.stop()
-            console_print(
-                cannot_delete_resource_due_to_children_resources(
-                    resource_kind=CoreResourceKinds.ACTUATORCONFIGURATION,
-                    resource_id=resource_id,
-                    children_resources=children_resources,
-                ),
-                stderr=True,
+            raise ResourceHasChildrenError(
+                resource_id=resource_id,
+                kind=CoreResourceKinds.ACTUATORCONFIGURATION,
+                children_resources=children_resources,
             )
-            raise typer.Exit(1)
 
         spinner.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
             sql.delete_actuator_configuration(resource_id)
-        except DeleteFromDatabaseError:
+        except Exception:
             spinner.stop()
             raise
-
-    console_print(SUCCESS, stderr=True)

--- a/orchestrator/cli/resources/context/delete.py
+++ b/orchestrator/cli/resources/context/delete.py
@@ -1,37 +1,32 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-import typer
 import yaml
 from rich.prompt import Confirm
 
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
-from orchestrator.cli.utils.output.prints import (
-    HINT,
-    INFO,
-    SUCCESS,
-    WARN,
-    console_print,
-    context_not_in_available_contexts_error_str,
-    cyan,
-)
+from orchestrator.cli.utils.output.prints import HINT, INFO, WARN, console_print, cyan
+from orchestrator.metastore.base import ContextDoesNotExistError
 from orchestrator.utilities.dictionaries import get_nested_value
 
 
 def delete_context(parameters: AdoDeleteCommandParameters) -> None:
-    # Extract the single resource_id from the list
+    """Delete a single context.
+
+    Args:
+        parameters: Delete command parameters containing the context id and options.
+
+    Raises:
+        ContextDoesNotExistError: If the requested context does not exist.
+    """
     resource_id = parameters.resource_ids[0]
 
     available_contexts = parameters.ado_configuration.available_contexts
     if resource_id not in available_contexts:
-        console_print(
-            context_not_in_available_contexts_error_str(
-                requested_context=resource_id,
-                available_contexts=available_contexts,
-            ),
-            stderr=True,
+        raise ContextDoesNotExistError(
+            resource_id=resource_id,
+            available_contexts=available_contexts,
         )
-        raise typer.Exit(1)
 
     configuration_file = parameters.ado_configuration.project_context_path_for_context(
         resource_id
@@ -64,7 +59,6 @@ def delete_context(parameters: AdoDeleteCommandParameters) -> None:
             )
 
     configuration_file.unlink()
-    console_print(SUCCESS, stderr=True)
 
     if resource_id == parameters.ado_configuration.active_context:
         parameters.ado_configuration.active_context = None

--- a/orchestrator/cli/resources/data_container/delete.py
+++ b/orchestrator/cli/resources/data_container/delete.py
@@ -1,7 +1,6 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-import typer
 from rich.status import Status
 
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
@@ -9,19 +8,25 @@ from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.output.prints import (
     ADO_SPINNER_DELETING_FROM_DB,
     ADO_SPINNER_QUERYING_DB,
-    SUCCESS,
-    cannot_delete_resource_due_to_children_resources,
-    console_print,
 )
 from orchestrator.core import CoreResourceKinds
 from orchestrator.metastore.base import (
-    DeleteFromDatabaseError,
     ResourceDoesNotExistError,
+    ResourceHasChildrenError,
 )
 
 
 def delete_data_container(parameters: AdoDeleteCommandParameters) -> None:
-    # Extract the single resource_id from the list
+    """Delete a single data container.
+
+    Args:
+        parameters: Delete command parameters containing the data container id.
+
+    Raises:
+        ResourceDoesNotExistError: If the data container does not exist.
+        ResourceHasChildrenError: If the data container has dependent resources.
+        DeleteFromDatabaseError: If a database error occurs during deletion.
+    """
     resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
@@ -40,21 +45,15 @@ def delete_data_container(parameters: AdoDeleteCommandParameters) -> None:
         )
         if not children_resources.empty:
             status.stop()
-            console_print(
-                cannot_delete_resource_due_to_children_resources(
-                    resource_kind=CoreResourceKinds.DATACONTAINER,
-                    resource_id=resource_id,
-                    children_resources=children_resources,
-                ),
-                stderr=True,
+            raise ResourceHasChildrenError(
+                resource_id=resource_id,
+                kind=CoreResourceKinds.DATACONTAINER,
+                children_resources=children_resources,
             )
-            raise typer.Exit(1)
 
         status.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
-            sql.delete_discovery_space(identifier=resource_id)
-        except DeleteFromDatabaseError:
+            sql.delete_data_container(identifier=resource_id)
+        except Exception:
             status.stop()
             raise
-
-    console_print(SUCCESS)

--- a/orchestrator/cli/resources/discovery_space/delete.py
+++ b/orchestrator/cli/resources/discovery_space/delete.py
@@ -1,7 +1,6 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-import typer
 from rich.status import Status
 
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
@@ -9,19 +8,25 @@ from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.output.prints import (
     ADO_SPINNER_DELETING_FROM_DB,
     ADO_SPINNER_QUERYING_DB,
-    SUCCESS,
-    cannot_delete_resource_due_to_children_resources,
-    console_print,
 )
 from orchestrator.core import CoreResourceKinds
 from orchestrator.metastore.base import (
-    DeleteFromDatabaseError,
     ResourceDoesNotExistError,
+    ResourceHasChildrenError,
 )
 
 
 def delete_discovery_space(parameters: AdoDeleteCommandParameters) -> None:
-    # Extract the single resource_id from the list
+    """Delete a single discovery space.
+
+    Args:
+        parameters: Delete command parameters containing the discovery space id.
+
+    Raises:
+        ResourceDoesNotExistError: If the discovery space does not exist.
+        ResourceHasChildrenError: If the discovery space has dependent resources.
+        DeleteFromDatabaseError: If a database error occurs during deletion.
+    """
     resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
@@ -41,21 +46,15 @@ def delete_discovery_space(parameters: AdoDeleteCommandParameters) -> None:
         )
         if not children_resources.empty:
             status.stop()
-            console_print(
-                cannot_delete_resource_due_to_children_resources(
-                    resource_kind=CoreResourceKinds.DISCOVERYSPACE,
-                    resource_id=resource_id,
-                    children_resources=children_resources,
-                ),
-                stderr=True,
+            raise ResourceHasChildrenError(
+                resource_id=resource_id,
+                kind=CoreResourceKinds.DISCOVERYSPACE,
+                children_resources=children_resources,
             )
-            raise typer.Exit(1)
 
         status.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
             sql.delete_discovery_space(identifier=resource_id)
-        except DeleteFromDatabaseError:
+        except Exception:
             status.stop()
             raise
-
-    console_print(SUCCESS)

--- a/orchestrator/cli/resources/operation/delete.py
+++ b/orchestrator/cli/resources/operation/delete.py
@@ -1,7 +1,6 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-import typer
 from rich.status import Status
 
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
@@ -11,25 +10,28 @@ from orchestrator.cli.utils.generic.wrappers import (
 from orchestrator.cli.utils.output.prints import (
     ADO_SPINNER_DELETING_FROM_DB,
     ADO_SPINNER_QUERYING_DB,
-    ERROR,
-    HINT,
-    SUCCESS,
-    cannot_delete_resource_due_to_children_resources,
-    console_print,
-    cyan,
-    magenta,
 )
 from orchestrator.core.resources import CoreResourceKinds
 from orchestrator.metastore.base import (
-    DeleteFromDatabaseError,
-    NotSupportedOnSQLiteError,
     ResourceDoesNotExistError,
-    RunningOperationsPreventingDeletionError,
+    ResourceHasChildrenError,
 )
 
 
 def delete_operation(parameters: AdoDeleteCommandParameters) -> None:
-    # Extract the single resource_id from the list
+    """Delete a single operation.
+
+    Args:
+        parameters: Delete command parameters containing the operation id and options.
+
+    Raises:
+        ResourceDoesNotExistError: If the operation does not exist.
+        ResourceHasChildrenError: If the operation has dependent resources.
+        NotSupportedOnSQLiteError: If running-operations check is not supported on SQLite.
+        RunningOperationsPreventingDeletionError: If running operations are using the same
+            sample store.
+        DeleteFromDatabaseError: If a database error occurs during deletion.
+    """
     resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
@@ -48,15 +50,11 @@ def delete_operation(parameters: AdoDeleteCommandParameters) -> None:
         )
         if not children_resources.empty:
             status.stop()
-            console_print(
-                cannot_delete_resource_due_to_children_resources(
-                    resource_kind=CoreResourceKinds.OPERATION,
-                    resource_id=resource_id,
-                    children_resources=children_resources,
-                ),
-                stderr=True,
+            raise ResourceHasChildrenError(
+                resource_id=resource_id,
+                kind=CoreResourceKinds.OPERATION,
+                children_resources=children_resources,
             )
-            raise typer.Exit(1)
 
         status.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
@@ -64,28 +62,6 @@ def delete_operation(parameters: AdoDeleteCommandParameters) -> None:
                 identifier=resource_id,
                 ignore_running_operations=parameters.force,
             )
-        except NotSupportedOnSQLiteError as e:
-            status.stop()
-            console_print(
-                f"{ERROR}Checking for running operations using the same sample store as "
-                f"operation {magenta(resource_id)} is not supported on local contexts.\n"
-                f"{HINT}Make sure there are no such operations, and force the deletion by adding the "
-                f"{cyan('--force')} flag.",
-                stderr=True,
-            )
-            raise typer.Exit(1) from e
-        except RunningOperationsPreventingDeletionError as e:
-            status.stop()
-            console_print(
-                f"{ERROR}Operation {magenta(e.operation_id)} cannot be deleted "
-                f"because the following operations have started and have not completed: "
-                f"{e.running_operations}\n"
-                f"{HINT}You can force the deletion by adding the {cyan('--force')} flag.",
-                stderr=True,
-            )
-            raise typer.Exit(1) from e
-        except DeleteFromDatabaseError:
+        except Exception:
             status.stop()
             raise
-
-    console_print(SUCCESS)

--- a/orchestrator/cli/resources/sample_store/delete.py
+++ b/orchestrator/cli/resources/sample_store/delete.py
@@ -1,7 +1,6 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
-import typer
 from rich.status import Status
 
 from orchestrator.cli.models.parameters import AdoDeleteCommandParameters
@@ -9,23 +8,27 @@ from orchestrator.cli.utils.generic.wrappers import get_sql_store
 from orchestrator.cli.utils.output.prints import (
     ADO_SPINNER_DELETING_FROM_DB,
     ADO_SPINNER_QUERYING_DB,
-    ERROR,
-    HINT,
-    SUCCESS,
-    cannot_delete_resource_due_to_children_resources,
-    console_print,
-    cyan,
 )
 from orchestrator.core import CoreResourceKinds
 from orchestrator.metastore.base import (
-    DeleteFromDatabaseError,
-    NonEmptySampleStorePreventingDeletionError,
     ResourceDoesNotExistError,
+    ResourceHasChildrenError,
 )
 
 
 def delete_sample_store(parameters: AdoDeleteCommandParameters) -> None:
-    # Extract the single resource_id from the list
+    """Delete a single sample store.
+
+    Args:
+        parameters: Delete command parameters containing the sample store id and options.
+
+    Raises:
+        ResourceDoesNotExistError: If the sample store does not exist.
+        ResourceHasChildrenError: If the sample store has dependent resources.
+        NonEmptySampleStorePreventingDeletionError: If the sample store contains data
+            and force deletion was not requested.
+        DeleteFromDatabaseError: If a database error occurs during deletion.
+    """
     resource_id = parameters.resource_ids[0]
 
     sql = get_sql_store(project_context=parameters.ado_configuration.project_context)
@@ -45,30 +48,17 @@ def delete_sample_store(parameters: AdoDeleteCommandParameters) -> None:
 
         if not children_resources.empty:
             spinner.stop()
-            console_print(
-                cannot_delete_resource_due_to_children_resources(
-                    resource_kind=CoreResourceKinds.SAMPLESTORE,
-                    resource_id=resource_id,
-                    children_resources=children_resources,
-                ),
-                stderr=True,
+            raise ResourceHasChildrenError(
+                resource_id=resource_id,
+                kind=CoreResourceKinds.SAMPLESTORE,
+                children_resources=children_resources,
             )
-            raise typer.Exit(1)
 
         spinner.update(ADO_SPINNER_DELETING_FROM_DB)
         try:
             sql.delete_sample_store(
                 identifier=resource_id, force_deletion=parameters.force
             )
-        except NonEmptySampleStorePreventingDeletionError as e:
-            spinner.stop()
-            console_print(
-                f"{ERROR}{e}\n{HINT}You can force the deletion by adding the {cyan('--force')} flag.",
-                stderr=True,
-            )
-            raise typer.Exit(1) from e
-        except DeleteFromDatabaseError:
+        except Exception:
             spinner.stop()
             raise
-
-    console_print(SUCCESS)

--- a/orchestrator/metastore/base.py
+++ b/orchestrator/metastore/base.py
@@ -40,6 +40,28 @@ class NoRelatedResourcesError(ValueError):
         )
 
 
+class ResourceHasChildrenError(ValueError):
+    def __init__(
+        self,
+        resource_id: str,
+        kind: CoreResourceKinds,
+        children_resources: "pd.DataFrame",
+    ) -> None:
+        self.resource_id = resource_id
+        self.kind = kind
+        self.children_resources = children_resources
+        super().__init__(
+            f"Cannot delete {kind.value} {resource_id} because it has children resources"
+        )
+
+
+class ContextDoesNotExistError(ValueError):
+    def __init__(self, resource_id: str, available_contexts: list[str]) -> None:
+        self.resource_id = resource_id
+        self.available_contexts = available_contexts
+        super().__init__(f"Context {resource_id} does not exist")
+
+
 class DatabaseOperationError(Exception): ...
 
 


### PR DESCRIPTION
## Refactor `ado delete` exception handling

### What changed

**`ado delete` — error handling refactor (main change)**

Individual per-resource delete functions (`delete_operation`, `delete_discovery_space`, `delete_sample_store`, `delete_actuator_configuration`, `delete_context`, `delete_data_container`) previously each handled their own error display and raised `typer.Exit` directly.

They now raise typed exceptions instead and let the top-level `delete` command absorb and format them.

- New exceptions added to `metastore/base.py`: `ResourceHasChildrenError`, `ContextDoesNotExistError`
- New helper `_deletion_error_message()` in `delete.py` maps every known exception type to a user-facing string with `ERROR`/`HINT` formatting
- `_report_deletion_results()` updated: single-resource failures now print a plain failure message instead of silently swallowing the error
- Per-resource delete functions stripped of all `console_print`/`typer.Exit` calls — they only raise

**`ado delete` — also fixed: `delete_data_container` was calling `delete_discovery_space` internally (copy-paste bug)**
