### PR TITLE
refactor(cli)!: rename --query to --filter

### DIFF
--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -31,7 +31,7 @@ DOs:
   confirm what is available in metadata - ado template RESOURCETYPE
   --include-schema
 - Use Server side filtering
-  - prefer --query or --matching to fetching metadata and filtering on client
+  - prefer --filter or --matching to fetching metadata and filtering on client
     side
 - Fetch metadata over fetching data
   - if a query can be answered via metadata it is much faster
@@ -120,27 +120,27 @@ result).
 Filter resources based on metadata fields using MySQL JSON Path queries:
 
 ```bash
-uv run ado get $RESOURCETYPE --query 'path=candidate'
+uv run ado get $RESOURCETYPE --filter 'path=candidate'
 ```
 
 - Use single quotes around the candidate (required for strings, dictionaries,
   arrays)
 - Path is dot-separated (e.g., `config.metadata.labels`)
 - Candidate is a valid JSON value
-- Can specify `--query` multiple times (all filters must match)
+- Can specify `--filter` multiple times (all filters must match)
 
 **Examples:**
 
 ```bash
 # Find operations using a specific operator
-uv run ado get operations -q 'config.operation.module.moduleClass=RayTune'
+uv run ado get operations --filter 'config.operation.module.moduleClass=RayTune'
 
 # Find spaces with a specific experiment
-uv run ado get spaces -q 'config.experiments={"experiments":{"identifier":"finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0"}}'
+uv run ado get spaces --filter 'config.experiments={"experiments":{"identifier":"finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0"}}'
 
 # Combine multiple filters
-uv run ado get operations -q 'config.operation.parameters.batchSize=1'
--q 'status=[{"event": "finished", "exit_state": "success"}]'
+uv run ado get operations --filter 'config.operation.parameters.batchSize=1' \
+  --filter 'status=[{"event": "finished", "exit_state": "success"}]'
 ```
 
 For extensive examples, see `website/docs/resources/metastore.md`.
@@ -175,7 +175,7 @@ uv run ado get space --matching-space space.yaml
 ```
 
 **Note**: `--matching-point`, `--matching-space`, and `--matching-space-id` are
-exclusive to spaces and override `--query` and `--label`.
+exclusive to spaces and override `--filter` and `--label`.
 
 ### Related Resources
 
@@ -300,14 +300,16 @@ uv run ado template operation --operator-name OPERATOR_NAME --include-schema
 
 ### Find operations that finished successfully
 
+<!-- markdownlint-disable line-length -->
 ```bash
-uv run ado get operations -q 'status=[{"event": "finished", "exit_state": "success"}]'
+uv run ado get operations --filter 'status=[{"event": "finished", "exit_state": "success"}]'
 ```
+<!-- markdownlint-enable line-length -->
 
 ### Find spaces containing a specific model
 
 ```bash
-uv run ado get spaces -q 'config.entitySpace={"propertyDomain":{"values":["mistral-7b-v0.1"]}}'
+uv run ado get spaces --filter 'config.entitySpace={"propertyDomain":{"values":["mistral-7b-v0.1"]}}'
 ```
 
 ### Export operation entities to CSV

--- a/.cursor/skills/resource-yaml-creation/SKILL.md
+++ b/.cursor/skills/resource-yaml-creation/SKILL.md
@@ -18,7 +18,7 @@ problem formulation workflow, see
 
 Every resource YAML should include a `metadata` block. The CLI uses these for
 display (`ado get --details`) and filtering (`ado get --label`,
-`ado get --query`).
+`ado get --filter`).
 
 ```yaml
 metadata:
@@ -32,8 +32,8 @@ metadata:
 
 - `name` and `description` are shown by `ado get --details`
 - `labels` support filtering: `uv run ado get spaces --label project=my_project`
-- `--query` supports path-based filtering across any field:
-  `uv run ado get spaces --query "metadata.name=my_space"`
+- `--filter` supports path-based filtering across any field:
+  `uv run ado get spaces --filter "metadata.name=my_space"`
 
 ## Dynamic Reference Resolution
 

--- a/orchestrator/cli/commands/get.py
+++ b/orchestrator/cli/commands/get.py
@@ -84,10 +84,10 @@ def get_resource(
             show_default=False,
         ),
     ] = False,
