### PR TITLE
perf(core): enable partial cache reuse in entities_with_identifiers

### DIFF
--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -744,18 +744,20 @@ class SQLSampleStore(ActiveSampleStore):
             else entity_identifiers
         )
 
-        # Check cache first - if all requested entities are cached, return them
-        if self._entities:
-            cached_entities = [
-                self._entities[entity_id]
-                for entity_id in entity_ids_set
-                if entity_id in self._entities
-            ]
-            # If we got all requested entities from cache, return them
-            if len(cached_entities) == len(entity_ids_set):
-                return cached_entities
+        # Partition into cached and uncached IDs
+        cached_keys = (
+            entity_ids_set.intersection(self._entities.keys())
+            if self._entities
+            else set()
+        )
+        uncached_ids = entity_ids_set.difference(cached_keys)
+        cached_entities = [self._entities[k] for k in cached_keys]
 
-        # Query database for entities by identifiers
+        # All requested entities were already cached
+        if not uncached_ids:
+            return cached_entities
+
+        # Query database only for the uncached entities
         # Use SQLAlchemy's expanding bindparam for IN clause
         # This automatically handles the parameter expansion for the IN clause
         query = sqlalchemy.text(f"""
@@ -765,7 +767,7 @@ class SQLSampleStore(ActiveSampleStore):
             WHERE ent.identifier IN :entity_ids
         """).bindparams(  # noqa: S608 - self._tablename is not untrusted
             sqlalchemy.bindparam(
-                key="entity_ids", value=list(entity_ids_set), expanding=True
+                key="entity_ids", value=list(uncached_ids), expanding=True
             )
         )
 
@@ -821,7 +823,7 @@ class SQLSampleStore(ActiveSampleStore):
                 result=measurement_result
             )
 
-        return list(entities_dict.values())
+        return cached_entities + list(entities_dict.values())
 
     def entities_in_operations(self, operation_ids: str | set[str]) -> list[Entity]:
         """Get entities directly from one or more operations in one query.

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -773,6 +773,32 @@ def test_entities_by_identifiers_mixed_existing_nonexistent(
     assert {e.identifier for e in result} == existing_ids
 
 
+def test_entities_by_identifiers_partial_cache_reuse(
+    ml_multi_cloud_sample_store: SQLSampleStore,
+) -> None:
+    """Test entities_with_identifiers reuses cached entities and only queries the rest."""
+    all_entities = ml_multi_cloud_sample_store.entities
+    assert len(all_entities) >= 3
+
+    # Pre-warm the cache with only the first entity
+    first_id = all_entities[0].identifier
+    second_id = all_entities[1].identifier
+    # Access entities property to populate _entities cache
+    assert ml_multi_cloud_sample_store._entities is not None
+
+    # Remove all but the first entity from the cache to simulate partial warm cache
+    cached_only = {first_id: ml_multi_cloud_sample_store._entities[first_id]}
+    ml_multi_cloud_sample_store._entities = cached_only
+
+    # Now request both the cached entity and an uncached one
+    result = ml_multi_cloud_sample_store.entities_with_identifiers(
+        {first_id, second_id}
+    )
+
+    assert len(result) == 2
+    assert {e.identifier for e in result} == {first_id, second_id}
+
+
 def test_entities_by_identifiers_with_measurement_results(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[


### PR DESCRIPTION
## Partial cache reuse in `entities_with_identifiers`

Previously, `entities_with_identifiers` only used the in-memory entity cache as an all-or-nothing shortcut: if every requested entity was already cached it returned immediately, otherwise it re-fetched **all** requested entities from the database — even ones already in memory.

This PR changes the logic so that the cache is always consulted first and only the **uncached** entities are sent to the database. The results are then merged before returning.

### Changes
- **`ado/core/samplestore/sql.py`** — `entities_with_identifiers` now partitions the requested IDs into cached vs. uncached sets, queries the DB only for uncached IDs, and combines both sets in the return value.
- **`tests/samplestore/get/test_get.py`** — new test `test_entities_by_identifiers_partial_cache_reuse` verifies that a partially warm cache is reused correctly (only the missing entities are fetched from the database).

### Impact
Read performance improves for any caller that requests a mix of already-cached and not-yet-cached entities, since previously cached entities no longer trigger redundant database round-trips.