### PR TITLE
perf(cli): use preexisting metastore when creating DiscoverySpaces

### DIFF
--- a/ado/cli/utils/resources/formatters.py
+++ b/ado/cli/utils/resources/formatters.py
@@ -492,6 +492,7 @@ def format_ado_get_stats_for_spaces(
                         conf=space_resources[space_id].config,
                         project_context=project_context,  # type: ignore[arg-type]
                         identifier=space_id,
+                        metadata_store=sql_store,
                         sample_store=sample_store,
                         load_experiment_catalog=False,
                     )


### PR DESCRIPTION
Avoids re-fetching it from the resource on every instantiation