### PR TITLE
feat(core): add upgrade mechanism for orchestrator references in modules

### DIFF
--- a/ado/core/operation/config.py
+++ b/ado/core/operation/config.py
@@ -190,6 +190,24 @@ def validate_actuator_configuration_ids_against_space_ids(
 class OperatorModuleConf(ModuleConf):
     moduleType: Annotated[ModuleTypeEnum, pydantic.Field()] = ModuleTypeEnum.OPERATION
 
+    @classmethod
+    def _warn_legacy_module_name(cls, old_name: str, new_name: str) -> None:
+        from ado.core.resources import (
+            CoreResourceKinds,
+            warn_deprecated_resource_model_in_use,
+        )
+
+        warn_deprecated_resource_model_in_use(
+            affected_resource=CoreResourceKinds.OPERATION,
+            deprecated_from_ado_version="2.0.0",
+            removed_from_ado_version="3.0.0",
+            deprecated_fields="moduleName",
+            latest_format_documentation_url=(
+                "https://ibm.github.io/ado/migration/1x-to-2x/"
+                "#renamed-python-import-package-orchestrator-ado"
+            ),
+        )
+
     @property
     def operationType(self) -> DiscoveryOperationEnum:
         c: type[ado.modules.operators.base.DiscoveryOperationBase] = (

--- a/ado/core/samplestore/config.py
+++ b/ado/core/samplestore/config.py
@@ -27,6 +27,24 @@ class SampleStoreModuleConf(ModuleConf):
         ModuleTypeEnum.SAMPLE_STORE
     )
 
+    @classmethod
+    def _warn_legacy_module_name(cls, old_name: str, new_name: str) -> None:
+        from ado.core.resources import (
+            CoreResourceKinds,
+            warn_deprecated_resource_model_in_use,
+        )
+
+        warn_deprecated_resource_model_in_use(
+            affected_resource=CoreResourceKinds.SAMPLESTORE,
+            deprecated_from_ado_version="2.0.0",
+            removed_from_ado_version="3.0.0",
+            deprecated_fields="moduleName",
+            latest_format_documentation_url=(
+                "https://ibm.github.io/ado/migration/1x-to-2x/"
+                "#renamed-python-import-package-orchestrator-ado"
+            ),
+        )
+
 
 class SampleStoreSpecification(pydantic.BaseModel):
     """Model representing a SampleStore"""

--- a/ado/modules/module.py
+++ b/ado/modules/module.py
@@ -64,6 +64,38 @@ class ModuleConf(pydantic.BaseModel):
         ),
     ] = None
 
