### PR TITLE
perf(core): stop matching entities once discrete space is complete

### DIFF
--- a/ado/core/discoveryspace/space.py
+++ b/ado/core/discoveryspace/space.py
@@ -643,10 +643,18 @@ class DiscoverySpace:
 
         # Get all entities in the store
         all_entities = self.sample_store.entities
-        if self.entitySpace is not None:
-            entities = [e for e in all_entities if self.entitySpace.isEntityInSpace(e)]
-        else:
-            entities = all_entities
+        if self.entitySpace is None:
+            return all_entities
+
+        if not self.entitySpace.isDiscreteSpace:
+            return [e for e in all_entities if self.entitySpace.isEntityInSpace(e)]
+
+        entities = []
+        for entity in all_entities:
+            if self.entitySpace.isEntityInSpace(entity):
+                entities.append(entity)
+                if len(entities) == self.entitySpace.size:
+                    break
 
         return entities
 


### PR DESCRIPTION
In `DiscoverySpace.matchingEntities`, the entity-matching loop now short-circuits as soon as the required number of entities has been found, but only when the entity space is discrete (i.e. has a fixed, known `size`). For non-discrete spaces the existing full-scan behaviour is preserved. This avoids unnecessary iteration over the remaining entities in the sample store once the space is already satisfied.