### PR TITLE
feat(cli): add ado show stats

### DIFF
--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -229,15 +229,9 @@ trace, use:
 uv run ado show stats operation $OPERATION_ID
 ```
 
-This outputs the base table columns plus `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-`FAILED_RESULTS`, `MEASURED_ENTITIES`, `TOTAL_REQUESTS`, `FAILED_REQUESTS`,
-`SUCCESSFUL_REQUESTS`.
-
-For the full detail view:
-
-```bash
-uv run ado show details operation $OPERATION_ID
-```
+This outputs the base table columns output by ado get plus `TOTAL_RESULTS`,
+`SUCCESSFUL_RESULTS`, `FAILED_RESULTS`, `MEASURED_ENTITIES`, `TOTAL_REQUESTS`,
+`FAILED_REQUESTS`, `SUCCESSFUL_REQUESTS`.
 
 Compare this with the number of samples requested in the operator parameters.
 

--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -222,6 +222,19 @@ Relevant Documentation
 
 ### Step 1: Get Details on what was Sampled and Measured
 
+To get a numerical overview of results and requests before diving into the
+trace, use:
+
+```bash
+uv run ado show stats operation $OPERATION_ID
+```
+
+This outputs the base table columns plus `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
+`FAILED_RESULTS`, `MEASURED_ENTITIES`, `TOTAL_REQUESTS`, `FAILED_REQUESTS`,
+`SUCCESSFUL_REQUESTS`.
+
+For the full detail view:
+
 ```bash
 uv run ado show details operation $OPERATION_ID
 ```

--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -80,6 +80,13 @@ Goal: volume of work, recency, and which spaces attract the most operations.
    `MEASURED_ENTITIES` against the operator's `numberEntities` to check sampling
    completeness.
 
+   For richer stats that also include request-level counts
+   (`TOTAL_REQUESTS`, `FAILED_REQUESTS`, `SUCCESSFUL_REQUESTS`):
+
+   ```bash
+   uv run ado show stats operation --output-file operations-fullstats.csv -o csv
+   ```
+
 4. **Discovery Spaces (with statistics)**
 
    ```bash
@@ -88,6 +95,17 @@ Goal: volume of work, recency, and which spaces attract the most operations.
 
    Adds `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`, and
    `MEASURED_ENTITIES` columns.
+
+   For richer stats that also include full entity-space coverage columns
+   (`SIZE_OF_ENTITY_SPACE`, `UNMEASURED_ENTITIES`, `MATCHING_ENTITIES`, etc.):
+
+   ```bash
+   uv run ado show stats discoveryspace --output-file spaces-fullstats.csv -o csv
+   ```
+
+   > **Performance note**: `ado show stats discoveryspace` is slower than
+   > `ado get spaces -o stats` as it instantiates each `DiscoverySpace`.
+   > Prefer `ado get -o stats` for a quick overview across many spaces.
 
 5. **Sample Stores (with statistics)**
 

--- a/.cursor/skills/examining-discovery-spaces/SKILL.md
+++ b/.cursor/skills/examining-discovery-spaces/SKILL.md
@@ -142,14 +142,8 @@ memoization opportunities — a large gap signals other overlapping spaces exist
 For related resources (operations and stores linked to this space), execute:
 
 ```bash
-uv run ado show details space SPACE_ID
+uv run ado show related space SPACE_ID
 ```
-
-This outputs two sections:
-
-**DETAILS** — sampling coverage (same stats, alternative view).
-
-**RELATED RESOURCES** — all operations and stores linked to this space.
 
 > **Performance note**: both `ado show stats discoveryspace` and
 > `ado show details space` are slow as they fetch and aggregate entity data.

--- a/.cursor/skills/examining-discovery-spaces/SKILL.md
+++ b/.cursor/skills/examining-discovery-spaces/SKILL.md
@@ -123,7 +123,23 @@ Extract and summarise:
 
 ### Step 2: Sampling coverage and related resources
 
-Execute
+To get measured entities, experiments, operations, and full entity-space
+coverage columns, use:
+
+```bash
+uv run ado show stats discoveryspace SPACE_ID
+```
+
+This outputs the base table columns plus full entity-space coverage columns:
+`SIZE_OF_ENTITY_SPACE`, `UNMEASURED_ENTITIES`, `MATCHING_ENTITIES`,
+`MATCHING_WITH_MEASUREMENTS`, `ENTITIES_WITH_ALL_MEASUREMENTS`,
+`ENTITIES_WITH_PARTIAL_MEASUREMENTS`, `MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS`.
+
+Compare `MEASURED_ENTITIES` vs `SIZE_OF_ENTITY_SPACE` to understand exploration
+progress. Compare `MEASURED_ENTITIES` vs `MATCHING_ENTITIES` to understand
+memoization opportunities — a large gap signals other overlapping spaces exist.
+
+For related resources (operations and stores linked to this space), execute:
 
 ```bash
 uv run ado show details space SPACE_ID
@@ -131,22 +147,13 @@ uv run ado show details space SPACE_ID
 
 This outputs two sections:
 
-**DETAILS** — sampling coverage:
-
-- Total entities in the space
-- How many have been measured
-- How many have failed measurements
-- How many are unmeasured
-- How many are matching
-
-Compare measured vs total to understand exploration progress. Compare measured
-vs matching to understand memoization opportunities. Also, a signal that other
-overlapping spaces exist.
+**DETAILS** — sampling coverage (same stats, alternative view).
 
 **RELATED RESOURCES** — all operations and stores linked to this space.
 
-> **Performance note**: `ado show details space` is slow as it fetches and
-> aggregates entity data. Use only when sampling coverage is needed.
+> **Performance note**: both `ado show stats discoveryspace` and
+> `ado show details space` are slow as they fetch and aggregate entity data.
+> Use only when sampling coverage is needed.
 
 ### Step 3: Check for existing report
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -194,10 +194,13 @@ uv run ado show measurements space SPACE_ID
 uv run ado show measurements operation OPERATION_ID
 
 # Show in-depth statistics (more columns than ado get -o stats)
+# No IDs = all resources of that type
 uv run ado show stats operation
 uv run ado show stats operation --use-latest -o json
 uv run ado show stats discoveryspace SPACE_ID
 uv run ado show stats samplestore -l key=value
+# Include DESCRIPTION and LABELS columns
+uv run ado show stats operation --details
 ```
 
 ### ado describe
@@ -232,15 +235,15 @@ plus measured properties (outputs).
 
 <!-- markdownlint-disable line-length -->
 
-| Command                       | What It Shows                                                                                                           |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `show measurements operation` | Entities (inputs) and their measurements (outputs) from this operation                                                  |
-| `show measurements space`     | All entities and measurements collected in this space                                                                   |
-| `show trace operation`        | The trace of measurement requests made during an explore operation. Optionally can show per entity measurement metadata |
-| `show stats operation`        | In-depth stats: results (total/successful/failed), measured entities, plus request-level counts                         |
-| `show stats discoveryspace`   | In-depth stats: experiments, operations, measured entities, plus full entity-space coverage columns                     |
-| `show stats samplestore`      | In-depth stats: entities, results, and experiments counts                                                               |
-| `show stats datacontainer`    | In-depth stats: tables, locations, key-values, and data bytes                                                           |
+| Command                       | What It Shows                                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `show measurements operation` | Entities (inputs) and their measurements (outputs) from this operation                                                   |
+| `show measurements space`     | All entities and measurements collected in this space                                                                    |
+| `show trace operation`        | The trace of measurement requests made during an explore operation. Optionally can show per entity measurement metadata  |
+| `show stats operation`        | In-depth stats: results (total/successful/failed), measured entities, plus request-level counts. No IDs = all operations |
+| `show stats discoveryspace`   | In-depth stats: experiments, operations, measured entities, plus full entity-space coverage columns. No IDs = all spaces |
+| `show stats samplestore`      | In-depth stats: entities, results, and experiments counts. No IDs = all sample stores                                    |
+| `show stats datacontainer`    | In-depth stats: tables, locations, key-values, and data bytes. No IDs = all data containers                              |
 
 <!-- markdownlint-enable line-length -->
 

--- a/.cursor/skills/using-ado-cli/SKILL.md
+++ b/.cursor/skills/using-ado-cli/SKILL.md
@@ -192,6 +192,12 @@ uv run ado show trace operation OPERATION_ID
 # Get entities and measurements
 uv run ado show measurements space SPACE_ID
 uv run ado show measurements operation OPERATION_ID
