### PR TITLE
refactor(core): rename search operations to explore

### DIFF
--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -36,8 +36,8 @@ on, and whether measurements and results look healthy.
 Operations are applied to discoveryspaces. There are different types of
 operation. The General Workflow can be applied to all types of operation.
 
-In addition, the Explore/Search Workflow operations can be applied to
-Explore/Search operations.
+In addition, the Explore Operation Workflow can be applied to
+Explore operations.
 
 - Read [operations](../../../website/docs/resources/operation.md) documentation
   for details
@@ -115,9 +115,9 @@ However, it is possible it failed in a way that meant it could not record the
 failure. In this case:
 
 1. Determine how long it has been running.
-2. If it is many hours and the operationType is not search/explore flag that
+2. If it is many hours and the operationType is not explore flag that
    there may be a problem
-3. If it is many hours and the operationType is search/explore proceed use
+3. If it is many hours and the operationType is explore proceed use
    specific techniques in Explore Operation Workflow to determine if its still
    running
 
@@ -201,11 +201,11 @@ uv run ado get datacontainer $DATACONTAINER_IDENTIFIER -o yaml --output-file dat
 
 For each output resource summarize what it is/contains.
 
-## Explore/Search Operation Workflow
+## Explore Operation Workflow
 
 The following assumes the General Workflow has been applied.
 
-Explore/Search operations sample entities from a discovery space and make
+Explore operations sample entities from a discovery space and make
 measurements on them.
 
 Notes:
