### PR TITLE
feat(core): distinguish overlapping and disjoint space hierarchies

### DIFF
--- a/ado/cli/resources/discovery_space/get.py
+++ b/ado/cli/resources/discovery_space/get.py
@@ -235,7 +235,9 @@ def _find_spaces_matching_space(
         return result_df
 
     result_df = result_df[
-        result_df["RELATION_TO_INPUT_SPACE"] != SpaceHierarchy.UNDEFINED.value
+        ~result_df["RELATION_TO_INPUT_SPACE"].isin(
+            {SpaceHierarchy.UNDEFINED.value, SpaceHierarchy.DISJOINT.value}
+        )
     ]
     result_df = result_df.sort_values(by="AGE", ascending=False)
     result_df = result_df.reset_index(drop=True)

--- a/ado/core/discoveryspace/config.py
+++ b/ado/core/discoveryspace/config.py
@@ -18,6 +18,8 @@ class SpaceHierarchy(enum.Enum):
     SUB_SPACE = "subspace"
     SUPER_SPACE = "superspace"
     EQUAL_SPACE = "equal"
+    OVERLAPPING = "overlapping"
+    DISJOINT = "disjoint"
     UNDEFINED = "undefined"
 
 
@@ -221,9 +223,48 @@ class DiscoverySpaceConfiguration(pydantic.BaseModel):
 
         return True
 
+    def overlaps(self, other: "DiscoverySpaceConfiguration") -> bool:
+        """Returns True if the two spaces share at least one point.
+
+        Two spaces overlap when, for every property identifier present in
+        **both** spaces, the corresponding domains overlap.  If no property
+        identifiers are shared the spaces are considered disjoint.
+
+        Parameters:
+            other: The other DiscoverySpaceConfiguration to compare against
+        Returns:
+            True if the spaces overlap
+        """
+        self_property_domain_by_id = {
+            cp.identifier: cp.propertyDomain for cp in (self.entitySpace or [])
+        }
+        other_property_domain_by_id = {
+            cp.identifier: cp.propertyDomain for cp in (other.entitySpace or [])
+        }
+
+        shared_property_ids = set(self_property_domain_by_id).intersection(
+            other_property_domain_by_id
+        )
+        if not shared_property_ids:
+            return False
+
+        return all(
+            self_property_domain_by_id[property_id].overlaps(
+                other_property_domain_by_id[property_id]
+            )
+            for property_id in shared_property_ids
+        )
+
     def compare_space_hierarchy(
         self, reference_space: "DiscoverySpaceConfiguration"
     ) -> SpaceHierarchy:
+        """Compares the space hierarchy between self and reference_space.
+
+        Parameters:
+            reference_space: The reference DiscoverySpaceConfiguration
+        Returns:
+            A SpaceHierarchy enum value describing the relationship
+        """
         try:
             is_sub_space = self.is_sub_space(reference_space)
             is_super_space = reference_space.is_sub_space(self)
@@ -236,7 +277,11 @@ class DiscoverySpaceConfiguration(pydantic.BaseModel):
             return SpaceHierarchy.SUB_SPACE
         if is_super_space:
             return SpaceHierarchy.SUPER_SPACE
-        return SpaceHierarchy.UNDEFINED
+
+        # Neither is a sub-space — check for overlap
+        if self.overlaps(reference_space):
+            return SpaceHierarchy.OVERLAPPING
+        return SpaceHierarchy.DISJOINT
 
     def validate_entity_space_against_measurement_space(self) -> None:
         """Validates the entity space against the measurement space.

--- a/ado/schema/domain.py
+++ b/ado/schema/domain.py
@@ -262,6 +262,194 @@ def is_subdomain_of_open_categorical_domain(
     return testDomain.size != math.inf
 
 
+def overlaps_with_continuous_domain(
+    continuousDomain: "PropertyDomain", testDomain: "PropertyDomain"
+) -> bool:
+    """Returns True if testDomain shares at least one point with continuousDomain.
+
+    Parameters:
+        continuousDomain: A PropertyDomain with variableType CONTINUOUS_VARIABLE_TYPE
+        testDomain: A PropertyDomain with any variableType
+    Returns:
+        True if the domains overlap
+    """
+    match testDomain.variableType:
+        case (
+            VariableTypeEnum.UNKNOWN_VARIABLE_TYPE
+            | VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE
+        ):
+            return True
+        case VariableTypeEnum.CATEGORICAL_VARIABLE_TYPE:
+            return False
+        case VariableTypeEnum.CONTINUOUS_VARIABLE_TYPE:
+            if continuousDomain.domainRange is None or testDomain.domainRange is None:
+                return True
+            # [a, b) ∩ [c, d) != empty  iff  a < d and c < b
+            return min(continuousDomain.domainRange) < max(
+                testDomain.domainRange
+            ) and min(testDomain.domainRange) < max(continuousDomain.domainRange)
+        case VariableTypeEnum.DISCRETE_VARIABLE_TYPE:
+            if continuousDomain.domainRange is None:
+                return True
+            if testDomain.size == math.inf:
+                # Unbounded discrete overlaps any continuous
+                return True
+            # Check if at least one discrete value falls in [a, b)
+            return any(
+                min(continuousDomain.domainRange)
+                <= v
+                < max(continuousDomain.domainRange)
+                for v in testDomain.domain_values
+            )
+        case _:
+            # BINARY: check if 0 or 1 is within the continuous range
+            if continuousDomain.domainRange is None:
+                return True
+            return any(
+                min(continuousDomain.domainRange)
+                <= v
+                < max(continuousDomain.domainRange)
+                for v in [0, 1]
+            )
+
+
+def overlaps_with_discrete_domain(
+    discreteDomain: "PropertyDomain", testDomain: "PropertyDomain"
+) -> bool:
+    """Returns True if testDomain shares at least one point with discreteDomain.
+
+    Parameters:
+        discreteDomain: A PropertyDomain with variableType DISCRETE_VARIABLE_TYPE
+        testDomain: A PropertyDomain with any variableType
+    Returns:
+        True if the domains overlap
+    """
+    match testDomain.variableType:
+        case (
+            VariableTypeEnum.UNKNOWN_VARIABLE_TYPE
+            | VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE
+        ):
+            return True
+        case VariableTypeEnum.CONTINUOUS_VARIABLE_TYPE:
+            return overlaps_with_continuous_domain(
+                continuousDomain=testDomain, testDomain=discreteDomain
+            )
+        case VariableTypeEnum.DISCRETE_VARIABLE_TYPE:
+            if discreteDomain.size == math.inf or testDomain.size == math.inf:
+                # Unbounded discrete domains overlap
+                return True
+            return (
+                set(discreteDomain.domain_values).isdisjoint(testDomain.domain_values)
+                is False
+            )
+        case VariableTypeEnum.CATEGORICAL_VARIABLE_TYPE:
+            if discreteDomain.size == math.inf:
+                return True
+            return (
+                set(discreteDomain.domain_values).isdisjoint(testDomain.domain_values)
+                is False
+            )
+        case _:
+            # BINARY: check if 0 or 1 is in the discrete domain
+            if discreteDomain.size == math.inf:
+                return True
+            return any(v in discreteDomain.domain_values for v in [0, 1])
+
+
+def overlaps_with_categorical_domain(
+    categoricalDomain: "PropertyDomain", testDomain: "PropertyDomain"
+) -> bool:
+    """Returns True if testDomain shares at least one point with categoricalDomain.
+
+    Parameters:
+        categoricalDomain: A PropertyDomain with variableType CATEGORICAL_VARIABLE_TYPE
+        testDomain: A PropertyDomain with any variableType
+    Returns:
+        True if the domains overlap
+    """
+    match testDomain.variableType:
+        case (
+            VariableTypeEnum.UNKNOWN_VARIABLE_TYPE
+            | VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE
+        ):
+            return True
+        case VariableTypeEnum.CONTINUOUS_VARIABLE_TYPE:
+            return False
+        case VariableTypeEnum.CATEGORICAL_VARIABLE_TYPE:
+            return set(categoricalDomain.values).isdisjoint(testDomain.values) is False
+        case VariableTypeEnum.DISCRETE_VARIABLE_TYPE:
+            if testDomain.size == math.inf:
+                return True
+            return (
+                set(categoricalDomain.domain_values).isdisjoint(
+                    testDomain.domain_values
+                )
+                is False
+            )
+        case _:
+            # BINARY: check if 0 or 1 appears in the categorical values
+            return any(v in categoricalDomain.domain_values for v in [0, 1])
+
+
+def overlaps_with_binary_domain(
+    binaryDomain: "PropertyDomain", testDomain: "PropertyDomain"
+) -> bool:
+    """Returns True if testDomain shares at least one point with binaryDomain.
+
+    Parameters:
+        binaryDomain: A PropertyDomain with variableType BINARY_VARIABLE_TYPE
+        testDomain: A PropertyDomain with any variableType
+    Returns:
+        True if the domains overlap
+    """
+    match testDomain.variableType:
+        case (
+            VariableTypeEnum.UNKNOWN_VARIABLE_TYPE
+            | VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE
+            | VariableTypeEnum.BINARY_VARIABLE_TYPE
+        ):
+            return True
+        case VariableTypeEnum.CONTINUOUS_VARIABLE_TYPE:
+            return overlaps_with_continuous_domain(
+                continuousDomain=testDomain, testDomain=binaryDomain
+            )
+        case VariableTypeEnum.DISCRETE_VARIABLE_TYPE:
+            if testDomain.size == math.inf:
+                return True
+            return any(v in testDomain.domain_values for v in [0, 1])
+        case _:
+            # CATEGORICAL
+            return any(v in testDomain.domain_values for v in [0, 1])
+
+
+def overlaps_with_unknown_domain(
+    unknownDomain: "PropertyDomain", testDomain: "PropertyDomain"
+) -> bool:
+    """Returns True always — UNKNOWN domains overlap with any domain.
+
+    Parameters:
+        unknownDomain: A PropertyDomain with variableType UNKNOWN_VARIABLE_TYPE
+        testDomain: A PropertyDomain with any variableType
+    Returns:
+        True
+    """
+    return True
+
+
+def overlaps_with_open_categorical_domain(
+    openCategoricalDomain: "PropertyDomain", testDomain: "PropertyDomain"
+) -> bool:
+    """Returns True always — OPEN_CATEGORICAL domains overlap with any domain.
+
+    Parameters:
+        openCategoricalDomain: A PropertyDomain with variableType OPEN_CATEGORICAL_VARIABLE_TYPE
+        testDomain: A PropertyDomain with any variableType
+    Returns:
+        True
+    """
+    return True
+
+
 class ProbabilityFunction(pydantic.BaseModel):
     identifier: Annotated[ProbabilityFunctionsEnum, pydantic.Field()] = (
         ProbabilityFunctionsEnum.UNIFORM
@@ -706,6 +894,34 @@ class PropertyDomain(pydantic.BaseModel):
             )
         # fallback to previous logic if unknown type
         raise ValueError(f"Internal error: Unknown variable type {self.variableType}")
+
+    def overlaps(self, other: "PropertyDomain") -> bool:
+        """Returns True if self and other share at least one point.
+
+        Parameters:
+            other: A PropertyDomain to compare against
+        Returns:
+            True if the domains overlap (i.e. share at least one value)
+        """
+        if other.variableType == VariableTypeEnum.UNKNOWN_VARIABLE_TYPE:
+            return overlaps_with_unknown_domain(unknownDomain=other, testDomain=self)
+        if other.variableType == VariableTypeEnum.CONTINUOUS_VARIABLE_TYPE:
+            return overlaps_with_continuous_domain(
+                continuousDomain=other, testDomain=self
+            )
+        if other.variableType == VariableTypeEnum.DISCRETE_VARIABLE_TYPE:
+            return overlaps_with_discrete_domain(discreteDomain=other, testDomain=self)
+        if other.variableType == VariableTypeEnum.CATEGORICAL_VARIABLE_TYPE:
+            return overlaps_with_categorical_domain(
+                categoricalDomain=other, testDomain=self
+            )
+        if other.variableType == VariableTypeEnum.BINARY_VARIABLE_TYPE:
+            return overlaps_with_binary_domain(binaryDomain=other, testDomain=self)
+        if other.variableType == VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE:
+            return overlaps_with_open_categorical_domain(
+                openCategoricalDomain=other, testDomain=self
+            )
+        raise ValueError(f"Internal error: Unknown variable type {other.variableType}")
 
     @property
     def size(self) -> float | int:

--- a/tests/core/test_compare_space_hierarchy.py
+++ b/tests/core/test_compare_space_hierarchy.py
@@ -1,0 +1,157 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+"""Tests for DiscoverySpaceConfiguration.compare_space_hierarchy()
+
+Covers all six SpaceHierarchy return values:
+  EQUAL_SPACE, SUB_SPACE, SUPER_SPACE, OVERLAPPING, DISJOINT, UNDEFINED
+"""
+
+from collections.abc import Callable
+
+from ado.core.discoveryspace.config import DiscoverySpaceConfiguration, SpaceHierarchy
+from ado.schema.domain import PropertyDomain
+
+
+def test_equal_space(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Identical entity spaces → EQUAL_SPACE."""
+    space = make_continuous_space_configuration([0, 10])
+    assert space.compare_space_hierarchy(space) == SpaceHierarchy.EQUAL_SPACE
+
+
+def test_sub_space(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Strictly smaller space → SUB_SPACE."""
+    large = make_continuous_space_configuration([0, 10])
+    small = make_continuous_space_configuration([2, 8])
+    assert small.compare_space_hierarchy(large) == SpaceHierarchy.SUB_SPACE
+    assert large.compare_space_hierarchy(small) == SpaceHierarchy.SUPER_SPACE
+
+
+def test_super_space(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Strictly larger space → SUPER_SPACE."""
+    large = make_continuous_space_configuration([0, 20])
+    small = make_continuous_space_configuration([5, 15])
+    assert large.compare_space_hierarchy(small) == SpaceHierarchy.SUPER_SPACE
+    assert small.compare_space_hierarchy(large) == SpaceHierarchy.SUB_SPACE
+
+
+def test_overlapping_space(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Domains that intersect but neither contains the other → OVERLAPPING."""
+    space_a = make_continuous_space_configuration([0, 10])
+    space_b = make_continuous_space_configuration([5, 15])
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.OVERLAPPING
+    assert space_b.compare_space_hierarchy(space_a) == SpaceHierarchy.OVERLAPPING
+
+
+def test_disjoint_space(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Domains that share no points → DISJOINT."""
+    space_a = make_continuous_space_configuration([0, 5])
+    space_b = make_continuous_space_configuration([10, 20])
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.DISJOINT
+    assert space_b.compare_space_hierarchy(space_a) == SpaceHierarchy.DISJOINT
+
+
+def test_disjoint_space_no_shared_properties(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Spaces with completely different property identifiers → DISJOINT."""
+    space_a = make_continuous_space_configuration([0, 10], identifier="x")
+    space_b = make_continuous_space_configuration([0, 10], identifier="y")
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.DISJOINT
+    assert space_b.compare_space_hierarchy(space_a) == SpaceHierarchy.DISJOINT
+
+
+def test_undefined_when_entity_space_empty(
+    space_configuration_none_entity_space: DiscoverySpaceConfiguration,
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Empty entity spaces → UNDEFINED (exception path)."""
+    space = make_continuous_space_configuration([0, 10])
+    assert (
+        space_configuration_none_entity_space.compare_space_hierarchy(space)
+        == SpaceHierarchy.UNDEFINED
+    )
+    assert (
+        space.compare_space_hierarchy(space_configuration_none_entity_space)
+        == SpaceHierarchy.UNDEFINED
+    )
+
+
+def test_overlapping_multiple_properties(
+    make_multi_prop_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Overlapping result with multiple properties (all shared props must overlap)."""
+    space_a = make_multi_prop_space_configuration(
+        [
+            ("x", PropertyDomain(domainRange=[0, 10])),
+            ("y", PropertyDomain(values=["A", "B"])),
+        ]
+    )
+    space_b = make_multi_prop_space_configuration(
+        [
+            ("x", PropertyDomain(domainRange=[5, 15])),
+            ("y", PropertyDomain(values=["B", "C"])),
+        ]
+    )
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.OVERLAPPING
+
+
+def test_disjoint_when_one_shared_property_is_disjoint(
+    make_multi_prop_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """DISJOINT when at least one shared property domain is disjoint."""
+    space_a = make_multi_prop_space_configuration(
+        [
+            ("x", PropertyDomain(domainRange=[0, 5])),
+            ("y", PropertyDomain(values=["A", "B"])),
+        ]
+    )
+    space_b = make_multi_prop_space_configuration(
+        [
+            ("x", PropertyDomain(domainRange=[10, 20])),
+            ("y", PropertyDomain(values=["B", "C"])),
+        ]
+    )
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.DISJOINT
+
+
+def test_overlapping_discrete_domains(
+    make_discrete_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Overlapping with discrete domains sharing a value."""
+    space_a = make_discrete_space_configuration([1, 2, 3])
+    space_b = make_discrete_space_configuration([3, 4, 5])
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.OVERLAPPING
+
+
+def test_disjoint_discrete_domains(
+    make_discrete_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """DISJOINT with non-intersecting discrete domains."""
+    space_a = make_discrete_space_configuration([1, 2])
+    space_b = make_discrete_space_configuration([3, 4])
+    assert space_a.compare_space_hierarchy(space_b) == SpaceHierarchy.DISJOINT
+
+
+def test_sub_space_with_extra_property(
+    make_continuous_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+    make_multi_prop_space_configuration: Callable[..., DiscoverySpaceConfiguration],
+) -> None:
+    """Space with fewer properties than reference is a sub-space when contained."""
+    reference = make_multi_prop_space_configuration(
+        [
+            ("x", PropertyDomain(domainRange=[0, 10])),
+            ("y", PropertyDomain(values=["A", "B"])),
+        ]
+    )
+    sub = make_continuous_space_configuration([2, 8])
+    assert sub.compare_space_hierarchy(reference) == SpaceHierarchy.SUB_SPACE

--- a/tests/fixtures/core/space.py
+++ b/tests/fixtures/core/space.py
@@ -5,6 +5,7 @@
 import json
 import pathlib
 from collections.abc import Callable
+from typing import Any
 
 import pytest
 import yaml
@@ -15,6 +16,8 @@ from ado.core.discoveryspace.config import (
 )
 from ado.core.discoveryspace.resource import DiscoverySpaceResource
 from ado.metastore.sqlstore import SQLStore
+from ado.schema.domain import PropertyDomain
+from ado.schema.property import ConstitutiveProperty
 
 
 @pytest.fixture
@@ -148,3 +151,94 @@ def discovery_space_resource_from_file() -> DiscoverySpaceResource:
         conf = DiscoverySpaceConfiguration(**yaml.safe_load(f))
 
     return DiscoverySpaceResource(config=conf)
+
+
+@pytest.fixture
+def make_continuous_space_configuration() -> Callable[
+    [list[float], str], DiscoverySpaceConfiguration
+]:
+    """Factory: build a DiscoverySpaceConfiguration with a single continuous property over a given domainRange.
+
+    Usage::
+
+        def test_foo(make_continuous_space_configuration):
+            config = make_continuous_space_configuration([0, 10])
+    """
+
+    def _make(
+        domain_range: list[float],
+        identifier: str = "x",
+    ) -> DiscoverySpaceConfiguration:
+        return DiscoverySpaceConfiguration(
+            entitySpace=[
+                ConstitutiveProperty(
+                    identifier=identifier,
+                    propertyDomain=PropertyDomain(domainRange=domain_range),
+                )
+            ]
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_discrete_space_configuration() -> Callable[
+    [list[Any], str], DiscoverySpaceConfiguration
+]:
+    """Factory: build a DiscoverySpaceConfiguration with a single discrete property over a given set of values.
+
+    Usage::
+
+        def test_foo(make_discrete_space_configuration):
+            config = make_discrete_space_configuration([1, 2, 3])
+    """
+
+    def _make(
+        values: list[Any],
+        identifier: str = "n",
+    ) -> DiscoverySpaceConfiguration:
+        return DiscoverySpaceConfiguration(
+            entitySpace=[
+                ConstitutiveProperty(
+                    identifier=identifier,
+                    propertyDomain=PropertyDomain(values=values),
+                )
+            ]
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_multi_prop_space_configuration() -> Callable[
+    [list[tuple[str, PropertyDomain]]],
+    DiscoverySpaceConfiguration,
+]:
+    """Factory: build a DiscoverySpaceConfiguration from an explicit list of (identifier, PropertyDomain) pairs.
+
+    Usage::
+
+        def test_foo(make_multi_prop_space_configuration):
+            config = make_multi_prop_space_configuration([
+                ("x", PropertyDomain(domainRange=[0, 10])),
+                ("y", PropertyDomain(values=["A", "B"])),
+            ])
+    """
+
+    def _make(
+        properties: list[tuple[str, PropertyDomain]],
+    ) -> DiscoverySpaceConfiguration:
+        return DiscoverySpaceConfiguration(
+            entitySpace=[
+                ConstitutiveProperty(identifier=ident, propertyDomain=domain)
+                for ident, domain in properties
+            ]
+        )
+
+    return _make
+
+
+@pytest.fixture
+def space_configuration_none_entity_space() -> DiscoverySpaceConfiguration:
+    """DiscoverySpaceConfiguration with no entity space defined."""
+    return DiscoverySpaceConfiguration(entitySpace=None)

--- a/tests/schema/test_domain.py
+++ b/tests/schema/test_domain.py
@@ -1087,3 +1087,188 @@ def test_binary_variable_type_error_message_suggests_discrete() -> None:
         PropertyDomain(
             variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE, values=[True]
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for PropertyDomain.overlaps()
+# ---------------------------------------------------------------------------
+
+
+def test_overlaps_continuous_with_continuous() -> None:
+    """overlaps() between two continuous domains"""
+    d1 = PropertyDomain(domainRange=[0, 10])
+    d2 = PropertyDomain(domainRange=[5, 15])
+    d3 = PropertyDomain(domainRange=[10, 20])  # shares no point with d1 ([0,10))
+    unbounded = PropertyDomain(variableType=VariableTypeEnum.CONTINUOUS_VARIABLE_TYPE)
+
+    assert d1.overlaps(d2), "overlapping ranges should overlap (d1→d2)"
+    assert d2.overlaps(d1), "overlapping ranges should overlap (d2→d1)"
+    assert not d1.overlaps(d3), "[0,10) ∩ [10,20) should be empty"
+    assert not d3.overlaps(d1), "[10,20) ∩ [0,10) should be empty"
+    assert d1.overlaps(unbounded), "bounded overlaps unbounded"
+    assert unbounded.overlaps(d1), "unbounded overlaps bounded"
+
+
+def test_overlaps_continuous_with_discrete() -> None:
+    """overlaps() between continuous and discrete domains"""
+    cont = PropertyDomain(domainRange=[0, 10])
+    disc_inside = PropertyDomain(values=[2, 4, 6])
+    disc_outside = PropertyDomain(values=[10, 12])  # 10 is excluded from [0,10)
+    disc_unbounded = PropertyDomain(
+        variableType=VariableTypeEnum.DISCRETE_VARIABLE_TYPE, interval=1
+    )
+
+    assert cont.overlaps(disc_inside)
+    assert disc_inside.overlaps(cont)
+    assert not cont.overlaps(disc_outside)
+    assert not disc_outside.overlaps(cont)
+    assert cont.overlaps(disc_unbounded)
+    assert disc_unbounded.overlaps(cont)
+
+
+def test_overlaps_continuous_with_binary() -> None:
+    """overlaps() between continuous and binary domains"""
+    binary = PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE)
+    cont_contains_binary = PropertyDomain(domainRange=[-1, 2])  # contains 0 and 1
+    cont_missing_one = PropertyDomain(domainRange=[0, 1])  # 0 in, 1 excluded
+    cont_no_binary = PropertyDomain(domainRange=[-5, -1])
+
+    assert cont_contains_binary.overlaps(binary)
+    assert binary.overlaps(cont_contains_binary)
+    assert cont_missing_one.overlaps(binary), "0 is in [0,1)"
+    assert not cont_no_binary.overlaps(binary)
+
+
+def test_overlaps_continuous_with_categorical() -> None:
+    """Continuous and categorical domains never overlap"""
+    cont = PropertyDomain(domainRange=[0, 10])
+    cat = PropertyDomain(values=["A", "B"])
+    assert not cont.overlaps(cat)
+    assert not cat.overlaps(cont)
+
+
+def test_overlaps_continuous_with_unknown_and_open_cat() -> None:
+    """UNKNOWN and OPEN_CATEGORICAL always overlap continuous"""
+    cont = PropertyDomain(domainRange=[0, 10])
+    unknown = PropertyDomain(variableType=VariableTypeEnum.UNKNOWN_VARIABLE_TYPE)
+    open_cat = PropertyDomain(
+        variableType=VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE
+    )
+
+    assert cont.overlaps(unknown)
+    assert unknown.overlaps(cont)
+    assert cont.overlaps(open_cat)
+    assert open_cat.overlaps(cont)
+
+
+def test_overlaps_discrete_with_discrete() -> None:
+    """overlaps() between two discrete domains"""
+    d1 = PropertyDomain(values=[1, 2, 3])
+    d2 = PropertyDomain(values=[3, 4, 5])  # shares 3
+    d3 = PropertyDomain(values=[4, 5, 6])  # no intersection with d1
+    unbounded1 = PropertyDomain(
+        variableType=VariableTypeEnum.DISCRETE_VARIABLE_TYPE, interval=1
+    )
+    unbounded2 = PropertyDomain(
+        variableType=VariableTypeEnum.DISCRETE_VARIABLE_TYPE, interval=2
+    )
+
+    assert d1.overlaps(d2), "shared value 3 → overlap (d1→d2)"
+    assert d2.overlaps(d1), "shared value 3 → overlap (d2→d1)"
+    assert not d1.overlaps(d3)
+    assert not d3.overlaps(d1)
+    assert unbounded1.overlaps(unbounded2), "unbounded discrete domains overlap"
+    assert unbounded1.overlaps(d1), "unbounded discrete overlaps bounded"
+
+
+def test_overlaps_discrete_with_categorical() -> None:
+    """overlaps() between discrete and categorical domains"""
+    disc = PropertyDomain(values=[1, 2, 3])
+    cat_shared = PropertyDomain(values=[3, "X"])  # 3 is shared
+    cat_no_shared = PropertyDomain(values=["X", "Y"])
+
+    assert disc.overlaps(cat_shared)
+    assert cat_shared.overlaps(disc)
+    assert not disc.overlaps(cat_no_shared)
+    assert not cat_no_shared.overlaps(disc)
+
+
+def test_overlaps_discrete_with_binary() -> None:
+    """overlaps() between discrete and binary domains"""
+    binary = PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE)
+    disc_with_zero = PropertyDomain(values=[0, 5])
+    disc_with_one = PropertyDomain(values=[1, 5])
+    disc_no_binary = PropertyDomain(values=[2, 3])
+
+    assert disc_with_zero.overlaps(binary)
+    assert binary.overlaps(disc_with_zero)
+    assert disc_with_one.overlaps(binary)
+    assert binary.overlaps(disc_with_one)
+    assert not disc_no_binary.overlaps(binary)
+    assert not binary.overlaps(disc_no_binary)
+
+
+def test_overlaps_categorical_with_categorical() -> None:
+    """overlaps() between two categorical domains"""
+    c1 = PropertyDomain(values=["A", "B", "C"])
+    c2 = PropertyDomain(values=["C", "D"])  # shares C
+    c3 = PropertyDomain(values=["D", "E"])  # no intersection
+
+    assert c1.overlaps(c2)
+    assert c2.overlaps(c1)
+    assert not c1.overlaps(c3)
+    assert not c3.overlaps(c1)
+
+
+def test_overlaps_categorical_with_binary() -> None:
+    """overlaps() between categorical and binary domains"""
+    binary = PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE)
+    cat_has_zero = PropertyDomain(values=[0, "X"])
+    cat_no_binary = PropertyDomain(values=["X", "Y"])
+
+    assert cat_has_zero.overlaps(binary)
+    assert binary.overlaps(cat_has_zero)
+    assert not cat_no_binary.overlaps(binary)
+    assert not binary.overlaps(cat_no_binary)
+
+
+def test_overlaps_binary_with_binary() -> None:
+    """Two binary domains always overlap (both are {0,1})"""
+    b1 = PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE)
+    b2 = PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE)
+    assert b1.overlaps(b2)
+    assert b2.overlaps(b1)
+
+
+def test_overlaps_unknown_always_true() -> None:
+    """UNKNOWN domains overlap with everything"""
+    unknown = PropertyDomain(variableType=VariableTypeEnum.UNKNOWN_VARIABLE_TYPE)
+    others = [
+        PropertyDomain(domainRange=[0, 10]),
+        PropertyDomain(values=[1, 2, 3]),
+        PropertyDomain(values=["A", "B"]),
+        PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE),
+        PropertyDomain(variableType=VariableTypeEnum.UNKNOWN_VARIABLE_TYPE),
+        PropertyDomain(variableType=VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE),
+    ]
+    for other in others:
+        assert unknown.overlaps(other), f"UNKNOWN should overlap {other.variableType}"
+        assert other.overlaps(unknown), f"{other.variableType} should overlap UNKNOWN"
+
+
+def test_overlaps_open_categorical_always_true() -> None:
+    """OPEN_CATEGORICAL domains overlap with everything"""
+    open_cat = PropertyDomain(
+        variableType=VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE
+    )
+    others = [
+        PropertyDomain(domainRange=[0, 10]),
+        PropertyDomain(values=[1, 2, 3]),
+        PropertyDomain(values=["A", "B"]),
+        PropertyDomain(variableType=VariableTypeEnum.BINARY_VARIABLE_TYPE),
+        PropertyDomain(variableType=VariableTypeEnum.UNKNOWN_VARIABLE_TYPE),
+        PropertyDomain(variableType=VariableTypeEnum.OPEN_CATEGORICAL_VARIABLE_TYPE),
+    ]
+    for other in others:
+        assert open_cat.overlaps(other), f"OPEN_CAT should overlap {other.variableType}"
+        assert other.overlaps(open_cat), f"{other.variableType} should overlap OPEN_CAT"


### PR DESCRIPTION
## Distinguish overlapping and disjoint space hierarchies

Two discovery spaces that are neither sub- nor superspaces of each other were previously both labelled `UNDEFINED`. This PR replaces that catch-all with `OVERLAPPING` (the spaces share at least one point) and `DISJOINT` (they share none). The domain-level overlap logic is implemented across all variable type combinations, and the CLI space-matching filter is updated to exclude disjoint spaces alongside undefined ones.