### PR TITLE
feat(core): support fetching entities and entity identifiers for multiple operations at once

### DIFF
--- a/ado/core/discoveryspace/space.py
+++ b/ado/core/discoveryspace/space.py
@@ -623,28 +623,7 @@ class DiscoverySpace:
         if not operation_ids:
             return []
 
-        # Optimize for single operation: use direct query (1 query instead of 2)
-        if len(operation_ids) == 1:
-            sampled_entities = self.sample_store.entities_in_operation(
-                operation_id=next(iter(operation_ids))
-            )
-        else:
-            # Multiple operations: get entity IDs first, then fetch entities
-            # This approach handles deduplication across operations naturally
-            sampled_entity_ids = set()
-            for operationid in operation_ids:
-                sampled_entity_ids.update(
-                    self.entity_identifiers_in_operation(operation_id=operationid)
-                )
-
-            if not sampled_entity_ids:
-                return []
-
-            # Efficiently fetch only the entities that were sampled in operations
-            # This avoids loading all entities from the store when we only need a subset
-            sampled_entities = self.sample_store.entities_with_identifiers(
-                sampled_entity_ids
-            )
+        sampled_entities = self.sample_store.entities_in_operation(operation_ids)
 
         # TODO: Consider removing isEntitySpace check
         # The additional check of isEntityInSpace should not be required if things are working correctly
@@ -1072,9 +1051,11 @@ class DiscoverySpace:
         )
 
     @_perform_preflight_checks_for_sample_store_methods
-    def entity_identifiers_in_operation(self, operation_id: str) -> set[str]:
+    def entity_identifiers_in_operation(
+        self, operation_ids: str | set[str]
+    ) -> set[str]:
         return self.sample_store.entity_identifiers_in_operation(
-            operation_id=operation_id
+            operation_ids=operation_ids
         )
 
     @_perform_preflight_checks_for_sample_store_methods

--- a/ado/core/discoveryspace/space.py
+++ b/ado/core/discoveryspace/space.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import os
 import typing
+import warnings
 from collections.abc import Callable, Iterator
 from functools import wraps
 from typing import Any
@@ -623,7 +624,7 @@ class DiscoverySpace:
         if not operation_ids:
             return []
 
-        sampled_entities = self.sample_store.entities_in_operation(operation_ids)
+        sampled_entities = self.sample_store.entities_in_operations(operation_ids)
 
         # TODO: Consider removing isEntitySpace check
         # The additional check of isEntityInSpace should not be required if things are working correctly
@@ -1051,12 +1052,25 @@ class DiscoverySpace:
         )
 
     @_perform_preflight_checks_for_sample_store_methods
+    def entity_identifiers_in_operations(
+        self, operation_ids: str | set[str]
+    ) -> set[str]:
+        """Return entity identifiers sampled in the given operation(s)."""
+        return self.sample_store.entity_identifiers_in_operations(
+            operation_ids=operation_ids
+        )
+
+    @_perform_preflight_checks_for_sample_store_methods
     def entity_identifiers_in_operation(
         self, operation_ids: str | set[str]
     ) -> set[str]:
-        return self.sample_store.entity_identifiers_in_operation(
-            operation_ids=operation_ids
+        """Deprecated: use entity_identifiers_in_operations instead."""
+        warnings.warn(
+            "entity_identifiers_in_operation is deprecated, use entity_identifiers_in_operations instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return self.entity_identifiers_in_operations(operation_ids)
 
     @_perform_preflight_checks_for_sample_store_methods
     def experiments_in_operation(self, operation_id: str) -> list[Experiment]:

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -491,8 +491,16 @@ class ActiveSampleStore(SampleStore, ABC):
         """Commits all the changes to the source"""
 
     @abc.abstractmethod
-    def entities_in_operation(self, operation_id: str) -> list[Entity]:
-        """Returns list of entities in the given operation."""
+    def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
+        """Returns list of entities in the given operation(s).
+
+        Args:
+            operation_ids: A single operation identifier or a set of operation
+                identifiers to fetch entities for.
+
+        Returns:
+            List of Entity objects that were sampled in the specified operation(s).
+        """
 
     @abc.abstractmethod
     def operation_entity_statistics(self, operation_id: str) -> dict[str, int]:

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -3,6 +3,7 @@
 
 import abc
 import typing
+import warnings
 from abc import ABC
 from typing import Annotated, Literal
 
@@ -491,7 +492,7 @@ class ActiveSampleStore(SampleStore, ABC):
         """Commits all the changes to the source"""
 
     @abc.abstractmethod
-    def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
+    def entities_in_operations(self, operation_ids: str | set[str]) -> list[Entity]:
         """Returns list of entities in the given operation(s).
 
         Args:
@@ -501,6 +502,15 @@ class ActiveSampleStore(SampleStore, ABC):
         Returns:
             List of Entity objects that were sampled in the specified operation(s).
         """
+
+    def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
+        """Deprecated: use entities_in_operations instead."""
+        warnings.warn(
+            "entities_in_operation is deprecated, use entities_in_operations instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.entities_in_operations(operation_ids)
 
     @abc.abstractmethod
     def operation_entity_statistics(self, operation_id: str) -> dict[str, int]:

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -822,19 +822,23 @@ class SQLSampleStore(ActiveSampleStore):
 
         return list(entities_dict.values())
 
-    def entities_in_operation(self, operation_id: str) -> list[Entity]:
-        """Get entities directly from a single operation in one query.
+    def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
+        """Get entities directly from one or more operations in one query.
 
-        This method is optimized for the common case of fetching entities from
-        a single operation. It performs the entire operation in a single database
-        query, avoiding the need to first fetch entity IDs and then fetch entities.
+        This method fetches entities from one or more operations in a single
+        database query, avoiding the need to first fetch entity IDs and then
+        fetch entities.
 
         Args:
-            operation_id: The operation identifier to fetch entities for
+            operation_ids: A single operation identifier or a set of operation
+                identifiers to fetch entities for.
 
         Returns:
-            List of Entity objects that were sampled in the specified operation
+            List of Entity objects that were sampled in the specified operation(s)
         """
+        if isinstance(operation_ids, str):
+            operation_ids = {operation_ids}
+
         query = sqlalchemy.text(f"""
             SELECT
                 ent.identifier,
@@ -844,16 +848,18 @@ class SQLSampleStore(ActiveSampleStore):
             JOIN {self._tablename}_measurement_results res ON res.entity_id = ent.identifier
             JOIN {self._tablename}_measurement_requests_results reqres ON reqres.result_uid = res.uid
             JOIN {self._tablename}_measurement_requests req ON reqres.request_uid = req.uid
-            WHERE req.operation_id = :operation_id
+            WHERE req.operation_id IN :operation_ids
         """).bindparams(  # noqa: S608 - self._tablename is not untrusted
-            operation_id=operation_id
+            sqlalchemy.bindparam(
+                "operation_ids", value=list(operation_ids), expanding=True
+            )
         )
 
         try:
             with self.engine.begin() as connectable:
                 cur = connectable.execute(query)
         except SQLAlchemyError as error:
-            msg = f"Unable to fetch entities for operation {operation_id} from sample store {self._tablename}"
+            msg = f"Unable to fetch entities for operations {operation_ids} from sample store {self._tablename}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 
@@ -2122,7 +2128,21 @@ class SQLSampleStore(ActiveSampleStore):
             for e in cur
         ]
 
-    def entity_identifiers_in_operation(self, operation_id: str) -> set[str]:
+    def entity_identifiers_in_operation(
+        self, operation_ids: str | set[str]
+    ) -> set[str]:
+        """Get the set of entity identifiers sampled in one or more operations.
+
+        Args:
+            operation_ids: A single operation identifier or a set of operation
+                identifiers to look up entity identifiers for.
+
+        Returns:
+            Set of entity identifier strings across all specified operations.
+        """
+        if isinstance(operation_ids, str):
+            operation_ids = {operation_ids}
+
         try:
             with self.engine.begin() as connectable:
                 query = sqlalchemy.text(f"""
@@ -2130,16 +2150,18 @@ class SQLSampleStore(ActiveSampleStore):
                     FROM (
                         SELECT *
                         FROM {self._tablename}_measurement_requests
-                        WHERE operation_id = :operation_id
+                        WHERE operation_id IN :operation_ids
                     ) req
                     JOIN {self._tablename}_measurement_requests_results reqres ON reqres.request_uid = req.uid
                     JOIN {self._tablename}_measurement_results res ON reqres.result_uid = res.uid
                     """).bindparams(  # noqa: S608 - self._tablename is not untrusted
-                    operation_id=operation_id
+                    sqlalchemy.bindparam(
+                        "operation_ids", value=list(operation_ids), expanding=True
+                    )
                 )
                 cur = connectable.execute(query)
         except SQLAlchemyError as error:
-            msg = f"Unable to get the entity ids for operation {operation_id}"
+            msg = f"Unable to get the entity ids for operations {operation_ids}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -6,6 +6,7 @@ import json
 import logging
 import typing
 import uuid
+import warnings
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import pydantic
@@ -822,7 +823,7 @@ class SQLSampleStore(ActiveSampleStore):
 
         return list(entities_dict.values())
 
-    def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
+    def entities_in_operations(self, operation_ids: str | set[str]) -> list[Entity]:
         """Get entities directly from one or more operations in one query.
 
         This method fetches entities from one or more operations in a single
@@ -908,6 +909,15 @@ class SQLSampleStore(ActiveSampleStore):
                 )
 
         return list(entities_dict.values())
+
+    def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
+        """Deprecated: use entities_in_operations instead."""
+        warnings.warn(
+            "entities_in_operation is deprecated, use entities_in_operations instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.entities_in_operations(operation_ids)
 
     @property
     def numberOfEntities(self) -> int:
@@ -2128,7 +2138,7 @@ class SQLSampleStore(ActiveSampleStore):
             for e in cur
         ]
 
-    def entity_identifiers_in_operation(
+    def entity_identifiers_in_operations(
         self, operation_ids: str | set[str]
     ) -> set[str]:
         """Get the set of entity identifiers sampled in one or more operations.
@@ -2166,6 +2176,17 @@ class SQLSampleStore(ActiveSampleStore):
             raise SystemError(f"{msg}. Error: {error}") from error
 
         return {ident[0] for ident in cur}
+
+    def entity_identifiers_in_operation(
+        self, operation_ids: str | set[str]
+    ) -> set[str]:
+        """Deprecated: use entity_identifiers_in_operations instead."""
+        warnings.warn(
+            "entity_identifiers_in_operation is deprecated, use entity_identifiers_in_operations instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.entity_identifiers_in_operations(operation_ids)
 
     def complete_measurement_request_with_results_timeseries(
         self,

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -555,7 +555,7 @@ def test_experiments_in_operation(
     )
 
 
-def test_entity_identifiers_in_operation(
+def test_entity_identifiers_in_operations(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
@@ -581,7 +581,7 @@ def test_entity_identifiers_in_operation(
     for r in requests:
         entity_ids = entity_ids.union({e.identifier for e in r.entities})
 
-    retrieved_entity_ids = sample_store.entity_identifiers_in_operation(
+    retrieved_entity_ids = sample_store.entity_identifiers_in_operations(
         operation_ids=operation_id
     )
     assert len(entity_ids) == len(retrieved_entity_ids)
@@ -812,13 +812,13 @@ def test_entities_by_identifiers_with_measurement_results(
         assert len(entity.measurement_results) > 0
 
 
-def test_entities_in_operation_empty_operation(
+def test_entities_in_operations_empty_operation(
     random_identifier: Callable[[], str],
     ml_multi_cloud_sample_store: SQLSampleStore,
     valid_ado_project_context: ProjectContext,
     ml_multi_cloud_operation_configuration: "DiscoveryOperationResourceConfiguration",
 ) -> None:
-    """Test entities_in_operation with operation that has no entities."""
+    """Test entities_in_operations with operation that has no entities."""
     from ado.core import OperationResource
     from ado.core.operation.config import DiscoveryOperationEnum
     from ado.metastore.sqlstore import SQLResourceStore
@@ -837,20 +837,20 @@ def test_entities_in_operation_empty_operation(
     )
 
     # Should return empty list, not raise an error
-    result = ml_multi_cloud_sample_store.entities_in_operation(
+    result = ml_multi_cloud_sample_store.entities_in_operations(
         operation_ids=operation_id
     )
     assert result == []
 
 
-def test_entities_in_operation_single_operation(
+def test_entities_in_operations_single_operation(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """Test entities_in_operation returns correct entities for a single operation."""
+    """Test entities_in_operations returns correct entities for a single operation."""
     number_entities = 5
     number_requests = 3
     measurements_per_result = 2
@@ -870,8 +870,8 @@ def test_entities_in_operation_single_operation(
     for r in requests:
         expected_entity_ids.update({e.identifier for e in r.entities})
 
-    # Fetch entities using entities_in_operation
-    retrieved_entities = sample_store.entities_in_operation(operation_ids=operation_id)
+    # Fetch entities using entities_in_operations
+    retrieved_entities = sample_store.entities_in_operations(operation_ids=operation_id)
 
     # Should get all entities from the operation
     retrieved_entity_ids = {e.identifier for e in retrieved_entities}
@@ -879,14 +879,14 @@ def test_entities_in_operation_single_operation(
     assert retrieved_entity_ids == expected_entity_ids
 
 
-def test_entities_in_operation_with_measurement_results(
+def test_entities_in_operations_with_measurement_results(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """Test entities_in_operation includes measurement results."""
+    """Test entities_in_operations includes measurement results."""
     number_entities = 3
     number_requests = 2
     measurements_per_result = 2
@@ -901,8 +901,8 @@ def test_entities_in_operation_with_measurement_results(
         )
     )
 
-    # Fetch entities using entities_in_operation
-    retrieved_entities = sample_store.entities_in_operation(operation_ids=operation_id)
+    # Fetch entities using entities_in_operations
+    retrieved_entities = sample_store.entities_in_operations(operation_ids=operation_id)
 
     # Verify entities have measurement results
     for entity in retrieved_entities:
@@ -913,14 +913,14 @@ def test_entities_in_operation_with_measurement_results(
             assert len(result.measurements) > 0
 
 
-def test_entities_in_operation_deduplication(
+def test_entities_in_operations_deduplication(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """Test entities_in_operation deduplicates entities when same entity appears in multiple requests."""
+    """Test entities_in_operations deduplicates entities when same entity appears in multiple requests."""
     number_entities = 3
     number_requests = 5  # Multiple requests, some entities may repeat
     measurements_per_result = 2
@@ -940,8 +940,8 @@ def test_entities_in_operation_deduplication(
     for r in requests:
         all_entity_ids.update({e.identifier for e in r.entities})
 
-    # Fetch entities using entities_in_operation
-    retrieved_entities = sample_store.entities_in_operation(operation_ids=operation_id)
+    # Fetch entities using entities_in_operations
+    retrieved_entities = sample_store.entities_in_operations(operation_ids=operation_id)
 
     # Should get unique entities (no duplicates)
     retrieved_entity_ids = {e.identifier for e in retrieved_entities}
@@ -956,7 +956,7 @@ def test_entities_in_multiple_operations(
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """Test entities_in_operation returns deduplicated entities from multiple operations."""
+    """Test entities_in_operations returns deduplicated entities from multiple operations."""
     number_entities = 3
     number_requests = 3
     measurements_per_result = 2
@@ -980,7 +980,7 @@ def test_entities_in_multiple_operations(
     for r in requests1 + requests2:
         expected_ids.update({e.identifier for e in r.entities})
 
-    retrieved_entities = sample_store.entities_in_operation(operation_ids={op1, op2})
+    retrieved_entities = sample_store.entities_in_operations(operation_ids={op1, op2})
     retrieved_ids = {e.identifier for e in retrieved_entities}
 
     # All expected entities returned, no duplicates

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -582,7 +582,7 @@ def test_entity_identifiers_in_operation(
         entity_ids = entity_ids.union({e.identifier for e in r.entities})
 
     retrieved_entity_ids = sample_store.entity_identifiers_in_operation(
-        operation_id=operation_id
+        operation_ids=operation_id
     )
     assert len(entity_ids) == len(retrieved_entity_ids)
     assert len(entity_ids.intersection(retrieved_entity_ids)) == len(entity_ids)
@@ -838,7 +838,7 @@ def test_entities_in_operation_empty_operation(
 
     # Should return empty list, not raise an error
     result = ml_multi_cloud_sample_store.entities_in_operation(
-        operation_id=operation_id
+        operation_ids=operation_id
     )
     assert result == []
 
@@ -871,7 +871,7 @@ def test_entities_in_operation_single_operation(
         expected_entity_ids.update({e.identifier for e in r.entities})
 
     # Fetch entities using entities_in_operation
-    retrieved_entities = sample_store.entities_in_operation(operation_id=operation_id)
+    retrieved_entities = sample_store.entities_in_operation(operation_ids=operation_id)
 
     # Should get all entities from the operation
     retrieved_entity_ids = {e.identifier for e in retrieved_entities}
@@ -902,7 +902,7 @@ def test_entities_in_operation_with_measurement_results(
     )
 
     # Fetch entities using entities_in_operation
-    retrieved_entities = sample_store.entities_in_operation(operation_id=operation_id)
+    retrieved_entities = sample_store.entities_in_operation(operation_ids=operation_id)
 
     # Verify entities have measurement results
     for entity in retrieved_entities:
@@ -941,12 +941,51 @@ def test_entities_in_operation_deduplication(
         all_entity_ids.update({e.identifier for e in r.entities})
 
     # Fetch entities using entities_in_operation
-    retrieved_entities = sample_store.entities_in_operation(operation_id=operation_id)
+    retrieved_entities = sample_store.entities_in_operation(operation_ids=operation_id)
 
     # Should get unique entities (no duplicates)
     retrieved_entity_ids = {e.identifier for e in retrieved_entities}
     assert len(retrieved_entity_ids) == len(retrieved_entities)  # No duplicates
     assert retrieved_entity_ids == all_entity_ids
+
+
+def test_entities_in_multiple_operations(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Test entities_in_operation returns deduplicated entities from multiple operations."""
+    number_entities = 3
+    number_requests = 3
+    measurements_per_result = 2
+    op1 = random_identifier()
+    op2 = random_identifier()
+
+    sample_store, requests1, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=op1,
+    )
+    _, requests2, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=op2,
+    )
+
+    expected_ids = set()
+    for r in requests1 + requests2:
+        expected_ids.update({e.identifier for e in r.entities})
+
+    retrieved_entities = sample_store.entities_in_operation(operation_ids={op1, op2})
+    retrieved_ids = {e.identifier for e in retrieved_entities}
+
+    # All expected entities returned, no duplicates
+    assert retrieved_ids == expected_ids
+    assert len(retrieved_entities) == len(retrieved_ids)
 
 
 @requires_sqlite_3_38


### PR DESCRIPTION
### What changed

Two samplestore methods — `entities_in_operation` and `entity_identifiers_in_operation` — previously only accepted a single operation ID. They now accept either a single ID or a set of IDs, allowing callers to fetch deduplicated entities across multiple operations in **one database query** instead of N queries.

### Key changes

| Layer | Before | After |
|---|---|---|
| `SQLSampleStore` | `entities_in_operation(operation_id: str)` | `entities_in_operations(operation_ids: str \| set[str])` |
| `SQLSampleStore` | `entity_identifiers_in_operation(operation_id: str)` | `entity_identifiers_in_operations(operation_ids: str \| set[str])` |
| `ActiveSampleStore` (base) | abstract `entities_in_operation` | abstract `entities_in_operations` |
| `DiscoverySpace` | called both methods separately in a branch | delegates directly to `entities_in_operations` |

The old single-ID methods are kept as **deprecated shims** (emit `DeprecationWarning`) that forward to the new plural methods, preserving backwards compatibility.

The SQL queries were updated to use `IN :operation_ids` with SQLAlchemy's `expanding=True` bind parameter, which handles the single-or-many case natively.

### Tests

Existing tests were renamed from `*_in_operation` to `*_in_operations` and a new test `test_entities_in_multiple_operations` was added to cover the multi-operation deduplication path end-to-end.