+    @classmethod
+    def _warn_legacy_module_name(cls, old_name: str, new_name: str) -> None:
+        """Emit a deprecation warning when a legacy orchestrator.* moduleName is rewritten.
+
+        Subclasses should override this to emit a resource-specific rich
+        callout via warn_deprecated_resource_model_in_use. The base
+        implementation falls back to a plain log warning.
+        """
+        moduleLog.warning(
+            "Legacy moduleName %r has been auto-rewritten to %r. "
+            "Update your resource to use the new name. "
+            "See https://ibm.github.io/ado/migration/1x-to-2x/"
+            "#renamed-python-import-package-orchestrator-ado",
+            old_name,
+            new_name,
+        )
+
+    @pydantic.field_validator("moduleName", mode="before")
+    @classmethod
+    def migrate_orchestrator_module_name(cls, value: str | None) -> str | None:
+        """Rewrite legacy 'orchestrator.*' module names to 'ado.*'.
+
+        Resources stored before the orchestrator→ado rename (commit 5687809)
+        have moduleName values prefixed with 'orchestrator.'. This validator
+        transparently rewrites them so existing stored resources remain usable.
+        """
+        if isinstance(value, str) and value.startswith("orchestrator."):
+            rewritten = "ado." + value[len("orchestrator.") :]
+            cls._warn_legacy_module_name(value, rewritten)
+            return rewritten
+        return value
+
     @pydantic.field_validator("moduleName")
     def set_default_module_name_for_type(
         cls, value: str | None, values: "pydantic.FieldValidationInfo"

--- a/tests/core/test_module_conf.py
+++ b/tests/core/test_module_conf.py
@@ -1,0 +1,61 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModuleConf validators"""
+
+import logging
+
+import pytest
+
+from ado.core.samplestore.config import SampleStoreModuleConf
+from ado.modules.module import ModuleConf, ModuleTypeEnum
+
+
+def test_legacy_orchestrator_prefix_is_rewritten(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """orchestrator.* prefix is rewritten to ado.* and a warning is emitted."""
+    with caplog.at_level(logging.WARNING, logger="module"):
+        conf = ModuleConf(
+            moduleType=ModuleTypeEnum.SAMPLE_STORE,
+            moduleName="orchestrator.core.samplestore.sql",
+            moduleClass="SQLSampleStore",
+        )
+    assert conf.moduleName == "ado.core.samplestore.sql"
+    assert "orchestrator.core.samplestore.sql" in caplog.text
+    assert "ado.core.samplestore.sql" in caplog.text
+    assert "ibm.github.io/ado/migration" in caplog.text
+
+
+def test_orchestrator_not_at_prefix_is_unchanged() -> None:
+    """orchestrator. mid-string is not rewritten."""
+    conf = ModuleConf(
+        moduleType=ModuleTypeEnum.GENERIC,
+        moduleName="ado.something.orchestrator.module",
+    )
+    assert conf.moduleName == "ado.something.orchestrator.module"
+
+
+def test_none_triggers_default_for_sample_store_type() -> None:
+    """None moduleName is defaulted to ado.core.samplestore.sql for SAMPLE_STORE."""
+    conf = ModuleConf(
+        moduleType=ModuleTypeEnum.SAMPLE_STORE,
+        moduleClass="SQLSampleStore",
+    )
+    assert conf.moduleName == "ado.core.samplestore.sql"
+
+
+def test_samplestore_subclass_emits_rich_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SampleStoreModuleConf emits the resource-specific rich WARN callout."""
+    conf = SampleStoreModuleConf(
+        moduleName="orchestrator.core.samplestore.sql",
+        moduleClass="SQLSampleStore",
+    )
+    assert conf.moduleName == "ado.core.samplestore.sql"
+    stderr = capsys.readouterr().err
+    assert "WARN" in stderr
+    assert "moduleName" in stderr
+    assert "ado upgrade samplestores" in stderr
+    assert "ibm.github.io/ado/migration" in stderr


### PR DESCRIPTION
## Add backward-compatible migration of legacy `orchestrator.*` module names

### Problem
Resources created before the `orchestrator` → `ado` package rename (commit 5687809) stored `moduleName` values prefixed with `orchestrator.` (e.g. `orchestrator.core.samplestore.sql`). Loading those resources after the rename would fail.

### Solution
Add a Pydantic `field_validator` on `ModuleConf.moduleName` that transparently rewrites any `orchestrator.*` prefix to `ado.*` at parse time, so existing stored resources remain usable without manual intervention.

### Changes
- **`ado/modules/module.py`** — New `migrate_orchestrator_module_name` validator on `ModuleConf` rewrites `orchestrator.*` → `ado.*` and calls `_warn_legacy_module_name` (base: plain log warning). New `_warn_legacy_module_name` hook method for subclasses to override with richer warnings.
- **`ado/core/operation/config.py`** — `OperatorModuleConf` overrides `_warn_legacy_module_name` to emit a structured deprecation callout pointing users to the 1.x → 2.x migration guide.
- **`ado/core/samplestore/config.py`** — `SampleStoreModuleConf` does the same for samplestore resources.
- **`tests/core/test_module_conf.py`** — New test file covering: prefix rewrite + warning emission, mid-string `orchestrator.` left unchanged, `None` defaulting, and the rich warning path via the samplestore subclass.

### Deprecation window
`moduleName` with an `orchestrator.*` prefix is deprecated from **2.0.0** and will be removed in **3.0.0**.