@@ -240,7 +240,7 @@ were completed there are no issues ->
 [examine entities](#step-3-get-entities-and-measurements)
 
 If the state is not finished ->
-[Use the diagnose if sampling operation running workflow](#diagnose-if-an-explore-or-search-operation-is-running-workflow).
+[Use the diagnose if sampling operation running workflow](#diagnose-if-an-explore-operation-is-running-workflow).
 For all other combinations ->
 [Diagnose sampling issues](#step-2-optional-diagnose-sampling-issues)
 
@@ -285,7 +285,7 @@ Perform an analysis of the measurements, checking e.g. distributions of metrics,
 metric outliers, correlations between metrics. Take into account the domain of
 the experiment and meaning of metrics when looking for patterns.
 
-## Diagnose if an Explore or Search Operation is Running Workflow
+## Diagnose if an Explore Operation is Running Workflow
 
 - Check if the operation is submitting experiments in batches
 - Confirm if the operation uses continuous batching (new experiment requested

--- a/.cursor/skills/formulate-discovery-problem/reference.md
+++ b/.cursor/skills/formulate-discovery-problem/reference.md
@@ -86,7 +86,7 @@ See
 
 ### Operation Types
 
-- `search` - Exploration/optimization operations (e.g., random_walk, ray_tune)
+- `explore` - Exploration/optimization operations (e.g., random_walk, ray_tune)
 - `modify` - Space modification operations
 - `characterize` - Analysis/characterization operations
 - `compare` - Comparison operations

--- a/.cursor/skills/formulate-discovery-problem/yaml-examples/example1-operation.yaml
+++ b/.cursor/skills/formulate-discovery-problem/yaml-examples/example1-operation.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: random_walk
-    operationType: search
+    operationType: explore
   parameters:
     numberEntities: 50
     batchSize: 1

--- a/.cursor/skills/formulate-discovery-problem/yaml-examples/example6-operation.yaml
+++ b/.cursor/skills/formulate-discovery-problem/yaml-examples/example6-operation.yaml
@@ -4,7 +4,7 @@ spaces: [space-abc123]
 operation:
   module:
     operatorName: random_walk
-    operationType: search
+    operationType: explore
   parameters:
     numberEntities: 50
     batchSize: 1

--- a/.cursor/skills/formulate-discovery-problem/yaml-examples/reference-operation-structure.yaml
+++ b/.cursor/skills/formulate-discovery-problem/yaml-examples/reference-operation-structure.yaml
@@ -4,7 +4,7 @@ spaces: [space_id_1, space_id_2] # Required - list of space identifiers
 operation: # Required - operation definition
   module: # Required - operator specification
     operatorName: name # Required - operator identifier
-    operationType: type # Required - search/modify/characterize/etc.
+    operationType: type # Required - explore/modify/characterize/etc.
   parameters: # Required - operator-specific parameters
     param1: value1
     param2: value2

--- a/.cursor/skills/formulate-discovery-problem/yaml-examples/skill-operation-structure.yaml
+++ b/.cursor/skills/formulate-discovery-problem/yaml-examples/skill-operation-structure.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: random_walk # could be any operator_name
-    operationType: search # or modify, characterize, etc.
+    operationType: explore # or modify, characterize, etc.
   parameters:
     # These must include the appropriate parameters for the operator
     # that is defined by operatorName. In this case we override

--- a/examples/ml-multi-cloud/EXAMPLE_SIMPLE.md
+++ b/examples/ml-multi-cloud/EXAMPLE_SIMPLE.md
@@ -244,7 +244,7 @@ config:
   operation:
     module:
       operatorName: random_walk
-      operationType: search
+      operationType: explore
     parameters:
       batchSize: 1
       numberEntities: 48
@@ -259,7 +259,7 @@ kind: operation
 metadata:
   entities_submitted: 48
   experiments_requested: 74
-operationType: search
+operationType: explore
 operatorIdentifier: randomwalk-0.9.4.dev30+564196d4.dirty
 status:
   - event: created

--- a/examples/ml-multi-cloud/lhc_sampler.yaml
+++ b/examples/ml-multi-cloud/lhc_sampler.yaml
@@ -6,7 +6,7 @@ metadata:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     runtimeConfig:
       stop:

--- a/examples/ml-multi-cloud/randomwalk_ml_multicloud_operation.yaml
+++ b/examples/ml-multi-cloud/randomwalk_ml_multicloud_operation.yaml
@@ -8,7 +8,7 @@ spaces:
 operation:
   module:
     operatorName: "random_walk"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     numberEntities: 48
     batchSize: 1

--- a/examples/ml-multi-cloud/raytune_ml_multicloud_operation.yaml
+++ b/examples/ml-multi-cloud/raytune_ml_multicloud_operation.yaml
@@ -8,7 +8,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       search_alg:

--- a/examples/ml-multi-cloud/raytune_ml_multicloud_operation_custom_metric.yaml
+++ b/examples/ml-multi-cloud/raytune_ml_multicloud_operation_custom_metric.yaml
@@ -8,7 +8,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       search_alg:

--- a/examples/optimization_test_functions/README.md
+++ b/examples/optimization_test_functions/README.md
@@ -285,7 +285,7 @@ Operation:
     operation:
       module:
         operatorName: ray_tune
-        operationType: search
+        operationType: explore
       parameters:
         tuneConfig:
           max_concurrent_trials: 2
@@ -302,7 +302,7 @@ kind: operation
 metadata:
   entities_submitted: 40
   experiments_requested: 40
-operationType: search
+operationType: explore
 operatorIdentifier: raytune-1.4.1.dev6+b30c6f74
 status:
   - event: created

--- a/examples/optimization_test_functions/operation_bayesopt.yaml
+++ b/examples/optimization_test_functions/operation_bayesopt.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       metric: "function_value" # The metric that the test function measures

--- a/examples/optimization_test_functions/operation_nevergrad.yaml
+++ b/examples/optimization_test_functions/operation_nevergrad.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       metric: "function_value" # The metric that the test function measure

--- a/examples/pfas-generative-models/operation_random_walk_test.yaml
+++ b/examples/pfas-generative-models/operation_random_walk_test.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: "random_walk"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     numberEntities: 100
     batchSize: 10

--- a/examples/pfas-generative-models/operation_transformer_benchmark.yaml
+++ b/examples/pfas-generative-models/operation_transformer_benchmark.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: "random_walk"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     numberEntities: 43000
     batchSize: 1000

--- a/examples/trim/example_yamls/randomwalk_clhs_operation.yaml
+++ b/examples/trim/example_yamls/randomwalk_clhs_operation.yaml
@@ -8,7 +8,7 @@ spaces:
 operation:
   module:
     operatorName: "random_walk"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     numberEntities: 20
     batchSize: 5

--- a/examples/trim/example_yamls/randomwalk_sobol_operation.yaml
+++ b/examples/trim/example_yamls/randomwalk_sobol_operation.yaml
@@ -8,7 +8,7 @@ spaces:
 operation:
   module:
     operatorName: "random_walk"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     numberEntities: 20
     batchSize: 5

--- a/orchestrator/cli/resources/operator/get.py
+++ b/orchestrator/cli/resources/operator/get.py
@@ -104,12 +104,6 @@ def get_operator(parameters: AdoGetCommandParameters) -> None:
     else:
         console_print("Available operators by type:")
 
-    # AP: We want to rename some DiscoveryOperationEnums
-    type_names_mapping = {"search": "explore"}
-    operators["TYPE"] = operators["TYPE"].replace(type_names_mapping)
-
-    # After renaming some entries in the TYPE column
-    # the values may not be sorted anymore
     operators = operators.sort_values(by=["TYPE", "OPERATOR"]).reset_index(drop=True)
 
     from orchestrator.cli.utils.resources.handlers import handle_ado_get

--- a/orchestrator/core/discoveryspace/space.py
+++ b/orchestrator/core/discoveryspace/space.py
@@ -946,7 +946,7 @@ class DiscoverySpace:
         name: str,
         description: str | None = None,
         metadata: dict | None = None,
-        operation_type: DiscoveryOperationEnum = DiscoveryOperationEnum.SEARCH,
+        operation_type: DiscoveryOperationEnum = DiscoveryOperationEnum.EXPLORE,
         provenance: "orchestrator.core.metadata.PackageProvenance | None" = None,
     ) -> Iterator[str]:
         """Context manager that registers a script operation and manages its lifecycle.
@@ -960,7 +960,7 @@ class DiscoverySpace:
             name: Human-readable script name stored in the operation configuration.
             description: Optional description for the operation metadata.
             metadata: Optional extra metadata fields merged into ConfigurationMetadata.
-            operation_type: Semantic type for the operation (e.g. SEARCH for explore scripts).
+            operation_type: Semantic type for the operation (e.g. EXPLORE for explore scripts).
                 Script provenance is always recorded on metadata labels under
                 ``execution: script``.
             provenance: Optional Python distribution provenance for the script module.

--- a/orchestrator/core/discoveryspace/stats.py
+++ b/orchestrator/core/discoveryspace/stats.py
@@ -27,7 +27,7 @@ class DiscoverySpaceStatistics(pydantic.BaseModel):
             measurement space.
         number_of_operations: Total number of operations linked to this space.
         number_of_explore_operations: Number of operations whose ``operationType``
-            is ``search``.
+            is ``explore``.
         number_measured_entities: DISTINCT entity IDs that appear in at least one
             measurement result across all operations on this space.
         size_of_entity_space: Total number of points in the entity space when the
@@ -71,7 +71,7 @@ class DiscoverySpaceStatistics(pydantic.BaseModel):
     number_of_explore_operations: Annotated[
         int,
         pydantic.Field(
-            description=("Number of operations whose operationType is 'search'.")
+            description=("Number of operations whose operationType is 'explore'.")
         ),
     ]
     number_measured_entities: Annotated[

--- a/orchestrator/core/operation/config.py
+++ b/orchestrator/core/operation/config.py
@@ -31,7 +31,7 @@ if typing.TYPE_CHECKING:
 
 class DiscoveryOperationEnum(enum.Enum):
     CHARACTERIZE = "characterize"
-    SEARCH = "search"
+    EXPLORE = "explore"
     COMPARE = "compare"
     MODIFY = "modify"
     STUDY = "study"
@@ -40,6 +40,13 @@ class DiscoveryOperationEnum(enum.Enum):
     QUERY = "query"
     EXPORT = "export"
     SCRIPT = "script"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DiscoveryOperationEnum | None":
+        """Accept the legacy 'search' value and redirect it to EXPLORE."""
+        if value == "search":
+            return cls.EXPLORE
+        return None
 
 
 def get_actuator_configurations(
@@ -358,7 +365,7 @@ class ScriptOperatorConf(pydantic.BaseModel):
                 "Script provenance is recorded separately via operation metadata labels."
             ),
         ),
-    ] = DiscoveryOperationEnum.SEARCH
+    ] = DiscoveryOperationEnum.EXPLORE
 
     @property
     def operatorIdentifier(self) -> str:

--- a/orchestrator/core/operation/config.py
+++ b/orchestrator/core/operation/config.py
@@ -361,7 +361,7 @@ class ScriptOperatorConf(pydantic.BaseModel):
         DiscoveryOperationEnum,
         pydantic.Field(
             description=(
-                "Semantic operation type (e.g. search, characterize). "
+                "Semantic operation type (e.g. explore, characterize). "
                 "Script provenance is recorded separately via operation metadata labels."
             ),
         ),

--- a/orchestrator/metastore/sqlstore.py
+++ b/orchestrator/metastore/sqlstore.py
@@ -1785,7 +1785,7 @@ class SQLResourceStore(ResourceStore):
                 COUNT(op.identifier) AS total_operations,
                 COUNT(
                     CASE
-                        WHEN JSON_EXTRACT(op.data, '$.operationType') = :explore_type
+                        WHEN JSON_EXTRACT(op.data, '$.operationType') IN (:explore_type, :explore_type_legacy)
                         THEN 1
                     END
                 ) AS explore_operations
@@ -1804,7 +1804,8 @@ class SQLResourceStore(ResourceStore):
                 query = sqlalchemy.text(query_text).bindparams(
                     sqlalchemy.bindparam("space_ids", expanding=True),
                     space_ids=list(_space_ids),
-                    explore_type=DiscoveryOperationEnum.SEARCH.value,
+                    explore_type=DiscoveryOperationEnum.EXPLORE.value,
+                    explore_type_legacy="search",
                     op_kind=CoreResourceKinds.OPERATION.value,
                 )
 

--- a/orchestrator/modules/operators/_explore_orchestration.py
+++ b/orchestrator/modules/operators/_explore_orchestration.py
@@ -169,7 +169,7 @@ def orchestrate_explore_operation(
 ) -> OperationOutput:
     """Orchestrates an explore operation.
 
-    This function sets up and executes an explore (search) operation. It handles:
+    This function sets up and executes an explore operation. It handles:
     - Initializing the resource cleaner
     - Validating the measurement space consistency
     - Validating actuator configurations against the space

--- a/orchestrator/modules/operators/base.py
+++ b/orchestrator/modules/operators/base.py
@@ -204,7 +204,7 @@ class DiscoveryOperationBase(metaclass=abc.ABCMeta):
                     version="0.1.0",
                     configuration_model=MyOpParameters,
                     example_configuration=MyOpParameters(),
-                    type=DiscoveryOperationEnum.SEARCH,
+                    type=DiscoveryOperationEnum.EXPLORE,
                 )
         """
         raise NotImplementedError(f"{cls.__name__} must implement operator_metadata().")

--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -88,7 +88,7 @@ characterize = OperatorCollection(
     type=orchestrator.core.operation.config.DiscoveryOperationEnum.CHARACTERIZE
 )
 explore = OperatorCollection(
-    type=orchestrator.core.operation.config.DiscoveryOperationEnum.SEARCH
+    type=orchestrator.core.operation.config.DiscoveryOperationEnum.EXPLORE
 )
 modify = OperatorCollection(
     type=orchestrator.core.operation.config.DiscoveryOperationEnum.MODIFY
@@ -110,7 +110,7 @@ learn = OperatorCollection(
 )
 operationCollectionMap = {
     orchestrator.core.operation.config.DiscoveryOperationEnum.CHARACTERIZE: characterize,
-    orchestrator.core.operation.config.DiscoveryOperationEnum.SEARCH: explore,
+    orchestrator.core.operation.config.DiscoveryOperationEnum.EXPLORE: explore,
     orchestrator.core.operation.config.DiscoveryOperationEnum.MODIFY: modify,
     orchestrator.core.operation.config.DiscoveryOperationEnum.EXPORT: export,
     orchestrator.core.operation.config.DiscoveryOperationEnum.COMPARE: compare,

--- a/orchestrator/modules/operators/collections.py
+++ b/orchestrator/modules/operators/collections.py
@@ -206,7 +206,7 @@ def _validate_explore_cls(t: type, metadata: OperatorMetadata) -> None:
 def explore_operation(
     cls: "type[DiscoveryOperationBase]",
 ) -> "type[DiscoveryOperationBase]":
-    """Decorator that registers an explore (search) operator class.
+    """Decorator that registers an explore operator class.
 
     All metadata is sourced from the class's ``operator_metadata()``
     classmethod.  The decorator generates an :class:`OperatorFunction`,
@@ -222,7 +222,7 @@ def explore_operation(
                     version="0.1.0",
                     configuration_model=MyOpParameters,
                     example_configuration=MyOpParameters(),
-                    type=DiscoveryOperationEnum.SEARCH,
+                    type=DiscoveryOperationEnum.EXPLORE,
                 )
 
             async def run(self) -> OperationOutput | None: ...

--- a/orchestrator/modules/operators/randomwalk.py
+++ b/orchestrator/modules/operators/randomwalk.py
@@ -957,5 +957,5 @@ class RandomWalk(Explore):
             description=cls.description(),
             configuration_model=RandomWalkParameters,
             example_configuration=RandomWalkParameters(),
-            type=DiscoveryOperationEnum.SEARCH,
+            type=DiscoveryOperationEnum.EXPLORE,
         )

--- a/plugins/actuators/example_actuator/yamls/random_walk_operation.yaml
+++ b/plugins/actuators/example_actuator/yamls/random_walk_operation.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: random_walk
-    operationType: search
+    operationType: explore
   parameters:
     numberEntities: 10
     batchSize: 2

--- a/plugins/actuators/vllm_performance/yamls/operation_optuna.yaml
+++ b/plugins/actuators/vllm_performance/yamls/operation_optuna.yaml
@@ -7,7 +7,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       metric: "request_throughput" # The metric to optimize

--- a/plugins/actuators/vllm_performance/yamls/operation_optuna_multi.yaml
+++ b/plugins/actuators/vllm_performance/yamls/operation_optuna_multi.yaml
@@ -7,7 +7,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       metric:

--- a/plugins/operators/ray_tune/ado_ray_tune/operator.py
+++ b/plugins/operators/ray_tune/ado_ray_tune/operator.py
@@ -998,5 +998,5 @@ class RayTune(Explore):
                 ),
                 runtimeConfig=OrchRunConfig(),
             ),
-            type=DiscoveryOperationEnum.SEARCH,
+            type=DiscoveryOperationEnum.EXPLORE,
         )

--- a/tests/core/test_actuatorconfigs.py
+++ b/tests/core/test_actuatorconfigs.py
@@ -77,7 +77,7 @@ def test_operation_get_resource_without_plugin_validation(
     )
 
     resource = OperationResource(
-        operationType=DiscoveryOperationEnum.SEARCH,
+        operationType=DiscoveryOperationEnum.EXPLORE,
         operatorIdentifier="randomwalk-0.1.0",
         config=operation_configuration,
     )

--- a/tests/core/test_operation.py
+++ b/tests/core/test_operation.py
@@ -23,6 +23,11 @@ from orchestrator.core.resources import ADOResourceEventEnum, CoreResourceKinds
 from orchestrator.modules.module import load_module_class_or_function
 
 
+def test_discovery_operation_enum_legacy_search_redirects_to_explore() -> None:
+    """Legacy 'search' value is accepted and redirected to EXPLORE via _missing_."""
+    assert DiscoveryOperationEnum("search") is DiscoveryOperationEnum.EXPLORE
+
+
 @pytest.fixture
 def operation_result() -> dict:
 
@@ -38,7 +43,7 @@ def operation_resource(
     # This auto-generates the operation identifier
     return OperationResource(
         operatorIdentifier="test_operator",
-        operationType=DiscoveryOperationEnum.SEARCH,
+        operationType=DiscoveryOperationEnum.EXPLORE,
         config=operation_configuration,
     )
 
@@ -194,9 +199,9 @@ def test_script_operator_conf_round_trip() -> None:
     script_module = ScriptOperatorConf(
         name="grid-sweep",
         version="1.0.0",
-        operationType=DiscoveryOperationEnum.SEARCH,
+        operationType=DiscoveryOperationEnum.EXPLORE,
     )
-    assert script_module.operationType == DiscoveryOperationEnum.SEARCH
+    assert script_module.operationType == DiscoveryOperationEnum.EXPLORE
     assert script_module.operatorIdentifier == "script-grid-sweep-1.0.0"
 
     operation_configuration = DiscoveryOperationConfiguration(
@@ -215,7 +220,7 @@ def test_script_operator_conf_round_trip() -> None:
     assert isinstance(restored.operation.module, ScriptOperatorConf)
     assert restored.operation.module.name == "grid-sweep"
     assert restored.operation.module.version == "1.0.0"
-    assert restored.operation.module.operationType == DiscoveryOperationEnum.SEARCH
+    assert restored.operation.module.operationType == DiscoveryOperationEnum.EXPLORE
     assert restored.operation.parameters == {}
 
 

--- a/tests/core/test_space.py
+++ b/tests/core/test_space.py
@@ -462,9 +462,10 @@ def test_operation_context_success_lifecycle(pfas_space: DiscoverySpace) -> None
     assert operation_id in pfas_space.operations
     assert isinstance(operation.config.operation.module, ScriptOperatorConf)
     assert (
-        operation.config.operation.module.operationType == DiscoveryOperationEnum.SEARCH
+        operation.config.operation.module.operationType
+        == DiscoveryOperationEnum.EXPLORE
     )
-    assert operation.operationType == DiscoveryOperationEnum.SEARCH
+    assert operation.operationType == DiscoveryOperationEnum.EXPLORE
     assert operation.config.metadata.description == "Script operation for testing"
     assert operation.config.metadata.labels == {
         SCRIPT_OPERATION_LABEL_KEY: SCRIPT_OPERATION_EXECUTION_LABEL,

--- a/tests/core/test_space_statistics.py
+++ b/tests/core/test_space_statistics.py
@@ -150,7 +150,7 @@ def test_space_statistics_full_with_operation(
 
     assert stats.number_of_experiments == _NUMBER_OF_EXPERIMENTS
     assert stats.number_of_operations == 1
-    # The simulated operation uses operationType="search", which counts as explore
+    # The simulated operation uses operationType="explore"
     assert stats.number_of_explore_operations == 1
     assert stats.number_measured_entities == number_entities
     assert stats.size_of_entity_space == _ENTITY_SPACE_SIZE

--- a/tests/fixtures/core/operation.py
+++ b/tests/fixtures/core/operation.py
@@ -32,7 +32,7 @@ def ml_multi_cloud_operation_resource(
             ml_multi_cloud_operation_configuration.spaces = [space_id]
 
         return OperationResource(
-            operationType=DiscoveryOperationEnum.SEARCH,
+            operationType=DiscoveryOperationEnum.EXPLORE,
             operatorIdentifier=random_identifier(),
             config=ml_multi_cloud_operation_configuration,
         )
@@ -97,7 +97,7 @@ def operation_resource(
     # Create a random operation resource
     return OperationResource(
         config=operation_configuration,
-        operationType=orchestrator.core.operation.config.DiscoveryOperationEnum.SEARCH,
+        operationType=orchestrator.core.operation.config.DiscoveryOperationEnum.EXPLORE,
         operatorIdentifier="randomwalk-0.3.1",
     )
 

--- a/tests/fixtures/ml_multi_cloud/fixtures.py
+++ b/tests/fixtures/ml_multi_cloud/fixtures.py
@@ -332,7 +332,7 @@ def simulate_ml_multi_cloud_random_walk_operation(
         resource = OperationResource(
             identifier=operation_id,
             config=ml_multi_cloud_operation_configuration,
-            operationType=DiscoveryOperationEnum.SEARCH,
+            operationType=DiscoveryOperationEnum.EXPLORE,
             operatorIdentifier="doesnt-matter",
         )
         if created is not None:

--- a/tests/metastore/test_resourcestore.py
+++ b/tests/metastore/test_resourcestore.py
@@ -1206,7 +1206,7 @@ def two_op_hierarchy(
     )
     op1 = OperationResource(
         config=op1_config,
-        operationType=DiscoveryOperationEnum.SEARCH,
+        operationType=DiscoveryOperationEnum.EXPLORE,
         operatorIdentifier="test-op-1",
     )
     sql_store.addResourceWithRelationships(op1, relatedIdentifiers=[ds.identifier])
@@ -1217,7 +1217,7 @@ def two_op_hierarchy(
     )
     op2 = OperationResource(
         config=op2_config,
-        operationType=DiscoveryOperationEnum.SEARCH,
+        operationType=DiscoveryOperationEnum.EXPLORE,
         operatorIdentifier="test-op-2",
     )
     sql_store.addResourceWithRelationships(op2, relatedIdentifiers=[ds.identifier])

--- a/tests/metastore/test_space_statistics_from_db.py
+++ b/tests/metastore/test_space_statistics_from_db.py
@@ -31,13 +31,13 @@ def test_get_space_metastore_stats_single_no_operations(
 
 
 @requires_sqlite_3_38
-def test_get_space_metastore_stats_single_with_search_operation(
+def test_get_space_metastore_stats_single_with_explore_operation(
     random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
     ml_multi_cloud_operation_resource: Callable[[str | None], OperationResource],
     create_resource_with_related_identifiers: Callable[[ADOResource, list[str]], None],
     sql_store: "SQLStore",
 ) -> None:
-    """A space with one SEARCH operation has correct counts."""
+    """A space with one EXPLORE operation has correct counts."""
     space = random_space_resource_from_db()
     op = ml_multi_cloud_operation_resource(space_id=space.identifier)
     create_resource_with_related_identifiers(op, [space.identifier])
@@ -52,13 +52,13 @@ def test_get_space_metastore_stats_single_with_search_operation(
 
 
 @requires_sqlite_3_38
-def test_get_space_metastore_stats_single_with_non_search_operation(
+def test_get_space_metastore_stats_single_with_non_explore_operation(
     random_space_resource_from_db: Callable[[str | None], DiscoverySpaceResource],
     ml_multi_cloud_operation_resource: Callable[[str | None], OperationResource],
     create_resource_with_related_identifiers: Callable[[ADOResource, list[str]], None],
     sql_store: "SQLStore",
 ) -> None:
-    """A non-SEARCH operation is counted in total but not in explore."""
+    """A non-EXPLORE operation is counted in total but not in explore."""
     space = random_space_resource_from_db()
     op = ml_multi_cloud_operation_resource(space_id=space.identifier)
     op.operationType = DiscoveryOperationEnum.CHARACTERIZE
@@ -82,8 +82,8 @@ def test_get_space_metastore_stats_single_mixed_operations(
     """Mixed operation types: total and explore counts are both correct."""
     space = random_space_resource_from_db()
 
-    search_op = ml_multi_cloud_operation_resource(space_id=space.identifier)
-    create_resource_with_related_identifiers(search_op, [space.identifier])
+    explore_op = ml_multi_cloud_operation_resource(space_id=space.identifier)
+    create_resource_with_related_identifiers(explore_op, [space.identifier])
 
     characterize_op = ml_multi_cloud_operation_resource(space_id=space.identifier)
     characterize_op.operationType = DiscoveryOperationEnum.CHARACTERIZE

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -64,7 +64,7 @@ def test_operator_module_conf(
 
     assert (
         operator_module_conf.operationType
-        == orchestrator.core.operation.config.DiscoveryOperationEnum.SEARCH
+        == orchestrator.core.operation.config.DiscoveryOperationEnum.EXPLORE
     )
     cls = load_module_class_or_function(operator_module_conf)
     expected_name = cls.operator_metadata().name

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -120,7 +120,7 @@ def test_explore_operator_function_configurations(
     for operationName in expected_explore_operators:
         operationConf = orchestrator.core.operation.config.OperatorReference(
             operatorName=operationName,
-            operationType=orchestrator.core.operation.config.DiscoveryOperationEnum.SEARCH,
+            operationType=orchestrator.core.operation.config.DiscoveryOperationEnum.EXPLORE,
         )
         assert operationConf is not None
         assert operationConf.validateOperatorExists()
@@ -144,7 +144,7 @@ def test_explore_operator_function_conf_identifier_matches_registered_name() -> 
     for name in ["random_walk", "ray_tune"]:
         conf = orchestrator.core.operation.config.OperatorReference(
             operatorName=name,
-            operationType=orchestrator.core.operation.config.DiscoveryOperationEnum.SEARCH,
+            operationType=orchestrator.core.operation.config.DiscoveryOperationEnum.EXPLORE,
         )
         # The identifier must start with the registered function name, not the
         # class name (e.g. "random_walk-v0.1", not "randomwalk-1.7.1.dev...")
@@ -634,7 +634,7 @@ def test_operator_metadata_identifier_property() -> None:
         version="v2.0",
         configuration_model=_P,
         example_configuration=_P(),
-        type=DiscoveryOperationEnum.SEARCH,
+        type=DiscoveryOperationEnum.EXPLORE,
     )
     assert meta.operatorIdentifier == "my_op-v2.0"
 
@@ -655,7 +655,7 @@ def test_operator_metadata_identifier_default_version() -> None:
         name="op",
         configuration_model=_P,
         example_configuration=_P(),
-        type=DiscoveryOperationEnum.SEARCH,
+        type=DiscoveryOperationEnum.EXPLORE,
     )
     assert meta.operatorIdentifier == "op-0.1.0"
 
@@ -687,7 +687,7 @@ def test_operator_metadata_version_valid_pep440() -> None:
             version=ver,
             configuration_model=_P,
             example_configuration=_P(),
-            type=DiscoveryOperationEnum.SEARCH,
+            type=DiscoveryOperationEnum.EXPLORE,
         )
         assert meta.version == ver
 
@@ -712,7 +712,7 @@ def test_operator_metadata_version_invalid_pep440() -> None:
                 version=ver,
                 configuration_model=_P,
                 example_configuration=_P(),
-                type=DiscoveryOperationEnum.SEARCH,
+                type=DiscoveryOperationEnum.EXPLORE,
             )
 
 
@@ -727,7 +727,7 @@ def test_operator_function_conf_identifier_delegates_to_operator_metadata() -> N
     for name in ["random_walk", "ray_tune"]:
         conf = OperatorReference(
             operatorName=name,
-            operationType=DiscoveryOperationEnum.SEARCH,
+            operationType=DiscoveryOperationEnum.EXPLORE,
         )
         assert conf.operatorIdentifier == explore.operators[name].operatorIdentifier
 
@@ -758,7 +758,7 @@ def test_explore_operation_class_decorator_registers_function() -> None:
                 description="A test operator.",
                 configuration_model=_Params,
                 example_configuration=_Params(),
-                type=DiscoveryOperationEnum.SEARCH,
+                type=DiscoveryOperationEnum.EXPLORE,
             )
 
         def operationIdentifier(self) -> str:
@@ -804,7 +804,7 @@ def test_explore_operation_class_decorator_cls_stored() -> None:
                 version="0.1.0",
                 configuration_model=_ParamsCls,
                 example_configuration=_ParamsCls(),
-                type=DiscoveryOperationEnum.SEARCH,
+                type=DiscoveryOperationEnum.EXPLORE,
             )
 
         async def run(self) -> None:
@@ -839,7 +839,7 @@ def test_explore_operation_class_decorator_metadata_from_class() -> None:
                 description="Another test operator.",
                 configuration_model=_Params2,
                 example_configuration=_Params2(),
-                type=DiscoveryOperationEnum.SEARCH,
+                type=DiscoveryOperationEnum.EXPLORE,
             )
 
         def operationIdentifier(self) -> str:
@@ -854,11 +854,11 @@ def test_explore_operation_class_decorator_metadata_from_class() -> None:
     assert registered.description == "Another test operator."
     assert registered.configuration_model is _Params2
     assert isinstance(registered.example_configuration, _Params2)
-    assert registered.type == DiscoveryOperationEnum.SEARCH
+    assert registered.type == DiscoveryOperationEnum.EXPLORE
 
 
 def test_explore_operation_class_decorator_missing_operator_metadata_raises() -> None:
-    """Decorating a Search subclass without operator_metadata() raises NotImplementedError."""
+    """Decorating an Explore subclass without operator_metadata() raises NotImplementedError."""
 
     from orchestrator.modules.operators.base import Explore
     from orchestrator.modules.operators.collections import explore_operation

--- a/tests/resources/operation/operation_config6b.yaml
+++ b/tests/resources/operation/operation_config6b.yaml
@@ -5,7 +5,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       search_alg:

--- a/tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml
+++ b/tests/resources/operation/randomwalk-1.0.2.dev17+5e50632.dirty-d5c036.yaml
@@ -19,7 +19,7 @@ identifier: randomwalk-1.0.2.dev17+5e50632.dirty-d5c036
 metadata:
   entities_submitted: 12
   experiments_requested: 12
-operationType: search
+operationType: explore
 operatorIdentifier: randomwalk-1.0.2.dev17+5e50632.dirty
 status:
   - event: created

--- a/tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml
+++ b/tests/resources/operation/randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf.yaml
@@ -15,7 +15,7 @@ identifier: randomwalk-1.0.2.dev39+7f0c421.dirty-43dfdf
 metadata:
   entities_submitted: 10
   experiments_requested: 10
-operationType: search
+operationType: explore
 operatorIdentifier: randomwalk-1.0.2.dev39+7f0c421.dirty
 status:
   - event: created

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -206,7 +206,7 @@ def test_operation_entity_statistics_mixed_valid_invalid(
         OperationResource(
             identifier=operation_id,
             config=ml_multi_cloud_operation_configuration,
-            operationType=DiscoveryOperationEnum.SEARCH,
+            operationType=DiscoveryOperationEnum.EXPLORE,
             operatorIdentifier="test-operator",
         ),
         relatedIdentifiers=ml_multi_cloud_operation_configuration.spaces,
@@ -833,7 +833,7 @@ def test_entities_in_operation_empty_operation(
         OperationResource(
             identifier=operation_id,
             config=ml_multi_cloud_operation_configuration,
-            operationType=DiscoveryOperationEnum.SEARCH,
+            operationType=DiscoveryOperationEnum.EXPLORE,
             operatorIdentifier="test-operator",
         )
     )
@@ -1029,7 +1029,7 @@ def test_operation_measurement_statistics_mixed_valid_invalid(
         OperationResource(
             identifier=operation_id,
             config=ml_multi_cloud_operation_configuration,
-            operationType=DiscoveryOperationEnum.SEARCH,
+            operationType=DiscoveryOperationEnum.EXPLORE,
             operatorIdentifier="test-operator",
         ),
         relatedIdentifiers=ml_multi_cloud_operation_configuration.spaces,

--- a/tests/schema/test_provenance.py
+++ b/tests/schema/test_provenance.py
@@ -181,7 +181,7 @@ def test_provenance_for_plugin_actuator() -> None:
 
 def test_provenance_for_random_walk_operator() -> None:
     """The built-in random_walk explore operator should resolve a distribution."""
-    prov = provenance_for_operator("random_walk", DiscoveryOperationEnum.SEARCH)
+    prov = provenance_for_operator("random_walk", DiscoveryOperationEnum.EXPLORE)
     assert prov is not None
     assert prov.distributionName
     assert prov.distributionVersion
@@ -189,7 +189,7 @@ def test_provenance_for_random_walk_operator() -> None:
 
 def test_provenance_for_unknown_operator_returns_none() -> None:
     """Non-existent operator name returns None."""
-    prov = provenance_for_operator("nonexistent_op_xyz", DiscoveryOperationEnum.SEARCH)
+    prov = provenance_for_operator("nonexistent_op_xyz", DiscoveryOperationEnum.EXPLORE)
     assert prov is None
 
 
@@ -212,7 +212,7 @@ def test_operator_metadata_provenance_lifecycle() -> None:
         version="99.0.0",
         configuration_model=_ExampleConfig,
         example_configuration=_ExampleConfig(),
-        type=DiscoveryOperationEnum.SEARCH,
+        type=DiscoveryOperationEnum.EXPLORE,
         provenance=prov,
     )
 

--- a/website/docs/examples/finetune-locally.md
+++ b/website/docs/examples/finetune-locally.md
@@ -257,7 +257,7 @@ To create the Discovery Space:
    operation:
      module:
        operatorName: "random_walk"
-       operationType: "search"
+       operationType: "explore"
      parameters:
        numberEntities: all
        singleMeasurement: True

--- a/website/docs/examples/finetune-remotely.md
+++ b/website/docs/examples/finetune-remotely.md
@@ -443,7 +443,7 @@ experiment.
    operation:
      module:
        operatorName: "random_walk"
-       operationType: "search"
+       operationType: "explore"
      parameters:
        numberEntities: all
        singleMeasurement: True

--- a/website/docs/examples/vllm-performance-endpoint.md
+++ b/website/docs/examples/vllm-performance-endpoint.md
@@ -127,7 +127,7 @@ spaces:
 operation:
   module:
     operatorName: "ray_tune"
-    operationType: "search"
+    operationType: "explore"
   parameters:
     tuneConfig:
       metric: "request_throughput" # The metric to optimize

--- a/website/docs/getting-started/ado.md
+++ b/website/docs/getting-started/ado.md
@@ -1323,7 +1323,7 @@ Where:
     <!-- prettier-ignore-start -->
 
     - `characterize`
-    - `search`
+    - `explore`
     - `compare`
     - `modify`
     - `study`

--- a/website/docs/migration/1x-to-2x.md
+++ b/website/docs/migration/1x-to-2x.md
@@ -4,6 +4,25 @@ ado 2.x introduces a set of breaking changes that remove obsolete commands and
 APIs. This guide describes each breaking change and shows how to update your
 workflows.
 
+## Non-breaking changes
+
+### Renamed: `operationType: search` → `operationType: explore`
+
+The `explore` operation type was previously serialised as `"search"`. It is now
+serialised as `"explore"` to match what is shown in `ado get operators`.
+
+**Existing YAML files and stored operations continue to work without
+modification.** The value `"search"` is transparently accepted and treated as
+`"explore"` when loading any resource.
+
+To update stored operation records to the new canonical value, run:
+
+```shell
+ado upgrade operations
+```
+
+New operations and YAML files should use `operationType: explore`.
+
 ## Breaking Changes
 
 ### Removed: `ado show requests` and `ado show results`

--- a/website/docs/operators/creating-operators.md
+++ b/website/docs/operators/creating-operators.md
@@ -571,7 +571,7 @@ class MySearchOperator(Explore):
             description="A minimal example search operator.",
             configuration_model=MySearchParameters,
             example_configuration=MySearchParameters(),
-            type=DiscoveryOperationEnum.SEARCH,
+            type=DiscoveryOperationEnum.EXPLORE,
         )
 
     # --- callbacks from DiscoverySpaceManager --------------------------------

--- a/website/docs/operators/creating-operators.md
+++ b/website/docs/operators/creating-operators.md
@@ -568,7 +568,7 @@ class MySearchOperator(Explore):
         return OperatorMetadata(
             name="my_search",
             version="0.1.0",
-            description="A minimal example search operator.",
+            description="A minimal example explore operator.",
             configuration_model=MySearchParameters,
             example_configuration=MySearchParameters(),
             type=DiscoveryOperationEnum.EXPLORE,

--- a/website/docs/operators/explore_operators.md
+++ b/website/docs/operators/explore_operators.md
@@ -148,7 +148,7 @@ config:
   operation:
     module:
       operatorName: random_walk
-      operationType: search
+      operationType: explore
     parameters:
       batchSize: 4
       singleMeasurement: false
@@ -164,7 +164,7 @@ kind: operation
 metadata:
   entities_submitted: 160
   experiments_requested: 160
-operationType: search
+operationType: explore
 operatorIdentifier: randomwalk-0.6.4
 result: null
 status: []

--- a/website/docs/operators/random-walk.md
+++ b/website/docs/operators/random-walk.md
@@ -91,7 +91,7 @@ metadata:
 operation:
   module:
     operatorName: random_walk
-    operationType: search
+    operationType: explore
   parameters:
     batchSize: 1
     samplerConfig:
@@ -292,7 +292,7 @@ metadata:
 operation:
   module:
     operatorName: random_walk
-    operationType: search
+    operationType: explore
   parameters:
     batchSize: 1
     samplerConfig:

--- a/website/docs/resources/metastore.md
+++ b/website/docs/resources/metastore.md
@@ -280,7 +280,7 @@ Where:
     metadata:
       entities_submitted: 48
       experiments_requested: 74
-    operationType: search
+    operationType: explore
     operatorIdentifier: randomwalk-1.0.2.dev30+a96d4d1.dirty
     status:
     - event: created

--- a/website/docs/resources/operation.md
+++ b/website/docs/resources/operation.md
@@ -75,7 +75,7 @@ spaces: ###The spaces to operate on
 operation: #The operators
   module: # The operator will be random_walk
     operatorName: random_walk
-    operationType: search
+    operationType: explore
   parameters: # The parameters for this RandomWalk operation
     numberEntities: 60
     batchSize: 1
@@ -108,17 +108,6 @@ module:
   operatorName: rifferla # The name of the operator
   operationType: modify #The type of the operation/operator
 ```
-
-> [!WARNING]
->
-> To use operators listed with type _explore_ by `ado get operators`, currently
-> you must set operationType to **search** e.g.
->
-> ```yaml
-> module:
->  operatorName: random_walk
->  operationType: search # note: search not explore
-> ```
 
 ### Passing actuator parameters
 
@@ -212,7 +201,7 @@ kind: operation
 metadata:
   entities_submitted: 11
   experiments_requested: 11
-operationType: search
+operationType: explore
 operatorIdentifier: raytune-0.7.5.dev10+g731d1e21.d20241218
 status:
   - event: created


### PR DESCRIPTION
## Rename `operationType: search` → `operationType: explore`

This PR renames the `search` operation type to `explore` across the entire codebase to align the serialised value with what is displayed in `ado get operators`.

### What changed

- **Core enum** (`DiscoveryOperationEnum`): `SEARCH` is renamed to `EXPLORE`. A `_missing_` hook transparently maps the legacy `"search"` string to `EXPLORE`, so all existing stored operations and YAML files continue to work without modification.
- **All YAML files** (examples, plugins, tests, skills): updated `operationType: search` → `operationType: explore`.
- **Documentation**: all prose and code examples updated to use `explore`.
- **Migration guide** (`1x-to-2x.md`): a new "Non-breaking changes" section explains the rename, confirms backwards compatibility, and documents the optional `ado upgrade operations` command for updating stored records to the canonical new value.

### Backwards compatibility

No action is required for existing workflows. The old `"search"` value is silently accepted. New operations and YAML files should use `operationType: explore`.