### PR TITLE
refactor(core): replace table-based space stats with entity-based calculations

### DIFF
--- a/ado/core/discoveryspace/stats.py
+++ b/ado/core/discoveryspace/stats.py
@@ -322,36 +322,31 @@ def space_statistics_for_spaces(
         number_matching = len(matching_entities)
 
         measurement_exp_refs = set(space.measurementSpace.experimentReferences)
+        experiments_in_measurement_space = len(space.measurementSpace.experiments)
         number_matching_with_measurements = sum(
             1
             for e in matching_entities
             if len(e.observedPropertyValues) > 0
             and not measurement_exp_refs.isdisjoint(set(e.experimentReferences))
         )
-
-        measured_entities_table = space.measuredEntitiesTable(property_type="target")
-        experiments_in_measurement_space = len(space.measurementSpace.experiments)
-        entities_with_all_measurements = 0
-        if (
-            not measured_entities_table.empty
-            and "identifier" in measured_entities_table
-        ):
-            for _, group in measured_entities_table.groupby("identifier"):
-                if group.shape[0] == experiments_in_measurement_space:
-                    entities_with_all_measurements += 1
-        entities_with_partial_measurements = (
-            number_measured - entities_with_all_measurements
+        matching_entities_with_all_measurements = sum(
+            1
+            for e in matching_entities
+            if len(measurement_exp_refs.intersection(e.experimentReferences))
+            == experiments_in_measurement_space
         )
 
-        matching_entities_table = space.matchingEntitiesTable(property_type="target")
-        matching_entities_with_all_measurements = 0
-        if (
-            not matching_entities_table.empty
-            and "identifier" in matching_entities_table
-        ):
-            for _, group in matching_entities_table.groupby("identifier"):
-                if group.shape[0] == experiments_in_measurement_space:
-                    matching_entities_with_all_measurements += 1
+        sampled_entities = space.sampledEntities()
+        sampled_entities_with_all_measurements = sum(
+            1
+            for e in sampled_entities
+            if len(e.observedPropertyValues) > 0
+            and len(measurement_exp_refs.intersection(e.experimentReferences))
+            == experiments_in_measurement_space
+        )
+        entities_with_partial_measurements = (
+            number_measured - sampled_entities_with_all_measurements
+        )
 
         result[space.uri] = DiscoverySpaceStatistics(
             number_of_experiments=base.number_of_experiments,
@@ -362,7 +357,7 @@ def space_statistics_for_spaces(
             number_unmeasured_entities=number_unmeasured,
             number_matching_entities=number_matching,
             number_matching_entities_with_measurements=number_matching_with_measurements,
-            entities_with_all_measurements=entities_with_all_measurements,
+            entities_with_all_measurements=sampled_entities_with_all_measurements,
             entities_with_partial_measurements=entities_with_partial_measurements,
             matching_entities_with_all_measurements=matching_entities_with_all_measurements,
         )


### PR DESCRIPTION
In `space_statistics_for_spaces`, the logic for computing measurement coverage stats no longer goes through pandas DataFrames produced by `measuredEntitiesTable` / `matchingEntitiesTable`. It now operates directly on entity objects returned by `sampledEntities()` and the already-available `matching_entities` list.

## What changed
- `entities_with_all_measurements` is now derived by iterating over `sampledEntities()` and counting entities whose experiment references cover the full measurement space, instead of building a DataFrame and grouping by `"identifier"`.
- `matching_entities_with_all_measurements` follows the same pattern, computed inline over `matching_entities`.
- Both table-building calls (`measuredEntitiesTable`, `matchingEntitiesTable`) are removed entirely.

## Why
Using the entity objects directly avoids the overhead of constructing intermediate DataFrames and removes the fragile `"identifier" in table` guard checks, making the logic simpler and easier to follow. Most importantly, it avoids these methods calling matching/measured entities inside them again.