### PR TITLE
feat(cli): support --use-latest for datacontainers in ado describe

### DIFF
--- a/ado/cli/commands/describe.py
+++ b/ado/cli/commands/describe.py
@@ -36,8 +36,6 @@ from ado.modules.actuators.errors import (
 if typing.TYPE_CHECKING:
     from ado.cli.core.config import AdoConfiguration
 
-SPACE_ONLY_OPTIONS = "Space-only options"
-
 
 def describe_resource(
     ctx: typer.Context,
@@ -62,9 +60,9 @@ def describe_resource(
         bool,
         typer.Option(
             "--use-latest",
-            help="Describe the space using the latest space identifier created. "
+            help="Describe the resource using the latest identifier created. "
+            "Not supported for experiments. "
             "Ignored if a resource identifier is also specified.",
-            rich_help_panel=SPACE_ONLY_OPTIONS,
             show_default=False,
         ),
     ] = False,
@@ -102,9 +100,9 @@ def describe_resource(
     ado_configuration: AdoConfiguration = ctx.obj
 
     if use_latest:
-        if resource_type != AdoDescribeSupportedResourceTypes.DISCOVERY_SPACE:
+        if resource_type == AdoDescribeSupportedResourceTypes.EXPERIMENT:
             console_print(
-                f"{ERROR}The {cyan('--use-latest')} flag is available only for spaces.",
+                f"{ERROR}The {cyan('--use-latest')} flag is not supported for experiments.",
                 stderr=True,
             )
             raise typer.Exit(1)

--- a/tests/ado/describe/test_ado_describe.py
+++ b/tests/ado/describe/test_ado_describe.py
@@ -9,8 +9,12 @@ from testcontainers.mysql import MySqlContainer
 from typer.testing import CliRunner
 
 from ado.cli.core.cli import app as ado
+from ado.core import DataContainerResource
+from ado.core.datacontainer.resource import DataContainer
 from ado.core.discoveryspace.space import DiscoverySpace
 from ado.metastore.project import ProjectContext
+from ado.metastore.sqlstore import SQLStore
+from tests.conftest import requires_sqlite_3_38
 
 
 def test_describe_nonexistent_space(
@@ -66,3 +70,45 @@ def test_describe_peptide_mineralization_experiment() -> None:
     assert ("Identifier: robotic_lab.peptide_mineralization") in result.output
 
     assert "Measures adsorption of peptide lanthanide combinations" in result.output
+
+
+@requires_sqlite_3_38
+def test_describe_datacontainer_with_use_latest(
+    tmp_path: pathlib.Path,
+    mysql_test_instance: MySqlContainer,
+    sql_store: SQLStore,
+    valid_ado_project_context: ProjectContext,
+    create_active_ado_context: Callable[
+        [CliRunner, pathlib.Path, ProjectContext], None
+    ],
+) -> None:
+    """Test that ado describe datacontainer --use-latest resolves the latest datacontainer."""
+    from datetime import datetime, timezone
+
+    runner = CliRunner()
+    create_active_ado_context(
+        runner=runner, path=tmp_path, project_context=valid_ado_project_context
+    )
+
+    # Create two datacontainer resources with different identifiers and timestamps
+    dc_1 = DataContainerResource(config=DataContainer(data={"key": "value1"}))
+    dc_1.identifier = "dc-test-older"
+    dc_1.created = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    sql_store.addResource(dc_1)
+
+    dc_2 = DataContainerResource(config=DataContainer(data={"key": "value2"}))
+    dc_2.identifier = "dc-test-latest"
+    dc_2.created = datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    sql_store.addResource(dc_2)
+
+    result = runner.invoke(ado, ["describe", "datacontainer", "--use-latest"])
+    assert result.exit_code == 0
+    if os.environ.get("CI", "false") != "true":
+        assert dc_2.identifier in result.output
+
+
+def test_describe_use_latest_rejected_for_experiment() -> None:
+    """Test that ado describe experiment --use-latest exits with code 1."""
+    runner = CliRunner()
+    result = runner.invoke(ado, ["describe", "experiment", "--use-latest"])
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary

Previously, the `--use-latest` flag in `ado describe` was restricted to discovery spaces only. Any other resource type would produce an error.

This PR broadens support so that `--use-latest` works for data containers, and only rejects it for **experiments** (which have no "latest" concept).

### Changes

**`ado/cli/commands/describe.py`**
- Removed the `SPACE_ONLY_OPTIONS` panel label that isolated `--use-latest`
  as a space-only option.
- Updated the `--use-latest` help text to reflect the wider scope and note
  the experiment exclusion.
- Changed the validation logic: instead of blocking every resource type
  except `DISCOVERY_SPACE`, it now only blocks `EXPERIMENT`.

**`tests/ado/describe/test_ado_describe.py`**
- Added `test_describe_datacontainer_with_use_latest`: verifies that
  `ado describe datacontainer --use-latest` resolves and describes the most
  recently created data container.
- Added `test_describe_use_latest_rejected_for_experiment`: verifies that
  `ado describe experiment --use-latest` exits with code `1`.