### PR TITLE
fix(ray-tune): handle sparse mutual information

### DIFF
--- a/plugins/operators/ray_tune/ado_ray_tune/space_analysis.py
+++ b/plugins/operators/ray_tune/ado_ray_tune/space_analysis.py
@@ -147,6 +147,11 @@ def mi_pareto_selection(
             "above_threshold",
         ],
     )
+    if len(l1) < 2:
+        if return_all_above_threshold:
+            return [], pareto_pd
+        return []
+
     rid = 0
     mi_threshold = np.sum(l1) * min_mi_threshold
     below_threshold_since = 0

--- a/plugins/operators/ray_tune/tests/test_space_analysis.py
+++ b/plugins/operators/ray_tune/tests/test_space_analysis.py
@@ -1,0 +1,18 @@
+# Copyright IBM Corporation 2026
+# SPDX-License-Identifier: MIT
+
+import pytest
+from ado_ray_tune.space_analysis import mi_pareto_selection
+
+
+@pytest.mark.parametrize(
+    "mutual_information",
+    [
+        {"provider": 0.0, "cpu_family": 0.0},
+        {"provider": 0.0, "nodes": 0.454},
+    ],
+)
+def test_mi_pareto_selection_with_fewer_than_two_significant_dimensions(
+    mutual_information: dict[str, float],
+) -> None:
+    assert mi_pareto_selection(mutual_information) == []  # noqa: S101


### PR DESCRIPTION
Closes #1253

Returns an empty Pareto selection when fewer than two dimensions exceed the mutual-information threshold, avoiding the empty object-typed DataFrame passed to `paretoset`.

Tests cover zero and one significant dimension, including the reported `nodes: 0.454` case.
