### PR TITLE
fix(ordered-pip): reuse existing event loop when recreating garbage-collected ray runtime environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           - --no-color
           - --verbose
           - --scopes
-          - anomalous-series,autoconf,changelog,ci,cli,container,contributing,core,cplex-mip,deps,docs,example-actuator,hooks,profile-space,ray-tune,sfttrainer,test,trim,vllm-performance,website
+          - anomalous-series,autoconf,changelog,ci,cli,container,contributing,core,cplex-mip,deps,docs,example-actuator,hooks,profile-space,ray-tune,sfttrainer,test,trim,vllm-performance,website,ordered-pip
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:

--- a/ado/utilities/ray_env/ordered_pip.py
+++ b/ado/utilities/ray_env/ordered_pip.py
@@ -344,13 +344,24 @@ class OrderedPipPlugin(RuntimeEnvPlugin):
             logger.warning(
                 f"The pip environment at {env_dir} has been garbage collected - recreating it"
             )
+
             import asyncio
 
-            asyncio.run(
+            from ray._common.utils import get_or_create_event_loop
+
+            # modify_context is synchronous but may be called from inside
+            # Ray's async runtime-env agent which already has a running event
+            # loop. asyncio.run() raises RuntimeError in that case, so
+            # schedule the coroutine on the existing (or newly created) loop
+            # and block the calling thread until it completes.
+            loop = get_or_create_event_loop()
+            future = asyncio.run_coroutine_threadsafe(
                 self.create(
                     uris[0], runtime_env=runtime_env, context=context, logger=logger
-                )
+                ),
+                loop,
             )
+            future.result()
 
         self._pip_plugin.modify_context(
             uris=uris,


### PR DESCRIPTION
Fixes #1255 