### PR TITLE
build(hooks): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: detect-secrets # pragma: whitelist secret
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+    rev: v0.15.22
     hooks:
       - id: ruff
         args:
@@ -42,13 +42,13 @@ repos:
           - --scopes
           - anomalous-series,autoconf,changelog,ci,cli,container,contributing,core,cplex-mip,deps,docs,example-actuator,hooks,profile-space,ray-tune,sfttrainer,test,trim,vllm-performance,website
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         additional_dependencies: ['tomli']
         args: ['--toml', 'pyproject.toml']
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.28
+    rev: 0.11.29
     hooks:
       - id: uv-lock
       - id: uv-export
@@ -58,7 +58,7 @@ repos:
     hooks:
       - id: add-headers
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.23.0
+    rev: v0.23.1
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/google/yamlfmt
@@ -66,7 +66,7 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v1.2.0
+    rev: v1.2.4
     hooks:
       - id: tombi-format
         args: ["--offline"]


### PR DESCRIPTION
## Updated pre-commit hooks

| Hook | From | To |
|---|---|---|
| [ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) | 0.15.21 | 0.15.22 |
| [codespell](https://github.com/codespell-project/codespell) | 2.4.2 | 2.4.3 |
| [uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) | 0.11.28 | 0.11.29 |
| [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | 0.23.0 | 0.23.1 |
| [tombi-pre-commit](https://github.com/tombi-toml/tombi-pre-commit) | 1.2.0 | 1.2.4 |