+
+# Show in-depth statistics (more columns than ado get -o stats)
+uv run ado show stats operation
+uv run ado show stats operation --use-latest -o json
+uv run ado show stats discoveryspace SPACE_ID
+uv run ado show stats samplestore -l key=value
 ```
 
 ### ado describe
@@ -231,6 +237,10 @@ plus measured properties (outputs).
 | `show measurements operation` | Entities (inputs) and their measurements (outputs) from this operation                                                  |
 | `show measurements space`     | All entities and measurements collected in this space                                                                   |
 | `show trace operation`        | The trace of measurement requests made during an explore operation. Optionally can show per entity measurement metadata |
+| `show stats operation`        | In-depth stats: results (total/successful/failed), measured entities, plus request-level counts                         |
+| `show stats discoveryspace`   | In-depth stats: experiments, operations, measured entities, plus full entity-space coverage columns                     |
+| `show stats samplestore`      | In-depth stats: entities, results, and experiments counts                                                               |
+| `show stats datacontainer`    | In-depth stats: tables, locations, key-values, and data bytes                                                           |
 
 <!-- markdownlint-enable line-length -->
 

--- a/orchestrator/cli/commands/show.py
+++ b/orchestrator/cli/commands/show.py
@@ -12,6 +12,9 @@ from orchestrator.cli.commands.show_measurements import (
 from orchestrator.cli.commands.show_related import (
     register_show_related_command,
 )
+from orchestrator.cli.commands.show_stats import (
+    register_show_stats_command,
+)
 from orchestrator.cli.commands.show_summary import (
     register_show_summary_command,
 )
@@ -33,6 +36,7 @@ show_command = typer.Typer(
 register_show_details_command(show_command)
 register_show_measurements_command(show_command)
 register_show_related_command(show_command)
+register_show_stats_command(show_command)
 register_show_summary_command(show_command)
 register_show_trace_command(show_command)
 

--- a/orchestrator/cli/commands/show_stats.py
+++ b/orchestrator/cli/commands/show_stats.py
@@ -1,0 +1,197 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import pathlib
+import typing
+from typing import Annotated
+
+import typer
+
+from orchestrator.cli.models.parameters import AdoShowStatsCommandParameters
+from orchestrator.cli.models.types import (
+    AdoShowStatsSupportedOutputFormats,
+    AdoShowStatsSupportedResourceTypes,
+)
+from orchestrator.cli.resources.datacontainer.show_stats import show_datacontainer_stats
+from orchestrator.cli.resources.discovery_space.show_stats import (
+    show_discovery_space_stats,
+)
+from orchestrator.cli.resources.operation.show_stats import show_operation_stats
+from orchestrator.cli.resources.samplestore.show_stats import show_samplestore_stats
+from orchestrator.cli.utils.input.parsers import (
+    enum_choice_with_plural_parser,
+    parse_key_value_pairs,
+)
+from orchestrator.cli.utils.output.prints import (
+    ERROR,
+    console_print,
+)
+from orchestrator.cli.utils.queries.parser import (
+    prepare_query_filters_for_db,
+)
+
+if typing.TYPE_CHECKING:
+    from orchestrator.cli.core.config import AdoConfiguration
+
+
+def show_stats_for_resources(
+    ctx: typer.Context,
+    resource_type: Annotated[
+        AdoShowStatsSupportedResourceTypes,
+        typer.Argument(
+            ...,
+            help="The kind of the resource to show full statistics for.",
+            show_default=False,
+            parser=enum_choice_with_plural_parser(AdoShowStatsSupportedResourceTypes),
+            metavar=f"[{'|'.join(m.value for m in AdoShowStatsSupportedResourceTypes)}]",
+        ),
+    ],
+    ids: Annotated[
+        list[str] | None,
+        typer.Argument(
+            ...,
+            help="The ids of the resources to show statistics for.",
+            show_default=False,
+        ),
+    ] = None,
+    use_latest: Annotated[
+        bool,
+        typer.Option(
+            "--use-latest",
+            help="Show stats for the latest identifier of the selected resource type. "
+            "Ignored if resource identifiers are also specified.",
+            show_default=False,
+        ),
+    ] = False,
+    query: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--query",
+            "-q",
+            help="""
+            Filter results by values contained in the resources. Will return all resources that match
+            the input. Can be specified multiple times to ensure all filters are matched.
+
+            Inputs must be specified in the form of key=value, where key is a path in the resource
+            and value is a JSON document.
+
+            Please refer to the documentation provided for more information and examples:
+            https://ibm.github.io/ado/getting-started/ado/#using-the-field-level-querying-functionality
+            """,
+            show_default=False,
+        ),
+    ] = None,
+    labels: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--label",
+            "-l",
+            help="""
+            Filter results by labels contained in the resources' metadata.
+            Can be specified multiple times.
+
+            Labels need to be specified in the form of key=value.
+            """,
+            show_default=False,
+        ),
+    ] = None,
+    output_format: Annotated[
+        AdoShowStatsSupportedOutputFormats,
+        typer.Option(
+            "--output",
+            "-o",
+            help="The format in which to output the statistics. "
+            "Options: table (rich console table), md-table (markdown table), "
+            "csv (CSV format), json (JSON), yaml (YAML).",
+        ),
+    ] = AdoShowStatsSupportedOutputFormats.TABLE.value,
+    output_file: Annotated[
+        pathlib.Path | None,
+        typer.Option(
+            "--output-file",
+            help="Write output to the specified file instead of stdout.",
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            resolve_path=True,
+            show_default=False,
+        ),
+    ] = None,
+    render_output: Annotated[
+        bool,
+        typer.Option(
+            "--render",
+            help="Render the output in the console. Only supported for markdown table output.",
+        ),
+    ] = False,
+) -> None:
+    """
+    Show full in-depth statistics for one or more resources.
+
+    Examples:
+
+    # Show stats for all operations
+    ado show stats operation
+
+    # Show stats for a specific discovery space
+    ado show stats discoveryspace <space-id>
+
+    # Show stats for the latest operation as JSON
+    ado show stats operation --use-latest -o json
+
+    # Show stats for samplstores matching a label
+    ado show stats samplestore -l key=value
+    """
+    ado_configuration: AdoConfiguration = ctx.obj
+
+    if use_latest:
+        from orchestrator.cli.utils.generic.common import get_effective_resource_id
+
+        resource_id = get_effective_resource_id(
+            explicit_resource_id=ids[0] if ids else None,
+            resource_type=resource_type.value,
+            project_context=ado_configuration.project_context,
+        )
+        ids = [resource_id]
+
+    try:
+        query_filters = prepare_query_filters_for_db(parse_key_value_pairs(query))
+        if labels:
+            for parsed_label in parse_key_value_pairs(labels):
+                for k, v in parsed_label.items():
+                    query_filters.extend(
+                        prepare_query_filters_for_db({"config.metadata.labels": {k: v}})
+                    )
+    except ValueError as e:
+        console_print(f"{ERROR}{e}", stderr=True)
+        raise typer.Exit(1) from e
+
+    parameters = AdoShowStatsCommandParameters(
+        ado_configuration=ado_configuration,
+        output_format=output_format,
+        output_file=output_file,
+        query=query_filters if (query or labels) else None,
+        render_output=render_output,
+        resource_ids=ids,
+    )
+
+    method_mapping = {
+        AdoShowStatsSupportedResourceTypes.DISCOVERY_SPACE: show_discovery_space_stats,
+        AdoShowStatsSupportedResourceTypes.OPERATION: show_operation_stats,
+        AdoShowStatsSupportedResourceTypes.SAMPLE_STORE: show_samplestore_stats,
+        AdoShowStatsSupportedResourceTypes.DATA_CONTAINER: show_datacontainer_stats,
+    }
+
+    method_mapping[resource_type](parameters=parameters)
+
+
+def register_show_stats_command(app: typer.Typer) -> None:
+    """Register the 'stats' subcommand onto the given typer app.
+
+    Args:
+        app: The typer application to register the command on.
+    """
+    app.command(
+        name="stats",
+        no_args_is_help=True,
+    )(show_stats_for_resources)

--- a/orchestrator/cli/commands/show_stats.py
+++ b/orchestrator/cli/commands/show_stats.py
@@ -147,7 +147,7 @@ def show_stats_for_resources(
     # Show stats for the latest operation as JSON
     ado show stats operation --use-latest -o json
 
-    # Show stats for samplstores matching a label
+    # Show stats for samplestores matching a label
     ado show stats samplestore -l key=value
     """
     ado_configuration: AdoConfiguration = ctx.obj

--- a/orchestrator/cli/commands/show_stats.py
+++ b/orchestrator/cli/commands/show_stats.py
@@ -117,6 +117,14 @@ def show_stats_for_resources(
             show_default=False,
         ),
     ] = None,
+    show_details: Annotated[
+        bool,
+        typer.Option(
+            "--details",
+            help="Output additional information on each object, such as names and descriptions.",
+            show_default=True,
+        ),
+    ] = False,
     render_output: Annotated[
         bool,
         typer.Option(
@@ -173,6 +181,7 @@ def show_stats_for_resources(
         query=query_filters if (query or labels) else None,
         render_output=render_output,
         resource_ids=ids,
+        show_details=show_details,
     )
 
     method_mapping = {

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -127,6 +127,7 @@ class AdoShowStatsCommandParameters(pydantic.BaseModel):
     query: list[dict[str, str | None]] | None
     render_output: bool
     resource_ids: list[str] | None
+    show_details: bool
 
 
 class AdoShowSummaryCommandParameters(pydantic.BaseModel):

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -15,6 +15,7 @@ from orchestrator.cli.models.types import (
     AdoShowMeasurementsSupportedEntityTypes,
     AdoShowMeasurementsSupportedOutputFormats,
     AdoShowMeasurementsSupportedPropertyFormats,
+    AdoShowStatsSupportedOutputFormats,
     AdoShowSummarySupportedOutputFormats,
     AdoShowTraceSupportedOutputFormats,
 )
@@ -117,6 +118,15 @@ class AdoShowTraceCommandParameters(pydantic.BaseModel):
     output_file: Path | None
     output_format: AdoShowTraceSupportedOutputFormats
     resource_id: str
+
+
+class AdoShowStatsCommandParameters(pydantic.BaseModel):
+    ado_configuration: AdoConfiguration
+    output_format: AdoShowStatsSupportedOutputFormats
+    output_file: Path | None
+    query: list[dict[str, str | None]] | None
+    render_output: bool
+    resource_ids: list[str] | None
 
 
 class AdoShowSummaryCommandParameters(pydantic.BaseModel):

--- a/orchestrator/cli/models/types.py
+++ b/orchestrator/cli/models/types.py
@@ -166,6 +166,22 @@ class AdoShowTraceSupportedResourceTypes(Enum):
     SAMPLE_STORE = _SAMPLE_STORE_SINGULAR
 
 
+#################### ado show stats ####################
+class AdoShowStatsSupportedOutputFormats(enum.Enum):
+    TABLE = _TABLE
+    MARKDOWN_TABLE = _MARKDOWN_TABLE
+    CSV = _CSV
+    JSON = _JSON
+    YAML = _YAML
+
+
+class AdoShowStatsSupportedResourceTypes(Enum):
+    DISCOVERY_SPACE = _DISCOVERY_SPACE_SINGULAR
+    OPERATION = _OPERATION_SINGULAR
+    SAMPLE_STORE = _SAMPLE_STORE_SINGULAR
+    DATA_CONTAINER = _DATA_CONTAINER_SINGULAR
+
+
 #################### ado show summary ####################
 class AdoShowSummarySupportedOutputFormats(enum.Enum):
     TABLE = _TABLE

--- a/orchestrator/cli/resources/datacontainer/show_stats.py
+++ b/orchestrator/cli/resources/datacontainer/show_stats.py
@@ -1,0 +1,89 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import typer
+from rich.status import Status
+
+from orchestrator.cli.models.parameters import AdoShowStatsCommandParameters
+from orchestrator.cli.utils.generic.wrappers import get_sql_store
+from orchestrator.cli.utils.output.prints import (
+    ADO_INFO_EMPTY_DATAFRAME,
+    ADO_SPINNER_GETTING_OUTPUT_READY,
+    ADO_SPINNER_QUERYING_DB,
+    ERROR,
+    console_print,
+)
+from orchestrator.cli.utils.output.stats import render_stats_dataframe
+from orchestrator.cli.utils.resources.formatters import (
+    build_resource_listing_dataframe,
+    format_ado_get_stats_for_datacontainers,
+    format_default_ado_get_multiple_resources,
+)
+from orchestrator.core.resources import CoreResourceKinds
+
+
+def show_datacontainer_stats(parameters: AdoShowStatsCommandParameters) -> None:
+    """Show statistics for one or more data containers.
+
+    Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE)
+    plus TABLES, LOCATIONS, KEY_VALUES, and DATA_BYTES stats columns.
+
+    Args:
+        parameters: Command parameters including resource IDs, output format,
+            output file, query filters, and render flag.
+    """
+    if parameters.query and parameters.resource_ids:
+        console_print(
+            f"{ERROR}You cannot specify datacontainer ids and queries/labels at the same time",
+            stderr=True,
+        )
+        raise typer.Exit(1)
+
+    sql_store = get_sql_store(
+        project_context=parameters.ado_configuration.project_context
+    )
+    with Status(ADO_SPINNER_QUERYING_DB) as status:
+        if parameters.resource_ids:
+            datacontainer_resources = sql_store.getResources(parameters.resource_ids)
+            base_df = format_default_ado_get_multiple_resources(
+                resources=build_resource_listing_dataframe(
+                    resources=datacontainer_resources,
+                    resource_kind=CoreResourceKinds.DATACONTAINER,
+                ),
+                resource_kind=CoreResourceKinds.DATACONTAINER,
+            )
+        else:
+            datacontainer_resources = sql_store.getResourceIdentifiersOfKind(
+                kind=CoreResourceKinds.DATACONTAINER.value,
+                field_selectors=parameters.query,
+            )
+            base_df = format_default_ado_get_multiple_resources(
+                resources=datacontainer_resources,
+                resource_kind=CoreResourceKinds.DATACONTAINER,
+            )
+
+        if base_df.empty:
+            if parameters.query:
+                console_print(
+                    f"{ERROR}The query/labels provided did not match any datacontainer.",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            if parameters.resource_ids:
+                console_print(
+                    f"{ERROR}No data was retrieved for any of the datacontainers: {parameters.resource_ids}",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
+            return
+
+        status.update(ADO_SPINNER_GETTING_OUTPUT_READY)
+        df = format_ado_get_stats_for_datacontainers(base_df, sql_store, spinner=status)
+
+    render_stats_dataframe(
+        df=df,
+        output_format=parameters.output_format,
+        output_file=parameters.output_file,
+        render_output=parameters.render_output,
+    )

--- a/orchestrator/cli/resources/datacontainer/show_stats.py
+++ b/orchestrator/cli/resources/datacontainer/show_stats.py
@@ -49,6 +49,7 @@ def show_datacontainer_stats(parameters: AdoShowStatsCommandParameters) -> None:
                 resources=build_resource_listing_dataframe(
                     resources=datacontainer_resources,
                     resource_kind=CoreResourceKinds.DATACONTAINER,
+                    show_details=parameters.show_details,
                 ),
                 resource_kind=CoreResourceKinds.DATACONTAINER,
             )
@@ -56,6 +57,7 @@ def show_datacontainer_stats(parameters: AdoShowStatsCommandParameters) -> None:
             datacontainer_resources = sql_store.getResourceIdentifiersOfKind(
                 kind=CoreResourceKinds.DATACONTAINER.value,
                 field_selectors=parameters.query,
+                details=parameters.show_details,
             )
             base_df = format_default_ado_get_multiple_resources(
                 resources=datacontainer_resources,

--- a/orchestrator/cli/resources/discovery_space/get.py
+++ b/orchestrator/cli/resources/discovery_space/get.py
@@ -20,6 +20,7 @@ from orchestrator.cli.utils.output.prints import (
 )
 from orchestrator.cli.utils.queries.parser import prepare_query_filters_for_db
 from orchestrator.cli.utils.resources.formatters import (
+    build_resource_listing_dataframe,
     format_default_ado_get_multiple_resources,
 )
 from orchestrator.core import DiscoverySpaceResource
@@ -45,8 +46,10 @@ def get_discovery_space(parameters: AdoGetCommandParameters) -> None:
         # For TABLE format, use DataFrame
         if parameters.output_format == AdoGetSupportedOutputFormats.TABLE:
             output_df = format_default_ado_get_multiple_resources(
-                resources=_discovery_space_resource_list_to_ado_get_default_dataframe(
-                    resources=matching_spaces, parameters=parameters
+                resources=build_resource_listing_dataframe(
+                    resources={space.identifier: space for space in matching_spaces},
+                    resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+                    sort_by_age_descending=True,
                 ),
                 resource_kind=CoreResourceKinds.DISCOVERYSPACE,
             )
@@ -242,33 +245,4 @@ def _find_spaces_matching_space(
         result_df
         if parameters.show_details
         else result_df[["IDENTIFIER", "NAME", "AGE", "RELATION_TO_INPUT_SPACE"]]
-    )
-
-
-def _discovery_space_resource_list_to_ado_get_default_dataframe(
-    resources: list[DiscoverySpaceResource],
-    parameters: AdoGetCommandParameters,
-) -> "pd.DataFrame":
-    from datetime import datetime, timezone
-
-    import pandas as pd
-
-    result_df = pd.DataFrame(
-        [
-            {
-                "IDENTIFIER": space_resource.identifier,
-                "NAME": space_resource.config.metadata.name,
-                "DESCRIPTION": space_resource.config.metadata.labels,
-                "AGE": datetime.now(timezone.utc) - space_resource.created,
-            }
-            for space_resource in resources
-        ]
-    )
-    result_df = result_df.sort_values(by="AGE", ascending=False)
-    result_df = result_df.reset_index(drop=True)
-
-    return (
-        result_df
-        if parameters.show_details
-        else result_df[["IDENTIFIER", "NAME", "AGE"]]
     )

--- a/orchestrator/cli/resources/discovery_space/show_stats.py
+++ b/orchestrator/cli/resources/discovery_space/show_stats.py
@@ -62,6 +62,7 @@ def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> Non
             resources=build_resource_listing_dataframe(
                 resources=space_resources,
                 resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+                show_details=parameters.show_details,
             ),
             resource_kind=CoreResourceKinds.DISCOVERYSPACE,
         )

--- a/orchestrator/cli/resources/discovery_space/show_stats.py
+++ b/orchestrator/cli/resources/discovery_space/show_stats.py
@@ -1,0 +1,101 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import typer
+from rich.status import Status
+
+from orchestrator.cli.models.parameters import AdoShowStatsCommandParameters
+from orchestrator.cli.utils.generic.wrappers import get_sql_store
+from orchestrator.cli.utils.output.prints import (
+    ADO_INFO_EMPTY_DATAFRAME,
+    ADO_SPINNER_GETTING_OUTPUT_READY,
+    ADO_SPINNER_QUERYING_DB,
+    ERROR,
+    console_print,
+)
+from orchestrator.cli.utils.output.stats import render_stats_dataframe
+from orchestrator.cli.utils.resources.formatters import (
+    build_resource_listing_dataframe,
+    format_ado_get_stats_for_spaces,
+    format_default_ado_get_multiple_resources,
+)
+from orchestrator.core.resources import ADOResource, CoreResourceKinds
+
+
+def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> None:
+    """Show statistics for one or more discovery spaces.
+
+    Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE)
+    plus lightweight stats columns (EXPERIMENTS, OPERATIONS,
+    EXPLORE_OPERATIONS, MEASURED_ENTITIES) and heavy stats columns
+    (SIZE_OF_ENTITY_SPACE, UNMEASURED_ENTITIES, MATCHING_ENTITIES,
+    MATCHING_WITH_MEASUREMENTS, ENTITIES_WITH_ALL_MEASUREMENTS,
+    ENTITIES_WITH_PARTIAL_MEASUREMENTS,
+    MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS).
+
+    Args:
+        parameters: Command parameters including resource IDs, output format,
+            output file, query filters, and render flag.
+    """
+    if parameters.query and parameters.resource_ids:
+        console_print(
+            f"{ERROR}You cannot specify space ids and queries/labels at the same time",
+            stderr=True,
+        )
+        raise typer.Exit(1)
+
+    sql_store = get_sql_store(
+        project_context=parameters.ado_configuration.project_context
+    )
+    with Status(ADO_SPINNER_QUERYING_DB) as status:
+        if parameters.resource_ids:
+            space_resources: dict[str, ADOResource] = sql_store.getResources(
+                parameters.resource_ids
+            )
+        else:
+            space_resources = sql_store.getResourcesOfKind(
+                kind=CoreResourceKinds.DISCOVERYSPACE.value,
+                field_selectors=parameters.query,
+            )
+
+        base_df = format_default_ado_get_multiple_resources(
+            resources=build_resource_listing_dataframe(
+                resources=space_resources,
+                resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+            ),
+            resource_kind=CoreResourceKinds.DISCOVERYSPACE,
+        )
+
+        if base_df.empty:
+            if parameters.query:
+                console_print(
+                    f"{ERROR}The query/labels provided did not match any space.",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            if parameters.resource_ids:
+                console_print(
+                    f"{ERROR}No data was retrieved for any of the spaces: {parameters.resource_ids}",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
+            return
+
+        # Compute all stats (lightweight + heavy) in one pass.
+        status.update(ADO_SPINNER_GETTING_OUTPUT_READY)
+        df = format_ado_get_stats_for_spaces(
+            base_df,
+            sql_store,
+            spinner=status,
+            include_heavy=True,
+            space_resources=space_resources,
+            project_context=parameters.ado_configuration.project_context,
+        )
+
+    render_stats_dataframe(
+        df=df,
+        output_format=parameters.output_format,
+        output_file=parameters.output_file,
+        render_output=parameters.render_output,
+    )

--- a/orchestrator/cli/resources/operation/show_stats.py
+++ b/orchestrator/cli/resources/operation/show_stats.py
@@ -1,0 +1,97 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import typer
+from rich.status import Status
+
+from orchestrator.cli.models.parameters import AdoShowStatsCommandParameters
+from orchestrator.cli.utils.generic.wrappers import get_sql_store
+from orchestrator.cli.utils.output.prints import (
+    ADO_INFO_EMPTY_DATAFRAME,
+    ADO_SPINNER_GETTING_OUTPUT_READY,
+    ADO_SPINNER_QUERYING_DB,
+    ERROR,
+    console_print,
+)
+from orchestrator.cli.utils.output.stats import render_stats_dataframe
+from orchestrator.cli.utils.resources.formatters import (
+    build_resource_listing_dataframe,
+    format_ado_get_stats_for_operations,
+    format_default_ado_get_multiple_resources,
+)
+from orchestrator.core.resources import CoreResourceKinds
+
+
+def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
+    """Show statistics for one or more operations.
+
+    Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE,
+    SPACE, STATUS, EXIT_STATE) plus result-level stats columns
+    (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES)
+    and request-level stats columns (TOTAL_REQUESTS, FAILED_REQUESTS,
+    SUCCESSFUL_REQUESTS).
+
+    Args:
+        parameters: Command parameters including resource IDs, output format,
+            output file, query filters, and render flag.
+    """
+    if parameters.query and parameters.resource_ids:
+        console_print(
+            f"{ERROR}You cannot specify operation ids and queries/labels at the same time",
+            stderr=True,
+        )
+        raise typer.Exit(1)
+
+    sql_store = get_sql_store(
+        project_context=parameters.ado_configuration.project_context
+    )
+    with Status(ADO_SPINNER_QUERYING_DB) as status:
+        if parameters.resource_ids:
+            operation_resources = sql_store.getResources(parameters.resource_ids)
+            base_df = format_default_ado_get_multiple_resources(
+                resources=build_resource_listing_dataframe(
+                    resources=operation_resources,
+                    resource_kind=CoreResourceKinds.OPERATION,
+                ),
+                resource_kind=CoreResourceKinds.OPERATION,
+            )
+        else:
+            operation_resources = sql_store.getResourceIdentifiersOfKind(
+                kind=CoreResourceKinds.OPERATION.value,
+                field_selectors=parameters.query,
+            )
+            base_df = format_default_ado_get_multiple_resources(
+                resources=operation_resources,
+                resource_kind=CoreResourceKinds.OPERATION,
+            )
+
+        if base_df.empty:
+            if parameters.query:
+                console_print(
+                    f"{ERROR}The query/labels provided did not match any operation.",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            if parameters.resource_ids:
+                console_print(
+                    f"{ERROR}No data was retrieved for any of the operations: {parameters.resource_ids}",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
+            return
+
+        status.update(ADO_SPINNER_GETTING_OUTPUT_READY)
+        df = format_ado_get_stats_for_operations(
+            base_df,
+            sql_store,
+            spinner=status,
+            include_request_columns=True,
+        )
+
+    render_stats_dataframe(
+        df=df,
+        output_format=parameters.output_format,
+        output_file=parameters.output_file,
+        render_output=parameters.render_output,
+    )

--- a/orchestrator/cli/resources/operation/show_stats.py
+++ b/orchestrator/cli/resources/operation/show_stats.py
@@ -52,6 +52,7 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
                 resources=build_resource_listing_dataframe(
                     resources=operation_resources,
                     resource_kind=CoreResourceKinds.OPERATION,
+                    show_details=parameters.show_details,
                 ),
                 resource_kind=CoreResourceKinds.OPERATION,
             )
@@ -59,6 +60,7 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
             operation_resources = sql_store.getResourceIdentifiersOfKind(
                 kind=CoreResourceKinds.OPERATION.value,
                 field_selectors=parameters.query,
+                details=parameters.show_details,
             )
             base_df = format_default_ado_get_multiple_resources(
                 resources=operation_resources,

--- a/orchestrator/cli/resources/samplestore/show_stats.py
+++ b/orchestrator/cli/resources/samplestore/show_stats.py
@@ -49,6 +49,7 @@ def show_samplestore_stats(parameters: AdoShowStatsCommandParameters) -> None:
                 resources=build_resource_listing_dataframe(
                     resources=samplestore_resources,
                     resource_kind=CoreResourceKinds.SAMPLESTORE,
+                    show_details=parameters.show_details,
                 ),
                 resource_kind=CoreResourceKinds.SAMPLESTORE,
             )
@@ -56,6 +57,7 @@ def show_samplestore_stats(parameters: AdoShowStatsCommandParameters) -> None:
             samplestore_resources = sql_store.getResourceIdentifiersOfKind(
                 kind=CoreResourceKinds.SAMPLESTORE.value,
                 field_selectors=parameters.query,
+                details=parameters.show_details,
             )
             base_df = format_default_ado_get_multiple_resources(
                 resources=samplestore_resources,

--- a/orchestrator/cli/resources/samplestore/show_stats.py
+++ b/orchestrator/cli/resources/samplestore/show_stats.py
@@ -1,0 +1,89 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import typer
+from rich.status import Status
+
+from orchestrator.cli.models.parameters import AdoShowStatsCommandParameters
+from orchestrator.cli.utils.generic.wrappers import get_sql_store
+from orchestrator.cli.utils.output.prints import (
+    ADO_INFO_EMPTY_DATAFRAME,
+    ADO_SPINNER_GETTING_OUTPUT_READY,
+    ADO_SPINNER_QUERYING_DB,
+    ERROR,
+    console_print,
+)
+from orchestrator.cli.utils.output.stats import render_stats_dataframe
+from orchestrator.cli.utils.resources.formatters import (
+    build_resource_listing_dataframe,
+    format_ado_get_stats_for_samplestores,
+    format_default_ado_get_multiple_resources,
+)
+from orchestrator.core.resources import CoreResourceKinds
+
+
+def show_samplestore_stats(parameters: AdoShowStatsCommandParameters) -> None:
+    """Show statistics for one or more sample stores.
+
+    Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE)
+    plus ENTITIES, RESULTS, and EXPERIMENTS stats columns.
+
+    Args:
+        parameters: Command parameters including resource IDs, output format,
+            output file, query filters, and render flag.
+    """
+    if parameters.query and parameters.resource_ids:
+        console_print(
+            f"{ERROR}You cannot specify samplestore ids and queries/labels at the same time",
+            stderr=True,
+        )
+        raise typer.Exit(1)
+
+    sql_store = get_sql_store(
+        project_context=parameters.ado_configuration.project_context
+    )
+    with Status(ADO_SPINNER_QUERYING_DB) as status:
+        if parameters.resource_ids:
+            samplestore_resources = sql_store.getResources(parameters.resource_ids)
+            base_df = format_default_ado_get_multiple_resources(
+                resources=build_resource_listing_dataframe(
+                    resources=samplestore_resources,
+                    resource_kind=CoreResourceKinds.SAMPLESTORE,
+                ),
+                resource_kind=CoreResourceKinds.SAMPLESTORE,
+            )
+        else:
+            samplestore_resources = sql_store.getResourceIdentifiersOfKind(
+                kind=CoreResourceKinds.SAMPLESTORE.value,
+                field_selectors=parameters.query,
+            )
+            base_df = format_default_ado_get_multiple_resources(
+                resources=samplestore_resources,
+                resource_kind=CoreResourceKinds.SAMPLESTORE,
+            )
+
+        if base_df.empty:
+            if parameters.query:
+                console_print(
+                    f"{ERROR}The query/labels provided did not match any samplestore.",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            if parameters.resource_ids:
+                console_print(
+                    f"{ERROR}No data was retrieved for any of the sampletores: {parameters.resource_ids}",
+                    stderr=True,
+                )
+                raise typer.Exit(1)
+            console_print(ADO_INFO_EMPTY_DATAFRAME, stderr=True)
+            return
+
+        status.update(ADO_SPINNER_GETTING_OUTPUT_READY)
+        df = format_ado_get_stats_for_samplestores(base_df, sql_store, spinner=status)
+
+    render_stats_dataframe(
+        df=df,
+        output_format=parameters.output_format,
+        output_file=parameters.output_file,
+        render_output=parameters.render_output,
+    )

--- a/orchestrator/cli/utils/output/stats.py
+++ b/orchestrator/cli/utils/output/stats.py
@@ -1,0 +1,95 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Shared rendering helper for `ado show stats` output."""
+
+import json
+import pathlib
+import typing
+
+import yaml
+
+from orchestrator.cli.models.types import AdoShowStatsSupportedOutputFormats
+from orchestrator.cli.utils.output.prints import (
+    SUCCESS,
+    console_print,
+    magenta,
+)
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+
+
+def render_stats_dataframe(
+    df: "pd.DataFrame",
+    output_format: AdoShowStatsSupportedOutputFormats,
+    output_file: pathlib.Path | None,
+    render_output: bool,
+    index_column: str = "IDENTIFIER",
+) -> None:
+    """Render a stats DataFrame to the requested output format.
+
+    Writes to *output_file* when provided, otherwise prints to stdout.
+
+    Args:
+        df: DataFrame to render. Must contain *index_column* when
+            using json or yaml output formats.
+        output_format: One of TABLE, MARKDOWN_TABLE, CSV, JSON, YAML.
+        output_file: Optional path to write output to instead of stdout.
+        render_output: When True and output_format is MARKDOWN_TABLE,
+            render the markdown via rich in the console.
+        index_column: Column to use as the outer key in json/yaml output.
+            Defaults to "IDENTIFIER".
+    """
+    Fmt = AdoShowStatsSupportedOutputFormats
+    match output_format:
+        case Fmt.JSON | Fmt.YAML:
+            # Convert to a plain dict so both branches share the same structure.
+            # We avoid df.to_json() because it lacks a default= coercion for
+            # non-serialisable types (e.g. datetime) and has no YAML equivalent;
+            # going through a dict keeps JSON and YAML output structurally identical.
+            data = df.set_index(index_column).to_dict(orient="index")
+            if output_format == Fmt.JSON:
+                result: str = json.dumps(data, indent=2, default=str)
+            else:
+                result = yaml.dump(data, default_flow_style=False)
+        case Fmt.TABLE:
+            import rich.box
+
+            from orchestrator.utilities.rich import (
+                dataframe_to_rich_table,
+                render_to_string,
+            )
+
+            table = dataframe_to_rich_table(
+                df,
+                show_edge=True,
+                show_index=True,
+                box=rich.box.SQUARE,
+                do_not_truncate_columns=True,
+            )
+            result = render_to_string(table, auto_width=True)
+        case Fmt.MARKDOWN_TABLE:
+            result = df.to_markdown()
+        case _:
+            # CSV
+            result = df.to_csv(index=False)
+
+    if output_file:
+        output_file.write_text(result)
+        console_print(
+            f"{SUCCESS} Output saved as {magenta(str(output_file))}",
+            stderr=True,
+        )
+        return
+
+    if (
+        render_output
+        and output_format == AdoShowStatsSupportedOutputFormats.MARKDOWN_TABLE
+    ):
+        from rich.markdown import Markdown
+
+        console_print(Markdown(result))
+        return
+
+    console_print(result)

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -164,6 +164,7 @@ def build_resource_listing_dataframe(
     resources: dict[str, "ADOResource"],
     resource_kind: "CoreResourceKinds",
     sort_by_age_descending: bool = False,
+    show_details: bool = False,
 ) -> "pd.DataFrame":
     """Build the same DataFrame shape as ``getResourceIdentifiersOfKind`` from a resources dict.
 
@@ -177,12 +178,16 @@ def build_resource_listing_dataframe(
         resource_kind: The kind of the resources (determines extra columns).
         sort_by_age_descending: When ``True``, sort the resulting DataFrame by
             ``AGE`` in descending order and reset the index.
+        show_details: When ``True``, include ``DESCRIPTION`` and ``LABELS``
+            columns in the returned DataFrame.
 
     Returns:
         A ``pd.DataFrame`` with columns ``IDENTIFIER``, ``NAME``, ``AGE``
         (as ``datetime.timedelta``) and, for operations, additionally
-        ``STATUS`` (JSON string) and ``SPACE``. The DataFrame is compatible
-        with :func:`format_default_ado_get_multiple_resources`.
+        ``STATUS`` (JSON string) and ``SPACE``. When ``show_details`` is
+        ``True`` the columns also include ``DESCRIPTION`` and ``LABELS``.
+        The DataFrame is compatible with
+        :func:`format_default_ado_get_multiple_resources`.
     """
     import pandas as pd
 
@@ -198,6 +203,10 @@ def build_resource_listing_dataframe(
             "AGE": now - resource.created,
         }
 
+        if show_details:
+            row["DESCRIPTION"] = metadata.description
+            row["LABELS"] = json.dumps(metadata.labels) if metadata.labels else None
+
         if resource_kind == CoreResourceKinds.OPERATION:
             row["STATUS"] = pydantic.RootModel[list[ADOResourceStatus]](
                 resource.status
@@ -207,6 +216,8 @@ def build_resource_listing_dataframe(
         return row
 
     columns = ["IDENTIFIER", "NAME", "AGE"]
+    if show_details:
+        columns = ["IDENTIFIER", "NAME", "DESCRIPTION", "LABELS", "AGE"]
     if resource_kind == CoreResourceKinds.OPERATION:
         columns.extend(["STATUS", "SPACE"])
 

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -51,6 +51,7 @@ if typing.TYPE_CHECKING:
     from rich.status import Status
 
     from orchestrator.cli.models.parameters import AdoGetCommandParameters
+    from orchestrator.metastore.project import ProjectContext
     from orchestrator.metastore.sqlstore import SQLStore
 
 
@@ -159,12 +160,77 @@ def format_default_ado_get_multiple_resources(
     return resources[columns]
 
 
+def build_resource_listing_dataframe(
+    resources: dict[str, "ADOResource"],
+    resource_kind: "CoreResourceKinds",
+    sort_by_age_descending: bool = False,
+) -> "pd.DataFrame":
+    """Build the same DataFrame shape as ``getResourceIdentifiersOfKind`` from a resources dict.
+
+    Used when specific identifiers are requested so that only those resources are
+    fetched (via ``getResources``) instead of loading every resource of that kind
+    and then filtering in-memory.
+
+    Args:
+        resources: Mapping of identifier → ``ADOResource`` as returned by
+            ``sql_store.getResources``.
+        resource_kind: The kind of the resources (determines extra columns).
+        sort_by_age_descending: When ``True``, sort the resulting DataFrame by
+            ``AGE`` in descending order and reset the index.
+
+    Returns:
+        A ``pd.DataFrame`` with columns ``IDENTIFIER``, ``NAME``, ``AGE``
+        (as ``datetime.timedelta``) and, for operations, additionally
+        ``STATUS`` (JSON string) and ``SPACE``. The DataFrame is compatible
+        with :func:`format_default_ado_get_multiple_resources`.
+    """
+    import pandas as pd
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    def resource_to_row(
+        identifier: str, resource: "ADOResource"
+    ) -> dict[str, typing.Any]:
+        metadata = resource.config.metadata or ConfigurationMetadata()
+        row = {
+            "IDENTIFIER": identifier,
+            "NAME": metadata.name,
+            "AGE": now - resource.created,
+        }
+
+        if resource_kind == CoreResourceKinds.OPERATION:
+            row["STATUS"] = pydantic.RootModel[list[ADOResourceStatus]](
+                resource.status
+            ).model_dump_json()
+            row["SPACE"] = resource.config.spaces[0] if resource.config.spaces else None
+
+        return row
+
+    columns = ["IDENTIFIER", "NAME", "AGE"]
+    if resource_kind == CoreResourceKinds.OPERATION:
+        columns.extend(["STATUS", "SPACE"])
+
+    df = pd.DataFrame(
+        [
+            resource_to_row(identifier, resource)
+            for identifier, resource in resources.items()
+        ],
+        columns=columns,
+    )
+
+    if sort_by_age_descending:
+        df = df.sort_values(by="AGE", ascending=False).reset_index(drop=True)
+
+    return df
+
+
 def format_ado_get_stats_for_operations(
     df: "pd.DataFrame",
     sql_store: "SQLStore",
     spinner: "Status | None" = None,
+    include_request_columns: bool = False,
 ) -> "pd.DataFrame":
-    """Append 4 measurement-statistics columns to an operations DataFrame.
+    """Append measurement-statistics columns to an operations DataFrame.
 
     Issues two queries regardless of the number of operations:
     one recursive-CTE query to resolve operation→samplestore relationships,
@@ -177,22 +243,34 @@ def format_ado_get_stats_for_operations(
         sql_store: The ``SQLStore`` to use for relationship and samplestore
             queries.
         spinner: Optional rich status spinner to update with progress messages.
+        include_request_columns: When ``True``, also append
+            ``TOTAL_REQUESTS``, ``FAILED_REQUESTS``, and
+            ``SUCCESSFUL_REQUESTS`` columns in addition to the default
+            result-level columns. Defaults to ``False``.
 
     Returns:
-        The same DataFrame with four extra columns appended:
-        ``TOTAL_RESULTS``, ``SUCCESSFUL_RESULTS``, ``FAILED_RESULTS``,
-        ``MEASURED_ENTITIES``. Operations with no recorded measurements show
-        ``0`` in all stats columns.
+        The same DataFrame with extra columns appended.
+        Always appended: ``TOTAL_RESULTS``, ``SUCCESSFUL_RESULTS``,
+        ``FAILED_RESULTS``, ``MEASURED_ENTITIES``.
+        Appended when *include_request_columns* is ``True``:
+        ``TOTAL_REQUESTS``, ``FAILED_REQUESTS``, ``SUCCESSFUL_REQUESTS``.
+        Operations with no recorded measurements show ``0`` in all stats
+        columns.
     """
 
     from orchestrator.core.resources import CoreResourceKinds
     from orchestrator.core.samplestore.base import SampleStore
 
-    _STATS_COLUMNS = [
+    _RESULT_COLUMNS = [
         "TOTAL_RESULTS",
         "SUCCESSFUL_RESULTS",
         "FAILED_RESULTS",
         "MEASURED_ENTITIES",
+    ]
+    _REQUEST_COLUMNS = [
+        "TOTAL_REQUESTS",
+        "FAILED_REQUESTS",
+        "SUCCESSFUL_REQUESTS",
     ]
 
     operation_ids: set[str] = set(df["IDENTIFIER"])
@@ -245,11 +323,17 @@ def format_ado_get_stats_for_operations(
                 "SUCCESSFUL_RESULTS": stat.successful_results,
                 "FAILED_RESULTS": stat.failed_results,
                 "MEASURED_ENTITIES": stat.measured_entities,
+                "TOTAL_REQUESTS": stat.total_requests,
+                "FAILED_REQUESTS": stat.failed_requests,
+                "SUCCESSFUL_REQUESTS": stat.successful_requests,
             }
 
-    # Attach stats columns; operations with no samplestore mapping show 0.
-    zeros = dict.fromkeys(_STATS_COLUMNS, 0)
-    for col in _STATS_COLUMNS:
+    # Attach result-level stats columns; operations with no samplestore mapping show 0.
+    all_columns = _RESULT_COLUMNS + (
+        _REQUEST_COLUMNS if include_request_columns else []
+    )
+    zeros = dict.fromkeys(_RESULT_COLUMNS + _REQUEST_COLUMNS, 0)
+    for col in all_columns:
         df[col] = df["IDENTIFIER"].apply(
             lambda operation_id, c=col: stats_lookup.get(operation_id, zeros)[c]
         )
@@ -261,43 +345,65 @@ def format_ado_get_stats_for_spaces(
     df: "pd.DataFrame",
     sql_store: "SQLStore",
     spinner: "Status | None" = None,
+    include_heavy: bool = False,
+    space_resources: "dict[str, ADOResource] | None" = None,
+    project_context: "ProjectContext | None" = None,
 ) -> "pd.DataFrame":
-    """Append 4 space-statistics columns to a discovery spaces DataFrame.
+    """Append statistics columns to a discovery spaces DataFrame.
 
-    Issues a metastore stats query for all spaces at once, then resolves each
-    space's linked operations and sample stores.  For each distinct sample
-    store a single batched :meth:`space_entity_statistics` query is issued.
+    Issues a single batched query for all spaces' child operations, then a
+    single batched query for their parent sample stores.
+
+    When ``include_heavy=False`` (default), also issues a metastore stats
+    query and a ``space_entity_statistics`` query per distinct sample store,
+    then appends four lightweight columns.
+
+    When ``include_heavy=True``, builds full
+    :class:`~orchestrator.core.discoveryspace.space.DiscoverySpace` instances
+    per samplestore group and delegates to
+    :func:`~orchestrator.core.discoveryspace.stats.space_statistics_for_spaces`
+    (which issues both the metastore and sample-store queries internally),
+    then appends all lightweight **and** heavy columns in one pass.
 
     Args:
         df: DataFrame with at least an ``IDENTIFIER`` column (one row per
             discovery space).
         sql_store: The ``SQLStore`` to use for relationship and stats queries.
         spinner: Optional rich status spinner to update with progress messages.
+        include_heavy: When ``True`` also compute and append the heavy stats
+            columns (``SIZE_OF_ENTITY_SPACE``, ``UNMEASURED_ENTITIES``,
+            ``MATCHING_ENTITIES``, ``MATCHING_WITH_MEASUREMENTS``,
+            ``ENTITIES_WITH_ALL_MEASUREMENTS``,
+            ``ENTITIES_WITH_PARTIAL_MEASUREMENTS``,
+            ``MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS``).
+            Requires ``space_resources`` and ``project_context``.
+        space_resources: Mapping of space identifier → hydrated
+            :class:`~orchestrator.core.resources.ADOResource`.  Required when
+            ``include_heavy=True``; ignored otherwise.
+        project_context: Project context used to instantiate
+            :class:`~orchestrator.core.discoveryspace.space.DiscoverySpace`.
+            Required when ``include_heavy=True``; ignored otherwise.
 
     Returns:
-        The same DataFrame with four extra columns appended:
-        ``EXPERIMENTS``, ``OPERATIONS``, ``EXPLORE_OPERATIONS``,
-        ``MEASURED_ENTITIES``.
+        The same DataFrame with extra columns appended.
+        Lightweight columns: ``EXPERIMENTS``, ``OPERATIONS``,
+        ``EXPLORE_OPERATIONS``, ``MEASURED_ENTITIES``.
+        Heavy columns (only when ``include_heavy=True``):
+        ``SIZE_OF_ENTITY_SPACE``, ``UNMEASURED_ENTITIES``,
+        ``MATCHING_ENTITIES``, ``MATCHING_WITH_MEASUREMENTS``,
+        ``ENTITIES_WITH_ALL_MEASUREMENTS``,
+        ``ENTITIES_WITH_PARTIAL_MEASUREMENTS``,
+        ``MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS``.
         Spaces with no recorded operations or sample store show ``0`` in all
-        stats columns.
+        lightweight stats columns; heavy columns show ``None`` for spaces
+        where the value cannot be determined.
     """
     from orchestrator.core.resources import CoreResourceKinds
     from orchestrator.core.samplestore.base import SampleStore
 
-    _STATS_COLUMNS = [
-        "EXPERIMENTS",
-        "OPERATIONS",
-        "EXPLORE_OPERATIONS",
-        "MEASURED_ENTITIES",
-    ]
-
     space_ids: set[str] = set(df["IDENTIFIER"])
 
-    # Query 1: metastore stats (number_of_experiments, number_of_operations,
-    # number_of_explore_operations) for all spaces in one SQL query.
-    metastore_stats = sql_store.get_space_metastore_stats(space_ids)
-
-    # Query 2: for each space, get its child operations.
+    # Query 1: for each space, get its child operations.
     # Returns {space_id: {CoreResourceKinds.OPERATION: set[operation_id]}}
     space_child_relationships: dict[str, dict[CoreResourceKinds, set[str]]] = (
         sql_store.get_resources_by_relationship(
@@ -317,7 +423,7 @@ def format_ado_get_stats_for_spaces(
             CoreResourceKinds.OPERATION, set()
         )
 
-    # Query 3: for each space, get its parent sample store(s),
+    # Query 2: for each space, get its parent sample store(s),
     # returning hydrated SampleStoreResource objects.
     # Returns {space_id: {CoreResourceKinds.SAMPLESTORE: {samplestore_id: SampleStoreResource}}}
     space_parent_relationships: dict[
@@ -341,46 +447,128 @@ def format_ado_get_stats_for_spaces(
             samplestore_id_to_resource[samplestore_id] = samplestore_resource
             samplestore_id_to_space_ids.setdefault(samplestore_id, set()).add(space_id)
 
-    # For each distinct sample store, issue one batched space_entity_statistics query.
-    space_id_to_measured_entity_count: dict[str, int] = {}
-    total_samplestores = len(samplestore_id_to_space_ids)
-    for index, (samplestore_id, samplestore_space_ids) in enumerate(
-        samplestore_id_to_space_ids.items(), start=1
-    ):
-        if spinner is not None:
-            spinner.update(
-                f"Calculating stats for spaces in samplestore {index}/{total_samplestores}: {samplestore_id}"
-            )
-        sample_store = SampleStore.from_resource(
-            samplestore_id_to_resource[samplestore_id]
-        )
-        operation_ids_per_space = {
-            space_id: space_id_to_operation_ids[space_id]
-            for space_id in samplestore_space_ids
-        }
-        entity_stats_per_space = sample_store.space_entity_statistics(
-            space_ids_to_operation_ids=operation_ids_per_space
-        )
-        for space_id, entity_stats in entity_stats_per_space.items():
-            space_id_to_measured_entity_count[space_id] = (
-                entity_stats.number_measured_entities or 0
-            )
+    from orchestrator.core.discoveryspace.stats import (
+        DiscoverySpaceStatistics,
+        space_statistics_for_spaces,
+    )
 
-    # Attach stats columns; spaces with no data show 0.
-    # get_space_metastore_stats always returns an entry for every requested
-    # space_id, so direct attribute access is safe.
+    all_stats: dict[str, DiscoverySpaceStatistics] = {}
+    total_samplestores = len(samplestore_id_to_space_ids)
+
+    if include_heavy:
+        # Heavy path: build all DiscoverySpace instances first (phase 1), then
+        # compute statistics in a single pass (phase 2).  Keeping the two phases
+        # separate means the spinner never alternates between "Initialising" and
+        # "Computing statistics" messages.
+        from orchestrator.core.discoveryspace.space import DiscoverySpace
+
+        # Phase 1: initialise all spaces.
+        total_spaces = len(space_ids)
+        all_spaces: list[DiscoverySpace] = []
+        for (
+            samplestore_id,
+            samplestore_space_ids,
+        ) in samplestore_id_to_space_ids.items():
+            sample_store = SampleStore.from_resource(
+                samplestore_id_to_resource[samplestore_id]
+            )
+            for space_id in samplestore_space_ids:
+                if spinner is not None:
+                    spinner.update(
+                        f"Initialising space {space_id} ({len(all_spaces) + 1}/{total_spaces})"
+                    )
+                all_spaces.append(
+                    DiscoverySpace.from_configuration(
+                        conf=space_resources[space_id].config,
+                        project_context=project_context,  # type: ignore[arg-type]
+                        identifier=space_id,
+                        sample_store=sample_store,
+                    )
+                )
+
+        # Phase 2: compute statistics for all spaces at once.
+        all_stats.update(
+            space_statistics_for_spaces(
+                all_spaces, lightweight_only=False, spinner=spinner
+            )
+        )
+    else:
+        # Lightweight path: issue a metastore stats query and one
+        # space_entity_statistics query per distinct sample store.
+        metastore_stats = sql_store.get_space_metastore_stats(space_ids)
+
+        for index, (samplestore_id, samplestore_space_ids) in enumerate(
+            samplestore_id_to_space_ids.items(), start=1
+        ):
+            if spinner is not None:
+                spinner.update(
+                    f"Calculating stats for spaces in samplestore {index}/{total_samplestores}: {samplestore_id}"
+                )
+            sample_store = SampleStore.from_resource(
+                samplestore_id_to_resource[samplestore_id]
+            )
+            operation_ids_per_space = {
+                space_id: space_id_to_operation_ids[space_id]
+                for space_id in samplestore_space_ids
+            }
+            entity_stats_per_space = sample_store.space_entity_statistics(
+                space_ids_to_operation_ids=operation_ids_per_space
+            )
+            for space_id, entity_stats in entity_stats_per_space.items():
+                all_stats[space_id] = DiscoverySpaceStatistics(
+                    number_of_experiments=metastore_stats[
+                        space_id
+                    ].number_of_experiments,
+                    number_of_operations=metastore_stats[space_id].number_of_operations,
+                    number_of_explore_operations=metastore_stats[
+                        space_id
+                    ].number_of_explore_operations,
+                    number_measured_entities=entity_stats.number_measured_entities or 0,
+                )
+
+    # Attach lightweight columns; spaces with no data show 0.
     df["EXPERIMENTS"] = df["IDENTIFIER"].apply(
-        lambda space_id: metastore_stats[space_id].number_of_experiments
+        lambda space_id: (
+            all_stats[space_id].number_of_experiments if space_id in all_stats else 0
+        )
     )
     df["OPERATIONS"] = df["IDENTIFIER"].apply(
-        lambda space_id: metastore_stats[space_id].number_of_operations
+        lambda space_id: (
+            all_stats[space_id].number_of_operations if space_id in all_stats else 0
+        )
     )
     df["EXPLORE_OPERATIONS"] = df["IDENTIFIER"].apply(
-        lambda space_id: metastore_stats[space_id].number_of_explore_operations
+        lambda space_id: (
+            all_stats[space_id].number_of_explore_operations
+            if space_id in all_stats
+            else 0
+        )
     )
     df["MEASURED_ENTITIES"] = df["IDENTIFIER"].apply(
-        lambda space_id: space_id_to_measured_entity_count.get(space_id, 0)
+        lambda space_id: (
+            all_stats[space_id].number_measured_entities if space_id in all_stats else 0
+        )
     )
+
+    # Attach heavy columns only when requested.
+    if include_heavy:
+        _heavy_field_map = {
+            "SIZE_OF_ENTITY_SPACE": "size_of_entity_space",
+            "UNMEASURED_ENTITIES": "number_unmeasured_entities",
+            "MATCHING_ENTITIES": "number_matching_entities",
+            "MATCHING_WITH_MEASUREMENTS": "number_matching_entities_with_measurements",
+            "ENTITIES_WITH_ALL_MEASUREMENTS": "entities_with_all_measurements",
+            "ENTITIES_WITH_PARTIAL_MEASUREMENTS": "entities_with_partial_measurements",
+            "MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS": "matching_entities_with_all_measurements",
+        }
+        for col, field in _heavy_field_map.items():
+            df[col] = df["IDENTIFIER"].apply(
+                lambda space_id, field_name=field: (
+                    getattr(all_stats[space_id], field_name, None)
+                    if space_id in all_stats
+                    else None
+                )
+            )
 
     return df
 

--- a/orchestrator/cli/utils/resources/formatters.py
+++ b/orchestrator/cli/utils/resources/formatters.py
@@ -570,6 +570,18 @@ def format_ado_get_stats_for_spaces(
                 )
             )
 
+        # Coerce SIZE_OF_ENTITY_SPACE and UNMEASURED_ENTITIES to int where the
+        # value is finite (i.e. not inf/nan/None).  Pandas stores mixed
+        # int/float/None columns as float64, which renders integers as "45.0".
+        def _coerce_to_int_if_finite(v: object) -> object:
+            if isinstance(v, float) and math.isfinite(v):
+                return int(v)
+            return v
+
+        for col in ("SIZE_OF_ENTITY_SPACE", "UNMEASURED_ENTITIES"):
+            if col in df.columns:
+                df[col] = df[col].apply(_coerce_to_int_if_finite)
+
     return df
 
 

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -143,6 +143,7 @@ class DiscoverySpace:
         identifier: str | None = None,
         metadata_store: "SQLResourceStore | None" = None,
         samplestore_resource: "orchestrator.core.SampleStoreResource | None" = None,
+        sample_store: "orchestrator.core.samplestore.base.SampleStore | None" = None,
         load_experiment_catalog: bool = True,
     ) -> "DiscoverySpace":
         """Creates a discovery space from a config
@@ -158,7 +159,11 @@ class DiscoverySpace:
                 discovery space generates the id versus how the id used to store was generated)
             metadata_store: Optional SQLResourceStore instance to reuse. If None, a new instance will be created.
             samplestore_resource: Optional pre-fetched SampleStoreResource. When provided the metastore
-                round-trip to fetch the samplestore is skipped.
+                round-trip to fetch the samplestore is skipped. Ignored when *sample_store* is provided.
+            sample_store: An already-instantiated SampleStore to use directly. When provided, both
+                the metastore round-trip and the ``SampleStore.from_resource`` call are skipped,
+                and the same object is reused — preserving any in-memory entity cache.
+                Takes precedence over *samplestore_resource*.
             load_experiment_catalog: When ``True`` (default) the samplestore's experiment catalog is
                 loaded and registered with the actuator registry.  Set to ``False`` for read-only
                 paths (e.g. CLI show commands) where replay experiment resolution is not needed.
@@ -174,13 +179,14 @@ class DiscoverySpace:
 
         entitySpace = None
 
-        sample_store = (
-            SampleStore.from_resource(samplestore_resource)
-            if samplestore_resource is not None
-            else SampleStore.from_identifier(
-                identifier=conf.sampleStoreIdentifier, metastore=metadata_store
+        if sample_store is None:
+            sample_store = (
+                SampleStore.from_resource(samplestore_resource)
+                if samplestore_resource is not None
+                else SampleStore.from_identifier(
+                    identifier=conf.sampleStoreIdentifier, metastore=metadata_store
+                )
             )
-        )
 
         if conf.entitySpace is not None:
             entitySpace = EntitySpaceRepresentation.representationFromConfiguration(

--- a/orchestrator/core/discoveryspace/stats.py
+++ b/orchestrator/core/discoveryspace/stats.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Annotated
 import pydantic
 
 if TYPE_CHECKING:
+    from rich.status import Status
+
     from orchestrator.core.discoveryspace.space import DiscoverySpace
     from orchestrator.core.samplestore.base import ActiveSampleStore
     from orchestrator.metastore.base import ResourceStore
@@ -173,11 +175,6 @@ def lightweight_space_statistics(
     ``number_matching_entities``, ``number_matching_entities_with_measurements``)
     are always ``None``.
 
-    .. note::
-        All ``space_ids`` must belong to the **same** sample store instance that
-        is passed in.  Mixing spaces from different sample stores will produce
-        incorrect results.
-
     Args:
         space_ids: Set of space URIs to compute statistics for.
         space_ids_to_operation_ids: Mapping from each space URI to the set of
@@ -238,23 +235,21 @@ def lightweight_space_statistics(
 def space_statistics_for_spaces(
     spaces: "list[DiscoverySpace]",
     lightweight_only: bool = False,
+    spinner: "Status | None" = None,
 ) -> "dict[str, DiscoverySpaceStatistics]":
     """Compute statistics for multiple discovery spaces with minimal DB round-trips.
 
     Issues a single batched metastore query for all spaces, then one batched
-    sample-store query for all spaces.
-
-    .. note::
-        All spaces in the list **must** share the same sample store instance
-        (i.e. ``spaces[0].sample_store`` is used for every space).  Mixing
-        spaces from different sample stores will produce incorrect results.
-        There is only one metastore, so no constraint applies there.
+    sample-store query per distinct sample store (spaces from different sample
+    stores are handled correctly).
 
     Args:
         spaces: List of :class:`~orchestrator.core.discoveryspace.space.DiscoverySpace`
-            instances to summarise.  All spaces must share the same sample store.
+            instances to summarise.  Spaces may belong to different sample stores.
         lightweight_only: When ``True`` skip all Python-side computation and
             return ``None`` for the heavy fields in every space's statistics.
+        spinner: Optional rich status spinner to update with per-space progress
+            messages during the heavy computation pass.
 
     Returns:
         ``dict[space_id, DiscoverySpaceStatistics]`` keyed by
@@ -265,22 +260,27 @@ def space_statistics_for_spaces(
     if not spaces:
         return {}
 
-    space_ids = {s.uri for s in spaces}
-    space_ids_to_operation_ids = {s.uri: set(s.operations) for s in spaces}
-    metastore = spaces[0].metadataStore
-    sample_store = spaces[0].sample_store
-
-    if not all(s.sample_store is sample_store for s in spaces):
-        raise ValueError(
-            "All spaces passed to space_statistics_for_spaces must share the same sample store."
+    # Group spaces by sample store so we can issue one batched query per store.
+    spaces_by_sample_store: dict[str, list[DiscoverySpace]] = {}
+    for space in spaces:
+        spaces_by_sample_store.setdefault(space.sample_store.identifier, []).append(
+            space
         )
 
-    lightweight_stats = lightweight_space_statistics(
-        space_ids=space_ids,
-        space_ids_to_operation_ids=space_ids_to_operation_ids,
-        metastore=metastore,
-        sample_store=sample_store,
-    )
+    metastore = spaces[0].metadataStore
+
+    lightweight_stats: dict[str, DiscoverySpaceStatistics] = {}
+    for store_spaces in spaces_by_sample_store.values():
+        group_space_ids = {s.uri for s in store_spaces}
+        group_operation_ids = {s.uri: set(s.operations) for s in store_spaces}
+        lightweight_stats.update(
+            lightweight_space_statistics(
+                space_ids=group_space_ids,
+                space_ids_to_operation_ids=group_operation_ids,
+                metastore=metastore,
+                sample_store=store_spaces[0].sample_store,
+            )
+        )
 
     if lightweight_only:
         return lightweight_stats
@@ -290,8 +290,13 @@ def space_statistics_for_spaces(
     # ------------------------------------------------------------------
 
     result: dict[str, DiscoverySpaceStatistics] = {}
+    total = len(spaces)
 
-    for space in spaces:
+    for idx, space in enumerate(spaces, start=1):
+        if spinner is not None:
+            spinner.update(
+                f"Computing heavy statistics for {space.uri} ({idx}/{total})"
+            )
         base = lightweight_stats[space.uri]
         number_measured = base.number_measured_entities
 

--- a/tests/ado/get/test_ado_get_stats.py
+++ b/tests/ado/get/test_ado_get_stats.py
@@ -618,3 +618,102 @@ def test_ado_get_datacontainers_stats_values(
         assert (
             rendered_output in result.output
         ), f"Expected output:\n{rendered_output}\nnot found in:\n{result.output}"
+
+
+@requires_sqlite_3_38
+def test_ado_get_operation_stats_details_columns(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None, datetime.datetime | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """ado get operation <id> -o stats --details adds DESCRIPTION and LABELS columns.
+
+    The operation config (randomwalk_ml_multicloud_operation.yaml) carries the
+    description 'Perform a random walk on all points in a space', so that string
+    must appear in the rendered table when --details is given.  LABELS must also
+    be present as a column header.
+    """
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    operation_id = "op-stats-details-op-001"
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=1,
+        number_requests=1,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "operation",
+            operation_id,
+            "-o",
+            "stats",
+            "--details",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        assert "DESCRIPTION" in result.output, "DESCRIPTION column missing from output"
+        assert "LABELS" in result.output, "LABELS column missing from output"
+        assert (
+            "Perform a random walk on all points in a space" in result.output
+        ), "Operation description missing from output"
+
+
+@requires_sqlite_3_38
+def test_ado_get_space_stats_details_columns(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    ml_multi_cloud_space: DiscoverySpace,
+) -> None:
+    """ado get space <id> -o stats --details adds DESCRIPTION and LABELS columns.
+
+    The ml_multicloud_basic space YAML carries no description or labels, so the
+    DESCRIPTION column must be present but empty, and LABELS must be present as
+    a column header with no value.
+    """
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            tmp_path,
+            "get",
+            "space",
+            ml_multi_cloud_space.uri,
+            "-o",
+            "stats",
+            "--details",
+            "--no-trunc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    if os.environ.get("CI", "false") != "true":
+        assert "DESCRIPTION" in result.output, "DESCRIPTION column missing from output"
+        assert "LABELS" in result.output, "LABELS column missing from output"

--- a/tests/ado/show_stats/__init__.py
+++ b/tests/ado/show_stats/__init__.py
@@ -1,0 +1,2 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT

--- a/tests/ado/show_stats/test_show_stats.py
+++ b/tests/ado/show_stats/test_show_stats.py
@@ -17,8 +17,9 @@ tested elsewhere.
   request-level columns (TOTAL_REQUESTS, FAILED_REQUESTS, SUCCESSFUL_REQUESTS).
 
 All other aspects (output formats, --use-latest, samplestore, datacontainer,
-query filters) are already covered by ``tests/ado/get/test_ado_get_stats.py``
-and ``tests/core/test_space_statistics.py``.
+query filters, loading all resources when no IDs are supplied, ``--details``
+columns) are already covered by ``tests/ado/get/test_ado_get_stats.py`` and
+``tests/core/test_space_statistics.py``.
 """
 
 import json

--- a/tests/ado/show_stats/test_show_stats.py
+++ b/tests/ado/show_stats/test_show_stats.py
@@ -1,0 +1,182 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for `ado show stats` — covering only behaviour not
+tested elsewhere.
+
+* Space stats: ``ado get space -o stats`` only emits the lightweight columns
+  (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES).
+  ``ado show stats discoveryspace`` is the **only** CLI path that appends the
+  heavy columns (SIZE_OF_ENTITY_SPACE, UNMEASURED_ENTITIES, MATCHING_ENTITIES,
+  MATCHING_WITH_MEASUREMENTS, ENTITIES_WITH_ALL_MEASUREMENTS,
+  ENTITIES_WITH_PARTIAL_MEASUREMENTS, MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS).
+
+* Operation request-level stats: ``ado get operation -o stats`` only emits the
+  result-level columns (TOTAL_RESULTS, …, MEASURED_ENTITIES).
+  ``ado show stats operation`` is the **only** CLI path that also appends the
+  request-level columns (TOTAL_REQUESTS, FAILED_REQUESTS, SUCCESSFUL_REQUESTS).
+
+All other aspects (output formats, --use-latest, samplestore, datacontainer,
+query filters) are already covered by ``tests/ado/get/test_ado_get_stats.py``
+and ``tests/core/test_space_statistics.py``.
+"""
+
+import json
+import pathlib
+from collections.abc import Callable
+
+from typer.testing import CliRunner
+
+from orchestrator.cli.core.cli import app as ado
+from orchestrator.core.discoveryspace.space import DiscoverySpace
+from orchestrator.core.samplestore.sql import SQLSampleStore
+from orchestrator.metastore.project import ProjectContext
+from orchestrator.schema.request import MeasurementRequest
+from tests.conftest import requires_sqlite_3_38
+
+# Expected constants for the ml_multi_cloud space
+# (entity space: provider x cpu_family x vcpu_size x nodes = 3x2x2x4 = 48 points)
+_ENTITY_SPACE_SIZE = 48
+_NUMBER_OF_MATCHING_ENTITIES = 42  # all CSV entities satisfy isEntityInSpace
+
+
+# ---------------------------------------------------------------------------
+# discoveryspace — heavy stats columns (unique to show stats)
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_show_stats_discoveryspace_heavy_stats_values(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    ml_multi_cloud_space: DiscoverySpace,
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """show stats discoveryspace emits accurate values for all heavy stats columns.
+
+    ``ado get space -o stats`` does **not** compute the heavy fields; this test
+    verifies the values that are unique to ``ado show stats discoveryspace``.
+
+    Setup: 1 operation, 1 request, 3 entities measured (all with the single
+    benchmark_performance experiment).  Expected values are derived from the
+    known ml_multi_cloud space geometry and CSV sample store:
+      - SIZE_OF_ENTITY_SPACE: 48 (3x2x2x4 entity-space points)
+      - UNMEASURED_ENTITIES: 45 (48 - 3 measured)
+      - MATCHING_ENTITIES: 42 (all CSV entities satisfy isEntityInSpace)
+      - MATCHING_WITH_MEASUREMENTS: 42 (CSV sample store carries observations)
+      - ENTITIES_WITH_ALL_MEASUREMENTS: 3 (one experiment, each entity has one result)
+      - ENTITIES_WITH_PARTIAL_MEASUREMENTS: 0
+      - MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS: 42
+    """
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_entities = 3
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=1,
+        measurements_per_result=1,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "stats",
+            "discoveryspace",
+            ml_multi_cloud_space.uri,
+            "-o",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert ml_multi_cloud_space.uri in data
+    stats = data[ml_multi_cloud_space.uri]
+
+    assert stats["SIZE_OF_ENTITY_SPACE"] == _ENTITY_SPACE_SIZE
+    assert stats["UNMEASURED_ENTITIES"] == _ENTITY_SPACE_SIZE - number_entities
+    assert stats["MATCHING_ENTITIES"] == _NUMBER_OF_MATCHING_ENTITIES
+    assert stats["MATCHING_WITH_MEASUREMENTS"] == _NUMBER_OF_MATCHING_ENTITIES
+    assert stats["ENTITIES_WITH_ALL_MEASUREMENTS"] == number_entities
+    assert stats["ENTITIES_WITH_PARTIAL_MEASUREMENTS"] == 0
+    assert (
+        stats["MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS"] == _NUMBER_OF_MATCHING_ENTITIES
+    )
+
+
+# ---------------------------------------------------------------------------
+# operation — request-level stats columns (unique to show stats)
+# ---------------------------------------------------------------------------
+
+
+@requires_sqlite_3_38
+def test_show_stats_operation_request_level_stats_values(
+    tmp_path: pathlib.Path,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """show stats operation emits accurate values for the request-level columns.
+
+    ``ado get operation -o stats`` does **not** compute the request columns;
+    this test verifies the values that are unique to ``ado show stats operation``.
+
+    Setup: 1 operation, 3 requests (all SUCCESS by default), 2 entities each.
+    Expected values:
+      - TOTAL_REQUESTS: 3
+      - FAILED_REQUESTS: 0
+      - SUCCESSFUL_REQUESTS: 3
+    """
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    number_requests = 3
+    operation_id = "show-stats-op-requests-001"
+    simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=2,
+        number_requests=number_requests,
+        measurements_per_result=1,
+        operation_id=operation_id,
+    )
+
+    result = runner.invoke(
+        ado,
+        [
+            "--override-ado-app-dir",
+            str(tmp_path),
+            "show",
+            "stats",
+            "operation",
+            operation_id,
+            "-o",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert operation_id in data
+    stats = data[operation_id]
+
+    assert stats["TOTAL_REQUESTS"] == number_requests
+    assert stats["FAILED_REQUESTS"] == 0
+    assert stats["SUCCESSFUL_REQUESTS"] == number_requests

--- a/tests/ado/show_stats/test_show_stats.py
+++ b/tests/ado/show_stats/test_show_stats.py
@@ -106,7 +106,9 @@ def test_show_stats_discoveryspace_heavy_stats_values(
     stats = data[ml_multi_cloud_space.uri]
 
     assert stats["SIZE_OF_ENTITY_SPACE"] == _ENTITY_SPACE_SIZE
+    assert isinstance(stats["SIZE_OF_ENTITY_SPACE"], int)
     assert stats["UNMEASURED_ENTITIES"] == _ENTITY_SPACE_SIZE - number_entities
+    assert isinstance(stats["UNMEASURED_ENTITIES"], int)
     assert stats["MATCHING_ENTITIES"] == _NUMBER_OF_MATCHING_ENTITIES
     assert stats["MATCHING_WITH_MEASUREMENTS"] == _NUMBER_OF_MATCHING_ENTITIES
     assert stats["ENTITIES_WITH_ALL_MEASUREMENTS"] == number_entities

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -1323,6 +1323,7 @@ The complete syntax of the `ado show stats` command is as follows:
 ado show stats RESOURCE_TYPE [IDS...] [--use-latest] \
                [--query | -q <path=value>] \
                [--label | -l <key=value>] \
+               [--details] \
                [--output | -o <table|md-table|csv|json|yaml>] \
                [--output-file <path>] \
                [--render]
@@ -1353,6 +1354,8 @@ Where:
 - `--query` (or `-q`) and `--label` (or `-l`) filter which resources are
   included (same semantics as `ado get`). Cannot be used together with explicit
   IDs.
+- `--details` appends `DESCRIPTION` and `LABELS` columns to the output,
+  mirroring the behaviour of `ado get --details`.
 - `--output` (or `-o`) selects the output format:
 
     <!-- prettier-ignore-start -->

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -782,7 +782,7 @@ ado get datacontainer --use-latest -o stats
 
 When interacting with resources, we might be interested in seeing some of their
 details, entities measured, or related resources. `ado show` provides this with
-the four following subcommands.
+the five following subcommands.
 
 #### ado show details
 
@@ -1304,6 +1304,139 @@ ado show summary space my-space-id -o md --output-file summary.md
 
 ```shell
 ado show summary space -q 'config.entitySpace={"propertyDomain":{"values":["granite-7b-base"]}}'
