### PR TITLE
feat(core): extend DiscoverySpaceStatistics with all stats from summary

### DIFF
--- a/orchestrator/cli/models/space.py
+++ b/orchestrator/cli/models/space.py
@@ -53,52 +53,14 @@ class SpaceDetails:
 
     @classmethod
     def from_space(cls, space: DiscoverySpace) -> "SpaceDetails":
-        import pandas as pd
-
-        # Delegate most fields to space_statistics(lightweight_only=False).
-        # The two "all/partial measurements" fields are not tracked in
-        # DiscoverySpaceStatistics, so we keep a targeted pandas iteration for
-        # those only.
         stats = space.space_statistics(lightweight_only=False)
 
-        # Entities sampled in the space — needed only to compute all/partial split
-        measured_entities_table = space.measuredEntitiesTable(property_type="target")
-        if (
-            measured_entities_table.empty
-            or "identifier" not in measured_entities_table.columns
-        ):
-            measured_entities_table["identifier"] = pd.Series(dtype="str")
-
-        experiments_in_measurement_space = len(space.measurementSpace.experiments)
-        entities_sampled_from_space_with_all_measurements_applied = 0
-        for _, group in measured_entities_table.groupby("identifier"):
-            if group.shape[0] == experiments_in_measurement_space:
-                entities_sampled_from_space_with_all_measurements_applied += 1
-
-        entities_sampled_from_space_with_partial_measurements_applied = (
-            len(measured_entities_table["identifier"].unique())
-            - entities_sampled_from_space_with_all_measurements_applied
-        )
-
-        # Matching entities with measurement space applied — targeted pandas iteration
-        matching_entities_table = space.matchingEntitiesTable(property_type="target")
-        if (
-            matching_entities_table.empty
-            or "identifier" not in matching_entities_table.columns
-        ):
-            matching_entities_table["identifier"] = pd.Series(dtype="str")
-
-        matching_entities_in_sample_store_with_measurement_space_applied = 0
-        for _, group in matching_entities_table.groupby("identifier"):
-            if group.shape[0] == experiments_in_measurement_space:
-                matching_entities_in_sample_store_with_measurement_space_applied += 1
-
         return cls(
-            entities_sampled_from_space_with_all_measurements_applied=entities_sampled_from_space_with_all_measurements_applied,
-            entities_sampled_from_space_with_partial_measurements_applied=entities_sampled_from_space_with_partial_measurements_applied,
+            entities_sampled_from_space_with_all_measurements_applied=stats.entities_with_all_measurements,
+            entities_sampled_from_space_with_partial_measurements_applied=stats.entities_with_partial_measurements,
             entities_yet_to_be_sampled_and_measured_from_space=stats.number_unmeasured_entities,
             entities_matching_the_space=stats.number_matching_entities,
-            matching_entities_in_sample_store_with_measurement_space_applied=matching_entities_in_sample_store_with_measurement_space_applied,
+            matching_entities_in_sample_store_with_measurement_space_applied=stats.matching_entities_with_all_measurements,
             size_of_entity_space=stats.size_of_entity_space,
         )
 

