### PR TITLE
fix(core): prevent accidental use of partially populated sample store

### DIFF
--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -392,9 +392,8 @@ class SQLSampleStore(ActiveSampleStore):
         self._engine = engine_for_sql_store(storageLocation)
 
         # Initialize entities cache as empty dict for lazy loading
-        # Empty dict is falsy, so lazy loading check `if not self._entities:` still works
-        # But it's also a valid dict that can be used for assignments
         self._entities = {}
+        self._all_entities_loaded = False
         self._last_insert_id = (
             0  # Track last processed insert_id for incremental refresh
         )
@@ -469,10 +468,9 @@ class SQLSampleStore(ActiveSampleStore):
 
     @property
     def entities(self) -> list[Entity]:
-        if not self._entities:
+        if not self._all_entities_loaded:
             # Initial load: delegate to refresh with force_fetch_all_entities=True
             self.log.debug(f"Initial load of entities for {self._tablename}")
-            self._entities = {}
             self.refresh(force_fetch_all_entities=True)
 
         return list(self._entities.values())
@@ -651,6 +649,7 @@ class SQLSampleStore(ActiveSampleStore):
             # Initial load: fetch all entities
             self._entities = self._fetch_entities(entity_ids=None)
             new_entities_count = len(self._entities)
+            self._all_entities_loaded = True
             self.log.debug(f"Fetched all {new_entities_count} entities")
 
         # Phase 2: Fetch new measurement results (already validated and grouped)

--- a/tests/samplestore/test_refresh.py
+++ b/tests/samplestore/test_refresh.py
@@ -362,3 +362,33 @@ def test_refresh_adds_measurements_to_existing_entities(
     # Verify measurements were added to existing entities
     refreshed_entities = store.entities
     assert all(len(e.measurement_results) == 1 for e in refreshed_entities)
+
+
+def test_entities_after_partial_cache_population(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+) -> None:
+    """Test that .entities returns all DB rows even when cache was partially populated.
+
+    Regression test for issue 733: if addEntities() had already populated
+    _entities with some rows, the old `if not self._entities:` guard would
+    skip the full DB load, returning only the cached subset.
+    """
+    store = random_sql_sample_store()
+
+    # Add both batches — addEntities writes to both the DB and _entities,
+    # but never sets _all_entities_loaded, so the flag stays False.
+    entities_batch1 = random_ml_multi_cloud_benchmark_performance_entities(3)
+    entities_batch2 = random_ml_multi_cloud_benchmark_performance_entities(2)
+    store.addEntities(entities=entities_batch1)
+    store.addEntities(entities=entities_batch2)
+
+    # Drop batch2 from the in-memory cache to simulate a partial-cache state
+    # (e.g. batch2 was added by another process that this instance never saw).
+    for entity in entities_batch2:
+        del store._entities[entity.identifier]
+
+    # .entities must trigger a full DB load and return all 5 rows
+    all_identifiers = {e.identifier for e in store.entities}
+    expected_identifiers = {e.identifier for e in entities_batch1 + entities_batch2}
+    assert all_identifiers == expected_identifiers


### PR DESCRIPTION
### Problem

`SQLSampleStore.entities` used `if not self._entities:` to decide whether a full DB load was needed. Since `addEntities()` writes to `_entities` without setting a "fully loaded" flag, any store that had already received entities via `addEntities()` would skip the full DB load and silently return only the cached subset — missing rows added by other processes or earlier batches.

Resolves #733 

### Solution

Replace the falsy-dict guard with an explicit boolean flag `_all_entities_loaded` (default `False`). The flag is only set to `True` after a successful full DB fetch inside `refresh(force_fetch_all_entities=True)`. The `entities` property now checks this flag instead of the dict's truthiness.

### Changes

| File | What changed |
|---|---|
| `ado/core/samplestore/sql.py` | Added `_all_entities_loaded = False` in `__init__`; `entities` property now guards on `not self._all_entities_loaded`; flag set to `True` after the initial full fetch in `refresh` |
| `tests/samplestore/test_refresh.py` | New regression test: simulates a partially-populated cache and asserts that `.entities` still returns all DB rows |