-    query: Annotated[
+    filters: Annotated[
         list[str] | None,
         typer.Option(
-            "--query",
+            "--filter",
             "-q",
             help="""
             Filter results by values contained in the resources. Will return all resources that match
@@ -97,7 +97,7 @@ def get_resource(
             and value is a JSON document.
 
             Please refer to the documentation provided for more information and examples:
-            https://ibm.github.io/ado/getting-started/ado/#using-the-field-level-querying-functionality
+            https://ibm.github.io/ado/getting-started/ado/#searching-and-filtering
             """,
             show_default=False,
         ),
@@ -221,7 +221,7 @@ def get_resource(
             help="""
             Provide a point configuration to match a space. Only for spaces.
 
-            If set, disregards --query and --label.
+            If set, disregards --filter and --label.
             """,
             file_okay=True,
             dir_okay=False,
@@ -236,7 +236,7 @@ def get_resource(
             help="""
             Provide a space configuration to match other spaces. Only for spaces.
 
-            If set, disregards --query and --label, and uses the table output format.
+            If set, disregards --filter and --label, and uses the table output format.
             """,
             file_okay=True,
             dir_okay=False,
@@ -252,7 +252,7 @@ def get_resource(
             Provide a space id to match other spaces. Only for spaces.
             Takes precedence over --matching-space.
 
-            If set, disregards --query and --label, and uses the table output format.
+            If set, disregards --filter and --label, and uses the table output format.
             """,
             show_default=False,
             rich_help_panel=DISCOVERY_SPACE_ONLY_OPTIONS,
@@ -345,11 +345,11 @@ def get_resource(
         exclude_unset = True
 
     try:
-        field_selectors = prepare_query_filters_for_db(parse_key_value_pairs(query))
+        filter_conditions = prepare_query_filters_for_db(parse_key_value_pairs(filters))
         if labels:
             for parsed_label in parse_key_value_pairs(labels):
                 for k, v in parsed_label.items():
-                    field_selectors.extend(
+                    filter_conditions.extend(
                         prepare_query_filters_for_db({"config.metadata.labels": {k: v}})
                     )
     except ValueError as e:
@@ -362,7 +362,7 @@ def get_resource(
         exclude_fields=exclude_fields,
         exclude_none=exclude_none,
         exclude_unset=exclude_unset,
-        field_selectors=field_selectors,
+        field_selectors=filter_conditions,
         matching_point=matching_point,
         matching_space_id=matching_space_id,
         matching_space=matching_space,

--- a/orchestrator/cli/commands/show_stats.py
+++ b/orchestrator/cli/commands/show_stats.py
@@ -63,10 +63,10 @@ def show_stats_for_resources(
             show_default=False,
         ),
     ] = False,
-    query: Annotated[
+    filters: Annotated[
         list[str] | None,
         typer.Option(
-            "--query",
+            "--filter",
             "-q",
             help="""
             Filter results by values contained in the resources. Will return all resources that match
@@ -76,7 +76,7 @@ def show_stats_for_resources(
             and value is a JSON document.
 
             Please refer to the documentation provided for more information and examples:
-            https://ibm.github.io/ado/getting-started/ado/#using-the-field-level-querying-functionality
+            https://ibm.github.io/ado/getting-started/ado/#searching-and-filtering
             """,
             show_default=False,
         ),
@@ -163,11 +163,11 @@ def show_stats_for_resources(
         ids = [resource_id]
 
     try:
-        query_filters = prepare_query_filters_for_db(parse_key_value_pairs(query))
+        filter_conditions = prepare_query_filters_for_db(parse_key_value_pairs(filters))
         if labels:
             for parsed_label in parse_key_value_pairs(labels):
                 for k, v in parsed_label.items():
-                    query_filters.extend(
+                    filter_conditions.extend(
                         prepare_query_filters_for_db({"config.metadata.labels": {k: v}})
                     )
     except ValueError as e:
@@ -178,7 +178,7 @@ def show_stats_for_resources(
         ado_configuration=ado_configuration,
         output_format=output_format,
         output_file=output_file,
-        query=query_filters if (query or labels) else None,
+        filters=filter_conditions if (filters or labels) else None,
         render_output=render_output,
         resource_ids=ids,
         show_details=show_details,

--- a/orchestrator/cli/commands/show_trace.py
+++ b/orchestrator/cli/commands/show_trace.py
@@ -3,7 +3,7 @@
 
 import pathlib
 import typing
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
@@ -78,6 +78,7 @@ def show_trace_for_resources(
         list[str] | None,
         typer.Option(
             "--filter",
+            "-q",
             help="Filter using YAML field names from the data model. "
             "Can be used multiple times for AND logic. "
             "Only request-level filters are supported. "
@@ -176,18 +177,18 @@ def show_trace_for_resources(
         )
 
     # Parse filters and prepare for DB
-    field_selectors = []
+    filter_conditions: list[dict[str, Any]] = []
     if filters:
         try:
             parsed_filters = parse_key_value_pairs(filters)
-            field_selectors = prepare_query_filters_for_db(parsed_filters)
+            filter_conditions = prepare_query_filters_for_db(parsed_filters)
         except ValueError as e:
             console_print(f"{ERROR}{e}", stderr=True)
             raise typer.Exit(1) from e
 
     parameters = AdoShowTraceCommandParameters(
         ado_configuration=ado_configuration,
-        field_selectors=field_selectors,  # type: ignore[arg-type]
+        field_selectors=filter_conditions,  # type: ignore[arg-type]
         hide_fields=hide_fields,
         unroll_entities=unroll_entities,
         no_trunc=no_trunc,

--- a/orchestrator/cli/models/parameters.py
+++ b/orchestrator/cli/models/parameters.py
@@ -118,7 +118,7 @@ class AdoShowStatsCommandParameters(pydantic.BaseModel):
     ado_configuration: AdoConfiguration
     output_format: AdoShowStatsSupportedOutputFormats
     output_file: Path | None
-    query: list[dict[str, str | None]] | None
+    filters: list[dict[str, str | None]] | None
     render_output: bool
     resource_ids: list[str] | None
     show_details: bool

--- a/orchestrator/cli/resources/datacontainer/show_stats.py
+++ b/orchestrator/cli/resources/datacontainer/show_stats.py
@@ -32,9 +32,9 @@ def show_datacontainer_stats(parameters: AdoShowStatsCommandParameters) -> None:
         parameters: Command parameters including resource IDs, output format,
             output file, query filters, and render flag.
     """
-    if parameters.query and parameters.resource_ids:
+    if parameters.filters and parameters.resource_ids:
         console_print(
-            f"{ERROR}You cannot specify datacontainer ids and queries/labels at the same time",
+            f"{ERROR}You cannot specify datacontainer ids and filters/labels at the same time",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -56,7 +56,7 @@ def show_datacontainer_stats(parameters: AdoShowStatsCommandParameters) -> None:
         else:
             datacontainer_resources = sql_store.getResourceIdentifiersOfKind(
                 kind=CoreResourceKinds.DATACONTAINER.value,
-                field_selectors=parameters.query,
+                field_selectors=parameters.filters,
                 details=parameters.show_details,
             )
             base_df = format_default_ado_get_multiple_resources(
@@ -65,9 +65,9 @@ def show_datacontainer_stats(parameters: AdoShowStatsCommandParameters) -> None:
             )
 
         if base_df.empty:
-            if parameters.query:
+            if parameters.filters:
                 console_print(
-                    f"{ERROR}The query/labels provided did not match any datacontainer.",
+                    f"{ERROR}The filter/labels provided did not match any datacontainer.",
                     stderr=True,
                 )
                 raise typer.Exit(1)

--- a/orchestrator/cli/resources/discovery_space/show_stats.py
+++ b/orchestrator/cli/resources/discovery_space/show_stats.py
@@ -37,9 +37,9 @@ def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> Non
         parameters: Command parameters including resource IDs, output format,
             output file, query filters, and render flag.
     """
-    if parameters.query and parameters.resource_ids:
+    if parameters.filters and parameters.resource_ids:
         console_print(
-            f"{ERROR}You cannot specify space ids and queries/labels at the same time",
+            f"{ERROR}You cannot specify space ids and filters/labels at the same time",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -55,7 +55,7 @@ def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> Non
         else:
             space_resources = sql_store.getResourcesOfKind(
                 kind=CoreResourceKinds.DISCOVERYSPACE.value,
-                field_selectors=parameters.query,
+                field_selectors=parameters.filters,
             )
 
         base_df = format_default_ado_get_multiple_resources(
@@ -68,9 +68,9 @@ def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> Non
         )
 
         if base_df.empty:
-            if parameters.query:
+            if parameters.filters:
                 console_print(
-                    f"{ERROR}The query/labels provided did not match any space.",
+                    f"{ERROR}The filter/labels provided did not match any space.",
                     stderr=True,
                 )
                 raise typer.Exit(1)

--- a/orchestrator/cli/resources/operation/show_stats.py
+++ b/orchestrator/cli/resources/operation/show_stats.py
@@ -35,9 +35,9 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
         parameters: Command parameters including resource IDs, output format,
             output file, query filters, and render flag.
     """
-    if parameters.query and parameters.resource_ids:
+    if parameters.filters and parameters.resource_ids:
         console_print(
-            f"{ERROR}You cannot specify operation ids and queries/labels at the same time",
+            f"{ERROR}You cannot specify operation ids and filters/labels at the same time",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -59,7 +59,7 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
         else:
             operation_resources = sql_store.getResourceIdentifiersOfKind(
                 kind=CoreResourceKinds.OPERATION.value,
-                field_selectors=parameters.query,
+                field_selectors=parameters.filters,
                 details=parameters.show_details,
             )
             base_df = format_default_ado_get_multiple_resources(
@@ -68,9 +68,9 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
             )
 
         if base_df.empty:
-            if parameters.query:
+            if parameters.filters:
                 console_print(
-                    f"{ERROR}The query/labels provided did not match any operation.",
+                    f"{ERROR}The filter/labels provided did not match any operation.",
                     stderr=True,
                 )
                 raise typer.Exit(1)

--- a/orchestrator/cli/resources/samplestore/show_stats.py
+++ b/orchestrator/cli/resources/samplestore/show_stats.py
@@ -32,9 +32,9 @@ def show_samplestore_stats(parameters: AdoShowStatsCommandParameters) -> None:
         parameters: Command parameters including resource IDs, output format,
             output file, query filters, and render flag.
     """
-    if parameters.query and parameters.resource_ids:
+    if parameters.filters and parameters.resource_ids:
         console_print(
-            f"{ERROR}You cannot specify samplestore ids and queries/labels at the same time",
+            f"{ERROR}You cannot specify samplestore ids and filters/labels at the same time",
             stderr=True,
         )
         raise typer.Exit(1)
@@ -56,7 +56,7 @@ def show_samplestore_stats(parameters: AdoShowStatsCommandParameters) -> None:
         else:
             samplestore_resources = sql_store.getResourceIdentifiersOfKind(
                 kind=CoreResourceKinds.SAMPLESTORE.value,
-                field_selectors=parameters.query,
+                field_selectors=parameters.filters,
                 details=parameters.show_details,
             )
             base_df = format_default_ado_get_multiple_resources(
@@ -65,9 +65,9 @@ def show_samplestore_stats(parameters: AdoShowStatsCommandParameters) -> None:
             )
 
         if base_df.empty:
-            if parameters.query:
+            if parameters.filters:
                 console_print(
-                    f"{ERROR}The query/labels provided did not match any samplestore.",
+                    f"{ERROR}The filter/labels provided did not match any samplestore.",
                     stderr=True,
                 )
                 raise typer.Exit(1)

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -80,7 +80,7 @@ def test_get_robotic_lab_actuator() -> None:
 
 
 @requires_sqlite_3_38
-def test_field_querying(
+def test_field_filtering(
     tmp_path: pathlib.Path,
     mysql_test_instance: MySqlContainer,
     sql_store: SQLStore,
@@ -144,7 +144,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             "config.operation.parameters.batchSize=1",
         ],
     )
@@ -167,7 +167,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             "config.operation.parameters.batchSize=1.0",
         ],
     )
@@ -190,7 +190,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             'config.parameters.batchSize="1"',
         ],
     )
@@ -208,7 +208,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "samplestores",
-            "-q",
+            "--filter",
             "config.metadata.name=null",
         ],
     )
@@ -226,7 +226,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "samplestores",
-            "-q",
+            "--filter",
             'config.metadata.name="null"',
         ],
     )
@@ -244,7 +244,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             "config.operation.parameters.singleMeasurement=false",
         ],
     )
@@ -267,7 +267,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             'config.parameters.singleMeasurement="false"',
         ],
     )
@@ -285,7 +285,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             'status=[{"event": "finished", "exit_state": "success"}]',
         ],
     )
@@ -309,7 +309,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             "config.spaces=space-7dab39-c0c30f",
         ],
     )
@@ -332,7 +332,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             'config={"spaces": ["space-7dab39-c0c30f"]}',
         ],
     )
@@ -355,7 +355,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "operations",
-            "-q",
+            "--filter",
             'config.operation.parameters={"batchSize": 2, "samplerConfig": {"mode": "sequential"}}',
         ],
     )
@@ -379,7 +379,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "actuatorconfigurations",
-            "-q",
+            "--filter",
             'config.parameters.outer_field.inner_field.test_value="found_it"',
         ],
     )
@@ -401,7 +401,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "actuatorconfigurations",
-            "-q",
+            "--filter",
             'config.parameters.outer_field={"inner_field": {"test_value": "found_it"}}',
         ],
     )
@@ -423,7 +423,7 @@ def test_field_querying(
             tmp_path,
             "get",
             "actuatorconfigurations",
-            "-q",
+            "--filter",
             'config.parameters.outer_field.another_field="simple"',
         ],
     )

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -482,7 +482,7 @@ ado get RESOURCE_TYPE [RESOURCE_ID] [--output | -o <default | yaml | json | conf
                                     [--exclude-unset | --no-exclude-unset ] \
                                     [--exclude-none | --no-exclude-none ] \
                                     [--minimize] \
-                                    [--query | -q <path=value>] \
+                                    [--filter | -q <path=value>] \
                                     [--label | -l <key=value>] \
                                     [--details] [--show-deprecated] \
                                     [--matching-point <point.yaml>] \
@@ -576,7 +576,7 @@ Where:
 See [searching the metastore](../resources/metastore.md#searching-the-metastore)
 for detailed information on the following options, including syntax.
 
-- By using (optionally multiple times) the `--query` (or `-q`) flag, users can
+- By using (optionally multiple times) the `--filter` (or `-q`) flag, users can
   restrict the resources returned by requiring that a field in the resource
   contains a given value. This flag can be specified multiple times (even in
   conjunction with `-l` to further filter results).
@@ -616,12 +616,12 @@ ado get spaces --details
 
 !!! info
 
-    More information on field-level querying is provided in the
+    More information on field-level filtering is provided in the
     [searching the metastore](../resources/metastore.md#searching-the-metastore)
     section
 
 ```shell
-ado get space -q 'config.entitySpace={"propertyDomain":{"values":["granite-7b-base"]}}'
+ado get space --filter 'config.entitySpace={"propertyDomain":{"values":["granite-7b-base"]}}'
 ```
 
 ##### Getting all Discovery Spaces with certain labels
@@ -1180,7 +1180,7 @@ Where:
   given type.
 - `--use-latest` shows statistics for the most recently created resource of the
   selected type. Ignored if resource identifiers are also specified.
-- `--query` (or `-q`) and `--label` (or `-l`) filter which resources are
+- `--filter` (or `-q`) and `--label` (or `-l`) filter which resources are
   included (same semantics as `ado get`). Cannot be used together with explicit
   IDs.
 - `--details` appends `DESCRIPTION` and `LABELS` columns to the output,

--- a/website/docs/resources/metastore.md
+++ b/website/docs/resources/metastore.md
@@ -228,7 +228,7 @@ will retrieve all operations that have the label `labelone` with the value
 
 ### Searching inside resource representations
 
-For more advanced searches, `ado` provides the `--query` option to find
+For more advanced searches, `ado` provides the `--filter` option to find
 resources based on the contents of their
 [stored representation](resources.md/#common-features-of-resources). This option
 can be specified multiple times and in conjunction with the `-l` option to find
@@ -237,14 +237,14 @@ resources that match all the specified filters.
 The syntax is:
 
 ```commandline
--q 'path=candidate'
+--filter 'path=candidate'
 ```
 
 !!! warning inline end
 
-    We suggest using single quotation marks around the candidate passed to the -q
-    option. **This is required when dealing with strings, dictionaries, and
-    arrays**.
+    We suggest using single quotation marks around the candidate passed to the
+    --filter option. **This is required when dealing with strings, dictionaries,
+    and arrays**.
 
 Where:
 
@@ -316,14 +316,16 @@ If the candidate is a scalar (a string in double quotes, a number, `true`,
 **same type** (treating integers and floats as equivalent) and has the **same
 value**.
 
-- ✅ `ado get operations -q 'config.operation.parameters.batchSize=1'` (1 == 1)
-- ✅ `ado get operations -q 'config.operation.parameters.batchSize=1.0'` (1.0 ==
-  1, floats and ints count as same type)
-- ❌ `ado get operations -q 'config.operation.parameters.batchSize="1"'` ("1" !=
-  1, type mismatch)
-- ✅ `ado get operation -q 'config.operation.parameters.singleMeasurement=true'`
-- ❌ `ado get operation -q 'config.operation.parameters.singleMeasurement=True'`
+<!-- markdownlint-disable line-length -->
+- ✅ `ado get operations --filter 'config.operation.parameters.batchSize=1'` (1 == 1)
+- ✅ `ado get operations --filter 'config.operation.parameters.batchSize=1.0'`
+  (1.0 == 1, floats and ints count as same type)
+- ❌ `ado get operations --filter 'config.operation.parameters.batchSize="1"'`
+  ("1" != 1, type mismatch)
+- ✅ `ado get operation --filter 'config.operation.parameters.singleMeasurement=true'`
+- ❌ `ado get operation --filter 'config.operation.parameters.singleMeasurement=True'`
   (`true` and `false` are the only boolean values in JSON)
+<!-- markdownlint-enable line-length -->
 
 ##### The path points to an array
 
@@ -331,20 +333,21 @@ value**.
 it **contains all elements of the candidate**.
 
 - ✅
-  `ado get operation -q 'status=[{"event": "finished", "exit_state": "success"}]'`
+  `ado get operation --filter 'status=[{"event": "finished", "exit_state": "success"}]'`
   (all keys are contained)
 - ❌
-  `ado get operation -q 'status=[{"exit_state": "success"}, {"exit_state": "failure"}]'`
+  <!-- markdownlint-disable-next-line line-length -->
+  `ado get operation --filter 'status=[{"exit_state": "success"}, {"exit_state": "failure"}]'`
   (no operation can have both a `success` and a `failure` exit state)
 
 **If the candidate is not an array**, the array at the specified path will match
 if it **contains the candidate**.
 
-- ✅ `ado get operation -q 'status={"exit_state": "success"}'` (status has an
-  element that contains the key `exit_state` and value `success`)
-- ✅ `ado get operation -q 'config.spaces=space-3904a4-96dd91'` (the string is
-  part of the array)
-- ❌ `ado get operation -q 'status={"event": "fake"}'` (no element of the
+- ✅ `ado get operation --filter 'status={"exit_state": "success"}'`
+  (status has an element that contains the key `exit_state` and value `success`)
+- ✅ `ado get operation --filter 'config.spaces=space-3904a4-96dd91'`
+  (the string is part of the array)
+- ❌ `ado get operation --filter 'status={"event": "fake"}'` (no element of the
   `status` array has the value `fake` for the `event` key)
 
 ##### The path points to a dictionary (JSON object)
@@ -354,10 +357,10 @@ match if it contains all keys and corresponding values from the candidate.
 
 <!-- markdownlint-disable line-length -->
 - ✅
-  `ado get operation -q 'config.operation.parameters={"batchSize": 1, "samplerConfig": {"mode": "random"}}'`
+  `ado get operation --filter 'config.operation.parameters={"batchSize": 1, "samplerConfig": {"mode": "random"}}'`
 - ❌
-  `ado get operation -q 'config.operation.parameters={"batchSize": 1, "samplerConfig": {"mode": "smart"}}'`
-  (the operation's `samplerConfig.mode` is `random`)
+  `ado get operation --filter 'config.operation.parameters={"batchSize": 1, "samplerConfig": {"mode": "smart"}}'`
+  (the operation's `samplerConfig.mode` is `random`)
 <!-- markdownlint-enable line-length -->
 
 !!! tip
@@ -371,34 +374,34 @@ match if it contains all keys and corresponding values from the candidate.
 
 ##### Finding operations using a certain operator
 
-If you want to query operations that use the RayTune operator you can do it
+If you want to filter operations that use the RayTune operator you can do it
 with:
 
 ```commandline
-ado get operations -q config.operation.module.moduleClass=RayTune
+ado get operations --filter config.operation.module.moduleClass=RayTune
 ```
 
 ##### Finding spaces with a boolean parameterization
 
-To query all spaces are parameterized with the `bf16` property with the boolean
-value `true`, you will have to query using the value `1` instead. This is
+To filter all spaces parameterized with the `bf16` property with the boolean
+value `true`, you will have to filter using the value `1` instead. This is
 because `ado` applies a type conversion to boolean values in
 [properties](/ado/resources/discovery-spaces/#defining-the-domains-of-constitutive-properties-in-the-entityspace):
 
 <!-- markdownlint-disable line-length -->
 ```commandline
-ado get spaces -q 'config.experiments={"experiments":{"parameterization":[{"property":{"identifier":"bf16"},"value":1}]}}
+ado get spaces --filter 'config.experiments={"experiments":{"parameterization":[{"property":{"identifier":"bf16"},"value":1}]}}
 ```
 <!-- markdownlint-enable line-length -->
 
 ##### Finding spaces with a specific experiment
 
-To query all spaces that contain the
+To filter all spaces that contain the
 `finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0` experiment:
 
 <!-- markdownlint-disable line-length -->
 ```commandline
-ado get spaces -q 'config.experiments={"experiments":{"identifier":"finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0"}}'
+ado get spaces --filter 'config.experiments={"experiments":{"identifier":"finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0"}}'
 ```
 <!-- markdownlint-enable line-length -->
 
@@ -407,9 +410,9 @@ To also include those using `NVIDIA-A100-SXM4-80GB` for `gpu_model` and
 
 <!-- markdownlint-disable line-length -->
 ```commandline
-ado get spaces -q 'config.entitySpace={"identifier": "model_name", "propertyDomain":{"values":["mistral-7b-v0.1"]}}' \
-               -q 'config.entitySpace={"identifier": "gpu_model", "propertyDomain":{"values":["NVIDIA-A100-SXM4-80GB"]}}' \
-               -q 'config.experiments={"experiments":{"identifier":"finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0"}}'
+ado get spaces --filter 'config.entitySpace={"identifier": "model_name", "propertyDomain":{"values":["mistral-7b-v0.1"]}}' \
+               --filter 'config.entitySpace={"identifier": "gpu_model", "propertyDomain":{"values":["NVIDIA-A100-SXM4-80GB"]}}' \
+               --filter 'config.experiments={"experiments":{"identifier":"finetune-lora-fsdp-r-4-a-16-tm-default-v2.0.0"}}'
 ```
 <!-- markdownlint-enable line-length -->
 


### PR DESCRIPTION
## Rename `--query` / `-q` to `--filter` in `ado get`

The CLI option previously called `--query` (short form `-q`) has been renamed to
`--filter` across the board. This is a purely cosmetic, user-facing rename — no
logic has changed.

### What changed

| Area | Change |
|---|---|
| **CLI** (`get.py`) | Option `--query` / `-q` → `--filter` / `-q`; updated help-text URL anchor to `#searching-and-filtering` |
| **Internal model** (`parameters.py`) | `AdoShowStatsCommandParameters.query` field renamed to `filters` |
| **`show_stats` / `show_trace` commands** | Local variable / parameter references updated from `query` → `filters` |
| **Tests** (`test_ado_get.py`) | `test_field_querying` renamed to `test_field_filtering`; all `-q` invocations updated to `--filter` |
| **Documentation** (`ado.md`, `metastore.md`) | All `--query` references replaced with `--filter`; section heading/anchor updated |
| **Agent skills** (`query-ado-data`, `resource-yaml-creation`) | Example commands updated to use `--filter` |

### Impact

- **Breaking change for scripts** that used `--query`; `--filter` is the new flag.
- The short form `-q` is retained and still works.
- No behavioural changes — filtering logic is identical.