--- a/orchestrator/core/discoveryspace/stats.py
+++ b/orchestrator/core/discoveryspace/stats.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class DiscoverySpaceStatistics(pydantic.BaseModel):
     """Aggregated statistics for a single discovery space.
 
-    Lightweight fields are always populated.  Heavy fields (those that require
+    Lightweight fields are always populated. Heavy fields (those that require
     Python-side computation) are ``None`` when ``lightweight_only=True`` was
     requested or when the field is not applicable (e.g. the entity space is
     continuous or not defined).
@@ -29,19 +29,28 @@ class DiscoverySpaceStatistics(pydantic.BaseModel):
         number_measured_entities: DISTINCT entity IDs that appear in at least one
             measurement result across all operations on this space.
         size_of_entity_space: Total number of points in the entity space when the
-            space is discrete.  ``None`` if the space is continuous, not defined,
+            space is discrete. ``None`` if the space is continuous, not defined,
             or ``lightweight_only=True``.
         number_unmeasured_entities: ``size_of_entity_space`` minus
-            ``number_measured_entities``.  ``None`` when ``lightweight_only=True``.
+            ``number_measured_entities``. ``None`` when ``lightweight_only=True``.
             May be ``math.inf`` for continuous spaces or ``math.nan`` when
             ``size_of_entity_space`` could not be determined.
         number_matching_entities: Count of entities in the sample store that
-            satisfy ``isEntityInSpace`` for this space.  ``None`` when
+            satisfy ``isEntityInSpace`` for this space. ``None`` when
             ``lightweight_only=True``.
         number_matching_entities_with_measurements: Subset of
             ``number_matching_entities`` that have at least one measurement whose
-            experiment reference is in the space's measurement space.  ``None``
+            experiment reference is in the space's measurement space. ``None``
             when ``lightweight_only=True``.
+        entities_with_all_measurements: Entities in the space that have a result
+            for every experiment in the measurement space. ``None`` when
+            ``lightweight_only=True``.
+        entities_with_partial_measurements: Entities with at least one result but
+            not for every experiment in the measurement space. ``None`` when
+            ``lightweight_only=True``.
+        matching_entities_with_all_measurements: Matching entities in the sample
+            store that have a result for every experiment in the measurement
+            space. ``None`` when ``lightweight_only=True``.
     """
 
     # --- Lightweight fields (always populated) ---
@@ -117,6 +126,36 @@ class DiscoverySpaceStatistics(pydantic.BaseModel):
             ),
         ),
     ]
+    entities_with_all_measurements: Annotated[
+        int | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Entities in the space that have a result for every experiment in "
+                "the measurement space. None when lightweight_only=True."
+            ),
+        ),
+    ]
+    entities_with_partial_measurements: Annotated[
+        int | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Entities with at least one result but not for every experiment in "
+                "the measurement space. None when lightweight_only=True."
+            ),
+        ),
+    ]
+    matching_entities_with_all_measurements: Annotated[
+        int | None,
+        pydantic.Field(
+            default=None,
+            description=(
+                "Matching entities in the sample store that have a result for every "
+                "experiment in the measurement space. None when lightweight_only=True."
+            ),
+        ),
+    ]
 
 
 def lightweight_space_statistics(
@@ -188,6 +227,9 @@ def lightweight_space_statistics(
             number_unmeasured_entities=None,
             number_matching_entities=None,
             number_matching_entities_with_measurements=None,
+            entities_with_all_measurements=None,
+            entities_with_partial_measurements=None,
+            matching_entities_with_all_measurements=None,
         )
         for space_id in space_ids
     }
@@ -282,6 +324,30 @@ def space_statistics_for_spaces(
             and not measurement_exp_refs.isdisjoint(set(e.experimentReferences))
         )
 