+```
+
+#### ado show stats
+
+_show stats_ supports displaying in-depth statistics for one or more resources.
+It always outputs the same base columns as the corresponding `ado get` table
+(e.g. `IDENTIFIER`, `NAME`, `AGE`) plus a richer set of statistics columns than
+the `ado get -o stats` view. For operations, it also includes request-level
+columns; for discovery spaces, it also includes full entity-space coverage
+columns.
+
+The complete syntax of the `ado show stats` command is as follows:
+
+<!-- markdownlint-disable line-length -->
+
+```shell
+ado show stats RESOURCE_TYPE [IDS...] [--use-latest] \
+               [--query | -q <path=value>] \
+               [--label | -l <key=value>] \
+               [--output | -o <table|md-table|csv|json|yaml>] \
+               [--output-file <path>] \
+               [--render]
+```
+
+<!-- markdownlint-enable line-length -->
+
+Where:
+
+- `RESOURCE_TYPE` is one of the supported resource types. See
+  [Resource Type Shorthands](#resource-type-shorthands) for shorthand aliases.
+  Currently supported:
+
+    <!-- prettier-ignore-start -->
+
+    - _discoveryspace_ (_space_)
+    - _operation_ (_op_)
+    - _samplestore_ (_store_)
+    - _datacontainer_ (_dcr_)
+
+    <!-- prettier-ignore-end -->
+
+- `IDS` is an optional list of one or more resource identifiers to show
+  statistics for. If omitted, statistics are shown for all resources of the
+  given type.
+- `--use-latest` shows statistics for the most recently created resource of the
+  selected type. Ignored if resource identifiers are also specified.
+- `--query` (or `-q`) and `--label` (or `-l`) filter which resources are
+  included (same semantics as `ado get`). Cannot be used together with explicit
+  IDs.
+- `--output` (or `-o`) selects the output format:
+
+    <!-- prettier-ignore-start -->
+
+    - `table` (**default**) — rich console table.
+    - `md-table` — Markdown table.
+    - `csv` — CSV format.
+    - `json` — JSON.
+    - `yaml` — YAML.
+
+    <!-- prettier-ignore-end -->
+
+- `--output-file` writes the output to the specified file instead of stdout.
+- `--render` renders the output in the console. Only supported for `md-table`
+  output.
+
+The statistics columns produced per resource type are:
+
+<!-- prettier-ignore-start -->
+
+- **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
+  `MEASURED_ENTITIES`, `TOTAL_REQUESTS`, `FAILED_REQUESTS`,
+  `SUCCESSFUL_REQUESTS`.
+- **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`,
+  `MEASURED_ENTITIES`, `SIZE_OF_ENTITY_SPACE`, `UNMEASURED_ENTITIES`,
+  `MATCHING_ENTITIES`, `MATCHING_WITH_MEASUREMENTS`,
+  `ENTITIES_WITH_ALL_MEASUREMENTS`, `ENTITIES_WITH_PARTIAL_MEASUREMENTS`,
+  `MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS`.
+- **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
+- **Data Containers**: `TABLES`, `LOCATIONS`, `KEY_VALUES`, `DATA_BYTES`.
+
+<!-- prettier-ignore-end -->
+
+!!! note
+
+    `ado show stats discoveryspace` computes full entity-space coverage
+    statistics including the heavy columns (`SIZE_OF_ENTITY_SPACE`,
+    `UNMEASURED_ENTITIES`, `MATCHING_ENTITIES`, etc.). This is slower than
+    `ado get spaces -o stats` because it instantiates each
+    `DiscoverySpace` and queries the sample store. Use `ado get -o stats` for
+    quick overviews.
+
+##### Examples
+
+###### Show full statistics for all operations
+
+```shell
+ado show stats operation
+```
+
+###### Show full statistics for a specific discovery space
+
+```shell
+ado show stats discoveryspace space-abc123-456def
+```
+
+###### Show full statistics for the latest operation as JSON
+
+```shell
+ado show stats operation --use-latest -o json
+```
+
+###### Show full statistics for the latest operation as YAML
+
+```shell
+ado show stats operation --use-latest -o yaml
+```
+
+###### Show full statistics for sample stores matching a label
+
+```shell
+ado show stats samplestore -l team=research
+```
+
+###### Show full statistics for all discovery spaces as a Markdown table
+
+```shell
+ado show stats discoveryspace -o md-table
+```
+
+###### Save full statistics to a file
+
+```shell
+ado show stats operation --output-file operations-stats.csv -o csv
 ```
 
 ### ado template


