### PR TITLE
docs: update README and website index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,128 +1,157 @@
-# Introduction
+# ado — accelerated discovery orchestrator
 
+![PyPI Version](https://img.shields.io/pypi/v/ado-core)
+![PyPI Python Version](https://img.shields.io/pypi/pyversions/ado-core)
+![GitHub License](https://img.shields.io/github/license/ibm/ado)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.10304/status.svg)](https://doi.org/10.21105/joss.10304)
-
-This is the repository for the **a**ccelerated **d**iscovery **o**rchestrator
-(**`ado`**).
 
 **`ado`** is a Python platform for **designing experiment campaigns and
 executing them at scale**. It enables distributed teams of researchers and
 engineers to collaborate, execute experiments, and share data.
 
-You can extend ado across different domains through its **plugin model**-often
-as simple as decorating a Python function. By integrating
-your methodology, you gain cross-cutting capabilities—such as
-**parallel execution**, **data provenance**, and a **unified CLI**—alongside a structured
-foundation that allows AI coding agents to **autonomously formulate and run your
-experiments**.
+You can extend ado across different domains through its **plugin model** — often
+as simple as decorating a Python function. By integrating your methodology, you
+gain cross-cutting capabilities — such as **parallel execution**, **data
+provenance**, and a **unified CLI** — alongside a structured foundation that
+allows AI coding agents to **autonomously formulate and run your experiments**.
 
-🧑‍💻 Using **`ado`** assumes familiarity with command line tools.
-
-🛠️ Developing **`ado`** requires knowledge of python.
+- 🧑‍💻 **Using `ado`** assumes familiarity with command line tools.
+- 🛠️ **Developing `ado`** requires knowledge of Python.
 
 ## Key Features
 
-- 💻 _CLI_: Our human-centric
-  CLI follows [best practices](https://clig.dev)
+- 💻 _CLI_: Our human-centric CLI follows [best practices](https://clig.dev)
 - 🤝 _Projects_: Allow distributed groups of users to
-  [collaborate and share data](https://ibm.github.io/ado/resources/metastore.md)
+  [collaborate and share data](https://ibm.github.io/ado/resources/metastore/)
 - 🔌 _Extendable_: Easily
-  [add new experiments](https://ibm.github.io/ado/actuators/creating-custom-experiments.md),
-  [optimizers or other tools.](https://ibm.github.io/ado/operators/creating-operators.md)
-- ⚙️ _Scalable_: We use [ray](https://ray.io) as our execution engine
-  allowing experiments and tools to easily scale
+  [add new experiments](https://ibm.github.io/ado/actuators/creating-custom-experiments/)
+  or
+  [optimizers and other tools](https://ibm.github.io/ado/operators/creating-operators/)
+- ⚙️ _Scalable_: We use [Ray](https://www.ray.io/) as our execution engine,
+  allowing experiments and tools to scale easily
 - ♻️ _Automatic data-reuse_: Avoid repeating work with
-  [transparent reuse of experiment results](https://ibm.github.io/ado/core-concepts/data-sharing.md).
-`ado` internal protocols ensure this happens only when it makes sense
-- 🔗 _Provenance_: As you work, the relationship between the data you create
-  and operations you perform are
-  [automatically tracked](https://ibm.github.io/ado/getting-started/ado.md#ado-show-related)
-- 🔎 _Optimization and sampling_: Out-of-the-box, leverage powerful
-  optimization methods [via `raytune`](operators/optimisation-with-ray-tune.md)
-  or use our [flexible in built sampler](https://ibm.github.io/ado/operators/random-walk.md)
-- 🤖 _Coding agents_: Supercharge your workflow. `ado`'s
-  typed resources and bundled skills enable AI assistants to autonomously
-  formulate, validate, and run experiments. [Learn more](https://ibm.github.io/ado/how-to/).
+  [transparent reuse of experiment results](https://ibm.github.io/ado/core-concepts/data-sharing/);
+  `ado`'s internal protocols ensure this happens only when it makes sense
+- 🔗 _Provenance_: Relationships between data and operations are
+  [automatically tracked](https://ibm.github.io/ado/getting-started/ado/#ado-show-related).
+  The versions of `ado-core` and every plugin used to create a resource are also
+  recorded, keeping results reproducible and debuggable
+- 🔎 _Optimization and sampling_: Out-of-the-box, leverage powerful optimization
+  methods
+  [via Ray Tune](https://ibm.github.io/ado/operators/optimisation-with-ray-tune/)
+  or use our
+  [flexible built-in sampler](https://ibm.github.io/ado/operators/random-walk/)
+- 🤖 _Coding agents_: Supercharge your workflow. `ado`'s typed resources and
+  bundled skills enable AI assistants to autonomously formulate, validate, and
+  run experiments. [Learn more](https://ibm.github.io/ado/how-to/)
 
 ### Foundation Model Experimentation
 
 We have developed `ado` plugins providing advanced capabilities for performance
-testing of foundation-models:
+testing of foundation models:
 
-- ⏱️[fine-tuning performance benchmarking](https://ibm.github.io/ado/actuators/sft-trainer)
 - ⏱️
-  [inference performance benchmarking](https://ibm.github.io/ado/examples/vllm-performance-endpoint.md)
-  (using [vLLM bench](https://docs.vllm.ai/en/latest/cli/bench/serve.html) or
+  [Fine-tuning performance benchmarking](https://ibm.github.io/ado/actuators/sft-trainer)
+- ⏱️
+  [Inference performance benchmarking](https://ibm.github.io/ado/examples/vllm-performance-endpoint/)
+  (using [vLLM bench](https://docs.vllm.ai/en/stable/cli/bench/serve/) or
   [guidellm](https://github.com/vllm-project/guidellm))
-- 🔮[predictive performance models creation](https://ibm.github.io/ado/operators/trim.md)
+- 🔮
+  [Predictive performance model creation](https://ibm.github.io/ado/operators/trim/)
+
+## Quick Start
+
+Install `ado` from PyPI (a virtual environment is recommended). For complete
+instructions see the
+[install guide](https://ibm.github.io/ado/getting-started/install/):
+
+```shell
+pip install ado-core
+```
+
+Then try:
+
+```shell
+ado get contexts
+```
+
+You will see a context named `local` — a local sandbox you can use straight
+away. To see the built-in operators:
+
+```shell
+ado get operators
+```
+
+Next, follow the short
+[random-walk tutorial](https://ibm.github.io/ado/examples/random-walk/) for a
+hands-on introduction to how `ado` works.
 
 ## Requirements
 
 A basic installation of `ado` only requires a recent Python version (3.10 to
-3.13). This will allow you to run
-[many of our examples](https://ibm.github.io/ado/examples/examples)
-and explore ado features.
+3.14). This will allow you to run
+[many of our examples](https://ibm.github.io/ado/examples/examples/) and explore
+`ado` features.
 
 ### Additional Requirements
 
 Some advanced features have additional requirements:
 
 <!-- markdownlint-disable descriptive-link-text -->
+
 - **Distributed Projects** **_(Optional)_**: To support projects with multiple
-  users you will need a remote, accessible, MySQL database. See
-  [here](https://ibm.github.io/ado/getting-started/installing-backend-services#using-the-distributed-mysql-backend-for-ado)
-  for more
-- **Multi-Node Execution** **_(Optional)_**: To support multi-node or scaling
-  execution you may need a multi-node RayCluster. See
-  [here](https://ibm.github.io/ado/getting-started/installing-backend-services#deploying-kuberay-and-creating-a-raycluster)
+  users you will need a remote, accessible MySQL database. See
+  [here](https://ibm.github.io/ado/getting-started/installing-backend-services/#using-the-distributed-mysql-backend-for-ado)
   for more details
+- **Multi-Node Execution** **_(Optional)_**: To support multi-node or scaled
+execution you may need a multi-node RayCluster. See
+[here](https://ibm.github.io/ado/getting-started/installing-backend-services/#deploying-kuberay-and-creating-a-raycluster)
+for more details
 <!-- markdownlint-enable descriptive-link-text -->
 
-In addition `ado` plugins may have additional requirements for executing
-**_realistic_** experiments. For example,
+In addition, `ado` plugins may have additional requirements for executing
+**_realistic_** experiments. For example:
 
 - **_Fine-Tuning Benchmarking_**: Requires a
-  [RayCluster with GPUs](https://ibm.github.io/ado/actuators/sft-trainer#configure-your-raycluster)
+  [RayCluster with GPUs](https://ibm.github.io/ado/actuators/sft-trainer/#configure-your-raycluster)
 - **_vLLM Performance Benchmarking_**: Requires an OpenShift cluster with GPUs
 
-## Install
+## Install from Source
 
-To install you can execute the following (we recommend you set up a virtual
-environment)
+To install `ado` from source (for development or to track the latest changes):
 
-```commandline
+```shell
 git clone https://github.com/IBM/ado.git
 cd ado
 pip install .
 ```
 
-Alternate instructions to install `ado` can be found here:
-<https://ibm.github.io/ado/getting-started/install/>
+Detailed installation instructions are available at
+<https://ibm.github.io/ado/getting-started/install/>.
 
-## Development
+## Contributing
 
-Instructions for developing ado are available in [DEVELOPING](DEVELOPING.md).
-
-### Testing
-
-To run unit-tests read [tests/README.md](tests/README.md).
+To set up a development environment, run the test suite, or understand code
+style and commit conventions, see [DEVELOPING.md](DEVELOPING.md) and
+[tests/README.md](tests/README.md).
 
 ## Example
 
 This video shows listing
-[actuators](website/docs/actuators/working-with-actuators.md) and getting the
-details of an experiment.
+[actuators](https://ibm.github.io/ado/actuators/working-with-actuators/) and
+getting the details of an experiment.
 
-Check [demo](https://ibm.github.io/ado/getting-started/demo) for more videos.
+Check the [demo page](https://ibm.github.io/ado/getting-started/demo) for more
+videos.
 
 [![Watch the video](website/docs/getting-started/videos/step1_trimmed_thumbnail.png)](https://github.com/user-attachments/assets/fc4862f3-763b-4967-ab3c-4bd359900a50)
 
 ## Citation
 
 For an overview of the design and architecture of `ado`, see
-[our Journal of Open Source Software paper.](https://doi.org/10.21105/joss.10304)
+[our Journal of Open Source Software paper](https://doi.org/10.21105/joss.10304).
 
-If `ado` has been helpful in your research, please cite us using:
+If `ado` has been useful in your research, please cite us using:
 
 ```bibtex
 @article{Johnston_ado_a_Python_2026,
@@ -139,8 +168,8 @@ year = {2026}
 }
 ```
 
-You can also click "Cite this repository" in the GitHub sidebar
-for alternative formats like APA.
+You can also click **"Cite this repository"** in the GitHub sidebar for
+alternative formats such as APA.
 
 ## Acknowledgement
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,66 +1,64 @@
 # Introduction
 
+![PyPI Version](https://img.shields.io/pypi/v/ado-core)
+![PyPI Python Version](https://img.shields.io/pypi/pyversions/ado-core)
+![GitHub License](https://img.shields.io/github/license/ibm/ado)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.10304/status.svg)](https://doi.org/10.21105/joss.10304)
-
-This is the webpage for the **a**ccelerated **d**iscovery **o**rchestrator
-(**`ado`**).
 
 **`ado`** is a Python platform for **designing experiment campaigns and
 executing them at scale**. It enables distributed teams of researchers and
 engineers to collaborate, execute experiments, and share data.
 
-You can extend ado across different domains through its **plugin model**-often
-as simple as decorating a Python function. By integrating
-your methodology, you gain cross-cutting capabilities—such as
-**parallel execution**, **data provenance**, and a **unified CLI**—alongside a structured
-foundation that allows AI coding agents to **autonomously formulate and run your
-experiments**.
+You can extend ado across different domains through its **plugin model** — often
+as simple as decorating a Python function. By integrating your methodology, you
+gain cross-cutting capabilities — such as **parallel execution**, **data
+provenance**, and a **unified CLI** — alongside a structured foundation that
+allows AI coding agents to **autonomously formulate and run your experiments**.
 
-🧑‍💻 Using **`ado`** assumes familiarity with command line tools.
-
-🛠️ Developing **`ado`** requires knowledge of python.
+- 🧑‍💻 **Using `ado`** assumes familiarity with command line tools.
+- 🛠️ **Developing `ado`** requires knowledge of Python.
 
 ## Key Features
 
-- :computer: _CLI_: Our human-centric CLI follows
-  [best practices](https://clig.dev)
+- :computer: _CLI_: Our human-centric CLI follows [best practices](https://clig.dev)
 - :handshake: _Projects_: Allow distributed groups of users to
   [collaborate and share data](resources/metastore.md)
 - 🔌 _Extendable_: Easily
-  [add new experiments](actuators/creating-custom-experiments.md),
-  [optimizers or other tools.](operators/creating-operators.md)
-- :gear: _Scalable_: We use [ray](https://ray.io) as our execution engine
-  allowing experiments and tools to easily scale
+  [add new experiments](actuators/creating-custom-experiments.md)
+  or [optimizers and other tools](operators/creating-operators.md)
+- :gear: _Scalable_: We use [Ray](https://ray.io) as our execution engine,
+  allowing experiments and tools to scale easily
 - :recycle: _Automatic data-reuse_: Avoid repeating work with
-  [transparent reuse of experiment results](core-concepts/data-sharing.md).
-  `ado` internal protocols ensure this happens only when it makes sense
-- :link: _Provenance_: As you work, the relationship between the data you create
-  and operations you perform are
-  [automatically tracked](getting-started/ado.md#ado-show-related)
-- :mag: _Optimization and sampling_: Out-of-the-box, leverage powerful
-  optimization methods [via `raytune`](operators/optimisation-with-ray-tune.md)
-  or use our [flexible in built sampler](operators/random-walk.md)
+  [transparent reuse of experiment results](core-concepts/data-sharing.md);
+  `ado`'s internal protocols ensure this happens only when it makes sense
+- :link: _Provenance_: Relationships between data and operations are
+  [automatically tracked](getting-started/ado.md#ado-show-related).
+  The versions of `ado-core` and every plugin used to create a resource are also
+  recorded, keeping results reproducible and debuggable
+- :mag: _Optimization and sampling_: Out-of-the-box, leverage powerful optimization
+  methods [via Ray Tune](operators/optimisation-with-ray-tune.md)
+  or use our [flexible built-in sampler](operators/random-walk.md)
 - :material-robot-outline: _Coding agents_: Supercharge your workflow. `ado`'s
   typed resources and bundled skills enable AI assistants to autonomously
-  formulate, validate, and run experiments. [Learn more](how-to/index.md).
+  formulate, validate, and run experiments. [Learn more](how-to/index.md)
 
 ### Foundation Model Experimentation
 
 We have developed `ado` plugins providing advanced capabilities for performance
-testing of foundation-models:
+testing of foundation models:
 
-- :stopwatch: [fine-tuning performance benchmarking](actuators/sft-trainer.md)
+- :stopwatch: [Fine-tuning performance benchmarking](actuators/sft-trainer.md)
 - :stopwatch:
-  [inference performance benchmarking](examples/vllm-performance-endpoint.md)
+  [Inference performance benchmarking](examples/vllm-performance-endpoint.md)
   (using [vLLM bench](https://docs.vllm.ai/en/latest/cli/bench/serve.html) or
   [guidellm](https://github.com/vllm-project/guidellm))
-- :crystal_ball: [predictive performance models creation](operators/trim.md)
+- :crystal_ball: [Predictive performance model creation](operators/trim.md)
 
 ## Requirements
 
 A basic installation of `ado` only requires a recent Python version (3.10 to
-3.13). This will allow you to run [many of our examples](examples/examples.md)
-and explore ado features.
+3.14). This will allow you to run [many of our examples](examples/examples.md)
+and explore `ado` features.
 
 ### Additional Requirements
 
@@ -69,17 +67,17 @@ Some advanced features have additional requirements:
 <!-- markdownlint-disable descriptive-link-text -->
 
 - **Distributed Projects** **_(Optional)_**: To support projects with multiple
-  users you will need a remote, accessible, MySQL database. See
+  users you will need a remote, accessible MySQL database. See
   [here](getting-started/installing-backend-services.md#using-the-distributed-mysql-backend-for-ado)
-  for more
-- **Multi-Node Execution** **_(Optional)_**: To support multi-node or scaling
-execution you may need a multi-node RayCluster. See
-[here](getting-started/installing-backend-services.md#deploying-kuberay-and-creating-a-raycluster)
-for more details
+  for more details
+- **Multi-Node Execution** **_(Optional)_**: To support multi-node or scaled
+  execution you may need a multi-node RayCluster. See
+  [here](getting-started/installing-backend-services.md#deploying-kuberay-and-creating-a-raycluster)
+  for more details
 <!-- markdownlint-enable descriptive-link-text -->
 
-In addition `ado` plugins may have additional requirements for executing
-**_realistic_** experiments. For example,
+In addition, `ado` plugins may have additional requirements for executing
+**_realistic_** experiments. For example:
 
 - **_Fine-Tuning Benchmarking_**: Requires a
   [RayCluster with GPUs](actuators/sft-trainer.md#configure-your-raycluster)


### PR DESCRIPTION
## docs: update README and website index page

Refreshes both the GitHub `README.md` and the website `docs/index.md` landing page. No code or behaviour changes.

### What changed

**README.md**

- **New title & badges** — renamed from "Introduction" to `ado — accelerated discovery orchestrator`; added PyPI version, Python version, and license shields.
- **Quick Start section** — new section with `pip install ado-core` and two starter CLI commands, pointing to the random-walk tutorial.
- **Provenance bullet** — expanded to mention that plugin versions are recorded alongside results for reproducibility.
- **Install section** — split into "Quick Start" (PyPI) and "Install from Source" (git clone); removed redundant alternate-install sentence.
- **Development/Testing** — collapsed into a single "Contributing" paragraph linking to `DEVELOPING.md` and `tests/README.md`.
- **Misc** — Python support bumped to 3.14, link URLs updated to trailing-slash form, wording and punctuation polished throughout.

**website/docs/index.md**

- Same badge row added at the top.
- Prose, bullet, and feature list brought in line with the README rewrite (provenance expansion, Ray Tune casing, list capitalisation, punctuation).
- Python version ceiling updated to 3.14.