### PR TITLE
fix: ensure example custom experiments are detected

### DIFF
--- a/examples/ml-multi-cloud/custom_experiment/pyproject.toml
+++ b/examples/ml-multi-cloud/custom_experiment/pyproject.toml
@@ -7,13 +7,8 @@ dynamic = ["version"]
 requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-include = [
-  "ado_actuators/ml_multi_cloud_custom_experiments/**",
-]
-
 [tool.hatch.build.targets.wheel]
-only-include = ["ado_actuators/ml_multi_cloud_custom_experiments"]
+packages = ["ado_actuators"]
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"

--- a/examples/pfas-generative-models/custom_actuator_function/pyproject.toml
+++ b/examples/pfas-generative-models/custom_actuator_function/pyproject.toml
@@ -7,13 +7,8 @@ dynamic = ["version"]
 requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-include = [
-  "ado_actuators/pfas_custom_experiments/**",
-]
-
 [tool.hatch.build.targets.wheel]
-only-include = ["ado_actuators/pfas_custom_experiments"]
+packages = ["ado_actuators"]
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"


### PR DESCRIPTION
## Fix: example custom experiment packages not detected by `ado get experiments`

Two example packages using the `ado_actuators` namespace scan for discovery
(`ml-multi-cloud` and `pfas-generative-models`) were silently invisible after
installation. Their `pyproject.toml` files used `only-include` to control
wheel contents, but omitted `packages = ["ado_actuators"]`. Without this,
hatchling did not register the code under the `ado_actuators` namespace, so
`ado_actuators.ml_multi_cloud_custom_experiments` and
`ado_actuators.pfas_custom_experiments` were not importable and the experiment
scanner could not find them.

**Fix:** replace `only-include` with `packages = ["ado_actuators"]` in both
`pyproject.toml` files, matching the pattern already used by in-tree actuator
plugins.

### Files changed
- `examples/ml-multi-cloud/custom_experiment/pyproject.toml`
- `examples/pfas-generative-models/custom_actuator_function/pyproject.toml`