### PR DESCRIPTION
## Add `ado show stats` command

Introduces a new `ado show stats <resource-type> [ids...]` subcommand that surfaces in-depth statistics for the four main resource types: **discoveryspace**, **operation**, **samplestore**, and **datacontainer**.

### What changed

**New CLI command — `ado show stats <resource-type> [ids...]`**
- Accepts one or more resource IDs, `--use-latest`, `--query`/`-q`, and `--label`/`-l` filters (same UX as `ado get`).
- `--details` flag appends name/description/labels to the output (parity with `ado get --details`).
- `--output`/`-o` supports five formats: rich console table (`table`), markdown table (`md-table`), `csv`, `json`, `yaml`; write to file with `--output-file`.
- `--render` flag renders a markdown table inline in the terminal via Rich.

**Per-resource stats surfaced**

| Resource | Lightweight columns | Heavy / `--details` columns |
|---|---|---|
| discoveryspace | EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES | SIZE_OF_ENTITY_SPACE, UNMEASURED_ENTITIES, MATCHING_ENTITIES (+ breakdown) |
| operation | TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES | TOTAL_REQUESTS, FAILED_REQUESTS, SUCCESSFUL_REQUESTS |
| samplestore | ENTITIES, RESULTS, EXPERIMENTS | — |
| datacontainer | dedicated stats columns | — |

