### PR TITLE
feat(core): support per-operation grouping when querying entity identifiers

### DIFF
--- a/ado/core/discoveryspace/space.py
+++ b/ado/core/discoveryspace/space.py
@@ -1061,11 +1061,27 @@ class DiscoverySpace:
 
     @_perform_preflight_checks_for_sample_store_methods
     def entity_identifiers_in_operations(
-        self, operation_ids: str | set[str]
-    ) -> set[str]:
-        """Return entity identifiers sampled in the given operation(s)."""
+        self,
+        operation_ids: str | set[str],
+        group_by_operation: bool = False,
+    ) -> set[str] | dict[str, set[str]]:
+        """Return entity identifiers sampled in the given operation(s).
+
+        Args:
+            operation_ids: A single operation identifier or a set of operation
+                identifiers to look up entity identifiers for.
+            group_by_operation: When True, return a dict mapping each operation
+                ID to its set of entity identifiers. When False (default),
+                return a flat set of entity identifiers across all operations.
+
+        Returns:
+            A flat set of entity identifier strings when group_by_operation is
+            False, or a dict mapping operation ID to set of entity identifiers
+            when group_by_operation is True.
+        """
         return self.sample_store.entity_identifiers_in_operations(
-            operation_ids=operation_ids
+            operation_ids=operation_ids,
+            group_by_operation=group_by_operation,
         )
 
     @_perform_preflight_checks_for_sample_store_methods

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -2067,43 +2067,66 @@ class SQLSampleStore(ActiveSampleStore):
         ]
 
     def entity_identifiers_in_operations(
-        self, operation_ids: str | set[str]
-    ) -> set[str]:
+        self,
+        operation_ids: str | set[str],
+        group_by_operation: bool = False,
+    ) -> set[str] | dict[str, set[str]]:
         """Get the set of entity identifiers sampled in one or more operations.
 
         Args:
             operation_ids: A single operation identifier or a set of operation
                 identifiers to look up entity identifiers for.
+            group_by_operation: When True, return a dict mapping each operation
+                ID to its set of entity identifiers. When False (default),
+                return a flat set of entity identifiers across all operations.
 
         Returns:
-            Set of entity identifier strings across all specified operations.
+            A flat set of entity identifier strings when group_by_operation is
+            False, or a dict mapping operation ID to set of entity identifiers
+            when group_by_operation is True.
         """
         if isinstance(operation_ids, str):
             operation_ids = {operation_ids}
 
         try:
-            with self.engine.begin() as connectable:
-                query = sqlalchemy.text(f"""
-                    SELECT DISTINCT(res.entity_id)
-                    FROM (
-                        SELECT *
-                        FROM {self._tablename}_measurement_requests
-                        WHERE operation_id IN :operation_ids
-                    ) req
-                    JOIN {self._tablename}_measurement_requests_results reqres ON reqres.request_uid = req.uid
-                    JOIN {self._tablename}_measurement_results res ON reqres.result_uid = res.uid
-                    """).bindparams(  # noqa: S608 - self._tablename is not untrusted
-                    sqlalchemy.bindparam(
-                        "operation_ids", value=list(operation_ids), expanding=True
-                    )
+            from sqlalchemy import select
+
+            req_table = self._request_table
+            reqres_table = self._request_result_table
+            res_table = self._result_table
+
+            stmt = (
+                select(
+                    req_table.c.operation_id,
+                    res_table.c.entity_id,
                 )
-                cur = connectable.execute(query)
+                .select_from(req_table)
+                .join(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
+                .join(res_table, reqres_table.c.result_uid == res_table.c.uid)
+                .where(req_table.c.operation_id.in_(operation_ids))
+                .distinct()
+            )
+
+            with self.engine.begin() as connectable:
+                rows = connectable.execute(stmt).fetchall()
         except SQLAlchemyError as error:
             msg = f"Unable to get the entity ids for operations {operation_ids}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 
-        return {ident[0] for ident in cur}
+        entity_ids_by_operation_id: dict[str, set[str]] = {}
+        for row in rows:
+            entity_ids_by_operation_id.setdefault(row.operation_id, set()).add(
+                row.entity_id
+            )
+
+        if group_by_operation:
+            return entity_ids_by_operation_id
+        return {
+            entity_id
+            for ids in entity_ids_by_operation_id.values()
+            for entity_id in ids
+        }
 
     def entity_identifiers_in_operation(
         self, operation_ids: str | set[str]

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -588,6 +588,56 @@ def test_entity_identifiers_in_operations(
     assert len(entity_ids.intersection(retrieved_entity_ids)) == len(entity_ids)
 
 
+def test_entity_identifiers_in_operations_grouped(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    number_entities = 3
+    number_requests = 3
+    measurements_per_result = 2
+    operation_id_1 = random_identifier()
+    operation_id_2 = random_identifier()
+
+    sample_store, requests_1, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_1,
+    )
+    _, requests_2, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=number_requests,
+        measurements_per_result=measurements_per_result,
+        operation_id=operation_id_2,
+    )
+
+    # Two-operation grouped result.
+    result = sample_store.entity_identifiers_in_operations(
+        operation_ids={operation_id_1, operation_id_2},
+        group_by_operation=True,
+    )
+
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {operation_id_1, operation_id_2}
+
+    expected_ids_1 = {e.identifier for r in requests_1 for e in r.entities}
+    expected_ids_2 = {e.identifier for r in requests_2 for e in r.entities}
+    assert result[operation_id_1] == expected_ids_1
+    assert result[operation_id_2] == expected_ids_2
+
+    # Single-string operation ID with group_by_operation=True returns a single-key dict.
+    single_result = sample_store.entity_identifiers_in_operations(
+        operation_ids=operation_id_1,
+        group_by_operation=True,
+    )
+    assert isinstance(single_result, dict)
+    assert set(single_result.keys()) == {operation_id_1}
+    assert single_result[operation_id_1] == expected_ids_1
+
+
 def test_entity_identifiers_in_sample_store(
     ml_multi_cloud_sample_store: SQLSampleStore,
 ) -> None:


### PR DESCRIPTION
## Add `group_by_operation` flag to entity identifier queries

Adds an optional `group_by_operation: bool = False` parameter to `SQLSampleStore.entity_identifiers_in_operations` and `DiscoverySpace.entity_identifiers_in_operations`.

When `False` (default), behaviour is unchanged — a flat `set[str]` of entity IDs is returned across all specified operations. When `True`, a `dict[str, set[str]]` is returned mapping each operation ID to its own set of entity identifiers.

The SQL query is also refactored from a raw `sqlalchemy.text` call to a type-safe SQLAlchemy Core `select` statement, and the result-processing loop now drives both return modes from a single pass over the rows. A new test (`test_entity_identifiers_in_operations_grouped`) covers the grouped path for multiple operations and for a single string operation ID.