### PR TITLE
build(hooks): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         additional_dependencies: ['tomli']
         args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.25
+    rev: 0.11.26
     hooks:
       - id: uv-lock
       - id: uv-export
@@ -60,7 +60,7 @@ repos:
     hooks:
       - id: add-headers
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.1
+    rev: v0.23.0
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/google/yamlfmt
@@ -68,7 +68,7 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v1.1.6
+    rev: v1.2.0
     hooks:
       - id: tombi-format
         args: ["--offline"]


### PR DESCRIPTION
## Updated pre-commit hooks

| Hook | From | To |
|---|---|---|
| [uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) | 0.11.25 | 0.11.26 |
| [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | 0.22.1 | 0.23.0 |
| [tombi-pre-commit](https://github.com/tombi-toml/tombi-pre-commit) | 1.1.6 | 1.2.0 |