### PR TITLE
fix: remove versioning from name in ml-multi-cloud example

### DIFF
--- a/examples/ml-multi-cloud/custom_experiment/ado_actuators/ml_multi_cloud_custom_experiments/custom_experiments.yaml
+++ b/examples/ml-multi-cloud/custom_experiment/ado_actuators/ml_multi_cloud_custom_experiments/custom_experiments.yaml
@@ -1,7 +1,8 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 experiments:
-  - identifier: 'ml-multicloud-cost-v1.0'
+  - identifier: 'ml-multicloud-cost'
+    version: "1.0.0"
     actuatorIdentifier: "custom_experiments"
     metadata:
       module:

--- a/examples/ml-multi-cloud/ml_multicloud_space_with_custom.yaml
+++ b/examples/ml-multi-cloud/ml_multicloud_space_with_custom.yaml
@@ -20,5 +20,6 @@ entitySpace:
 experiments:
   - experimentIdentifier: 'benchmark_performance'
     actuatorIdentifier: 'replay'
-  - experimentIdentifier: 'ml-multicloud-cost-v1.0'
+  - experimentIdentifier: 'ml-multicloud-cost'
     actuatorIdentifier: 'custom_experiments'
+    experimentVersion: 1.0.0

--- a/tests/fixtures/ml_multi_cloud/fixtures.py
+++ b/tests/fixtures/ml_multi_cloud/fixtures.py
@@ -187,8 +187,9 @@ def ml_multi_cloud_invalid_actuatorconfiguration(
 def ml_multi_cloud_cost_experiment() -> Experiment:
     return ActuatorRegistry.globalRegistry().experimentForReference(
         ExperimentReference(
-            experimentIdentifier="ml-multicloud-cost-v1.0",
+            experimentIdentifier="ml-multicloud-cost",
             actuatorIdentifier="custom_experiments",
+            experimentVersion="1.0.0",
         )
     )
 


### PR DESCRIPTION
## Fix: separate version from identifier in `ml-multicloud-cost` experiment

The version string was previously encoded directly in the experiment identifier (`ml-multicloud-cost-v1.0`). This PR moves the version to the dedicated `version` / `experimentVersion` field, bringing the ml-multi-cloud example in line with the canonical experiment schema.

### Changes

- **`custom_experiments.yaml`** — renamed identifier from `ml-multicloud-cost-v1.0` → `ml-multicloud-cost` and added an explicit `version: "1.0.0"` field.
- **`ml_multicloud_space_with_custom.yaml`** — updated the experiment reference to use the new identifier and added `experimentVersion: 1.0.0`.
- **`tests/fixtures/ml_multi_cloud/fixtures.py`** — updated the `ExperimentReference` fixture to match the new identifier + version fields.

### Before

`ado describe experiment ml-multicloud-cost-v1.0` was broken:

```
ERROR:  The custom_experiments actuator was found but a match to custom_experiments.ml-multicloud-cost-v1.0 was not found using mode any.
```