+        measured_entities_table = space.measuredEntitiesTable(property_type="target")
+        experiments_in_measurement_space = len(space.measurementSpace.experiments)
+        entities_with_all_measurements = 0
+        if (
+            not measured_entities_table.empty
+            and "identifier" in measured_entities_table
+        ):
+            for _, group in measured_entities_table.groupby("identifier"):
+                if group.shape[0] == experiments_in_measurement_space:
+                    entities_with_all_measurements += 1
+        entities_with_partial_measurements = (
+            number_measured - entities_with_all_measurements
+        )
+
+        matching_entities_table = space.matchingEntitiesTable(property_type="target")
+        matching_entities_with_all_measurements = 0
+        if (
+            not matching_entities_table.empty
+            and "identifier" in matching_entities_table
+        ):
+            for _, group in matching_entities_table.groupby("identifier"):
+                if group.shape[0] == experiments_in_measurement_space:
+                    matching_entities_with_all_measurements += 1
+
         result[space.uri] = DiscoverySpaceStatistics(
             number_of_experiments=base.number_of_experiments,
             number_of_operations=base.number_of_operations,
@@ -291,6 +357,9 @@ def space_statistics_for_spaces(
             number_unmeasured_entities=number_unmeasured,
             number_matching_entities=number_matching,
             number_matching_entities_with_measurements=number_matching_with_measurements,
+            entities_with_all_measurements=entities_with_all_measurements,
+            entities_with_partial_measurements=entities_with_partial_measurements,
+            matching_entities_with_all_measurements=matching_entities_with_all_measurements,
         )
 
     return result

--- a/tests/core/test_space_statistics.py
+++ b/tests/core/test_space_statistics.py
@@ -30,6 +30,9 @@ def test_heavy_fields_default_to_none() -> None:
     assert stats.number_unmeasured_entities is None
     assert stats.number_matching_entities is None
     assert stats.number_matching_entities_with_measurements is None
+    assert stats.entities_with_all_measurements is None
+    assert stats.entities_with_partial_measurements is None
+    assert stats.matching_entities_with_all_measurements is None
 
 
 def test_nan_unmeasured_entities_round_trip() -> None:
@@ -97,6 +100,9 @@ def test_space_statistics_lightweight_only(
     assert stats.number_unmeasured_entities is None
     assert stats.number_matching_entities is None
     assert stats.number_matching_entities_with_measurements is None
+    assert stats.entities_with_all_measurements is None
+    assert stats.entities_with_partial_measurements is None
+    assert stats.matching_entities_with_all_measurements is None
 
 
 @requires_sqlite_3_38
@@ -119,6 +125,7 @@ def test_space_statistics_full_no_operations(
     assert (
         stats.number_matching_entities_with_measurements == _NUMBER_OF_MATCHING_ENTITIES
     )
+    assert stats.matching_entities_with_all_measurements == _NUMBER_OF_MATCHING_ENTITIES
 
 
 @requires_sqlite_3_38
@@ -131,9 +138,12 @@ def test_space_statistics_full_with_operation(
 ) -> None:
     """Full stats reflect exact measured-entity counts after a single operation."""
     number_entities = 3
+    number_requests = 1
+    measurements_per_result = 2
     simulate_ml_multi_cloud_random_walk_operation(
         number_entities=number_entities,
-        number_requests=1,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
     )
 
     stats = ml_multi_cloud_space.space_statistics(lightweight_only=False)
@@ -150,6 +160,13 @@ def test_space_statistics_full_with_operation(
     # so all matching entities have measurements regardless of the simulated operation
     assert (
         stats.number_matching_entities_with_measurements == _NUMBER_OF_MATCHING_ENTITIES
+    )
+    assert stats.matching_entities_with_all_measurements == _NUMBER_OF_MATCHING_ENTITIES
+    assert stats.entities_with_all_measurements == number_entities
+    assert stats.entities_with_partial_measurements == 0
+    assert (
+        stats.entities_with_all_measurements + stats.entities_with_partial_measurements
+        == number_entities * number_requests
     )
 
 


### PR DESCRIPTION
## Extend `DiscoverySpaceStatistics` with full/partial measurement counts

Closes #1102

### What changed

Three new fields were added to `DiscoverySpaceStatistics` (in `orchestrator/core/discoveryspace/stats.py`):

| Field | Description |
|---|---|
| `entities_with_all_measurements` | Entities in the space that have a result for **every** experiment in the measurement space |
| `entities_with_partial_measurements` | Entities with **at least one** result but not a complete set |
| `matching_entities_with_all_measurements` | Matching entities in the sample store that have a result for every experiment |

All three fields follow the existing convention: they are `None` when `lightweight_only=True`.

The computation logic that previously lived inline in `SpaceDetails.from_space()` (CLI display model) was moved into `space_statistics_for_spaces()`, which is the correct place for it. As a result, `SpaceDetails.from_space()` now simply reads the values off `stats`, removing ~35 lines of pandas iteration code from the CLI layer.

Tests in `tests/core/test_space_statistics.py` were extended to assert the new fields are `None` in lightweight mode and carry correct counts in full mode.