**Internal improvements**
- `format_ado_get_stats_for_spaces` / `format_ado_get_stats_for_operations` in `formatters.py` gained a lightweight vs. heavy two-path design; `include_request_columns` and `include_heavy` flags gate the extra columns; float-printing bug for entity counts fixed.
- New `build_resource_listing_dataframe` helper avoids loading all resources of a kind when only specific IDs are requested.
- New `render_stats_dataframe` shared utility in `orchestrator/cli/utils/output/stats.py` handles all five output formats consistently for every resource type.
- `DiscoverySpace.from_configuration` accepts a pre-instantiated `sample_store` parameter to skip the metastore round-trip and reuse in-memory entity caches.
- `space_statistics_for_spaces` now handles spaces from **different** sample stores correctly (previously raised `ValueError`); accepts an optional `spinner` for per-space progress updates.
- New `AdoShowStatsCommandParameters`, `AdoShowStatsSupportedOutputFormats`, and `AdoShowStatsSupportedResourceTypes` types added in `cli/models/`.

**Tests & docs**
- 185-line integration test suite added under `tests/ado/show_stats/`; 99-line tests added for `ado get` stats path under `tests/ado/get/`.
- Getting-started documentation extended with `ado show stats` examples; cross-references added in `examining-ado-operations`, `examining-discovery-spaces`, `examining-ado-project`, and `using-ado-cli` skills.