### PR TITLE
fix(core): add support for scanning RECORD files for distributions on Python 3.10

### DIFF
--- a/ado/utilities/distribution.py
+++ b/ado/utilities/distribution.py
@@ -62,18 +62,6 @@ def distribution_from_module(module_name: str) -> str | None:
         except Exception:  # noqa: S110
             pass
 
-    # Fallback for non-editable installs whose distribution has no top_level.txt
-    # (Python 3.10 only reads top_level.txt; 3.11+ also infers from RECORD).
-    # Scan all distributions' RECORD files for a direct path match.
-    for dist in im.distributions():
-        for file in dist.files or []:
-            try:
-                file_path = Path(dist.locate_file(file)).resolve()
-                if file_path == module_path:
-                    return dist.metadata["Name"]
-            except Exception:  # noqa: PERF203, S110
-                pass
-
     # Fallback for src-layout editable installs: packages_distributions() has no
     # entry for the top-level package because hatchling only adds a .pth file
     # (no source files appear in RECORD). Scan all editable distributions and
@@ -99,4 +87,20 @@ def distribution_from_module(module_name: str) -> str | None:
         except Exception:  # noqa: PERF203, S110
             pass
 
-    return most_specific_dist_name
+    if most_specific_dist_name is not None:
+        return most_specific_dist_name
+
+    # Last-resort fallback for non-editable installs whose distribution has no
+    # top_level.txt (Python 3.10 only reads top_level.txt; 3.11+ also infers
+    # from RECORD). Scan all distributions' RECORD files for a direct path match.
+    # This is expensive, so it runs only after all cheaper strategies are exhausted.
+    for dist in im.distributions():
+        for file in dist.files or []:
+            try:
+                file_path = Path(dist.locate_file(file)).resolve()
+                if file_path == module_path:
+                    return dist.metadata["Name"]
+            except Exception:  # noqa: PERF203, S110
+                pass
+
+    return None

--- a/ado/utilities/distribution.py
+++ b/ado/utilities/distribution.py
@@ -36,7 +36,11 @@ def distribution_from_module(module_name: str) -> str | None:
     module_path = Path(module.__file__).resolve()
     top_level = module_name.split(".")[0]
 
-    # Get all distributions that provide this top-level package
+    # Get all distributions that provide this top-level package.
+    # packages_distributions() only reads top_level.txt on Python 3.10; on 3.11+
+    # it also infers top-level names from RECORD.  When the distribution has no
+    # top_level.txt (e.g. robotic_lab in a non-editable tox install), the lookup
+    # returns an empty list and we fall through to the broader scans below.
     for dist_name in im.packages_distributions().get(top_level, []):
         dist = im.distribution(dist_name)
 
@@ -57,6 +61,18 @@ def distribution_from_module(module_name: str) -> str | None:
                         return dist.metadata["Name"]
         except Exception:  # noqa: S110
             pass
+
+    # Fallback for non-editable installs whose distribution has no top_level.txt
+    # (Python 3.10 only reads top_level.txt; 3.11+ also infers from RECORD).
+    # Scan all distributions' RECORD files for a direct path match.
+    for dist in im.distributions():
+        for file in dist.files or []:
+            try:
+                file_path = Path(dist.locate_file(file)).resolve()
+                if file_path == module_path:
+                    return dist.metadata["Name"]
+            except Exception:  # noqa: PERF203, S110
+                pass
 
     # Fallback for src-layout editable installs: packages_distributions() has no
     # entry for the top-level package because hatchling only adds a .pth file

--- a/tests/schema/test_provenance.py
+++ b/tests/schema/test_provenance.py
@@ -93,13 +93,14 @@ def test_package_provenance_from_module_name_unknown() -> None:
 
 
 def test_package_provenance_from_module_name_src_layout() -> None:
-    """from_module_name resolves src-layout editable installs (robotic_lab_actuator).
+    """from_module_name resolves robotic_lab_actuator regardless of install mode.
 
-    robotic_lab is installed as a src-layout editable: hatchling adds
-    plugins/actuators/example_actuator/src to sys.path via a .pth file, so
-    importlib.metadata.packages_distributions() has no entry for
-    'robotic_lab_actuator'. Resolution must fall back to scanning
-    direct_url.json for all distributions.
+    In a locked (dev) install robotic_lab is editable (hatchling adds a .pth
+    file so packages_distributions() has no entry for 'robotic_lab_actuator').
+    In a nonlocked tox install it is non-editable but still has no top_level.txt,
+    so packages_distributions() also misses it on Python 3.10 (which only reads
+    top_level.txt, unlike 3.11+ which also infers from RECORD).
+    Resolution falls back to scanning RECORD files across all distributions.
     """
     prov = PackageProvenance.from_module_name("robotic_lab_actuator.actuator")
     assert prov is not None


### PR DESCRIPTION
### Problem
`PackageProvenance.from_module_name()` failed to identify the distribution for
certain packages (e.g. `robotic_lab_actuator`) when running under **Python 3.10**
in a non-editable install (e.g. tox CI).

`importlib.metadata.packages_distributions()` only reads `top_level.txt` on
Python 3.10; Python 3.11+ also infers top-level names from the `RECORD` file.
Packages installed without a `top_level.txt` therefore returned an empty list
on 3.10, causing distribution resolution to fail silently.

### Fix
Added a new fallback in `distribution_from_module()` that scans the `RECORD`
files of **all** installed distributions, resolving the distribution by matching
the module's file path directly. This runs after the existing
`packages_distributions()` lookup and before the editable-install scan, covering
non-editable packages that lack `top_level.txt`.

### Changes
| File | What changed |
|---|---|
| `orchestrator/utilities/distribution.py` | New RECORD-scanning fallback loop; updated existing comment to explain the Python 3.10/3.11 difference |
| `tests/schema/test_provenance.py` | Updated docstring on `test_package_provenance_from_module_name_src_layout` to document both editable and non-editable scenarios |