### PR TITLE
feat(core): separate entity fetching from measurement result loading 

### DIFF
--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -73,6 +73,30 @@ class SampleStore(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def get_entities(
+        self,
+        identifiers: str | set[str] | None = None,
+        require_measurements: bool = False,
+        refresh: bool = False,
+    ) -> list[Entity]:  # pragma: nocover
+        """Retrieve entities from the store.
+
+        Args:
+            identifiers: Which entities to return.
+                - ``None`` (default): all entities.
+                - ``str``: a single entity identifier.
+                - ``set[str]``: an explicit subset of entity identifiers.
+            require_measurements: When ``True``, measurement results are
+                fetched and attached to every returned entity.
+                Defaults to ``False``.
+            refresh: When ``True``, cached data is evicted before fetching.
+                Defaults to ``False``.
+
+        Returns:
+            List of ``Entity`` objects.
+        """
+
+    @abc.abstractmethod
     def containsEntityWithIdentifier(self, entity_id: str) -> bool:  # pragma: nocover
         pass
 

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -19,7 +19,7 @@ from ado.schema.experiment import Experiment
 from ado.schema.property import (
     ConstitutivePropertyDescriptor,
 )
-from ado.schema.property_value import PropertyValue
+from ado.schema.property_value import ConstitutivePropertyValue
 from ado.schema.request import MeasurementRequest
 
 if typing.TYPE_CHECKING:
@@ -101,41 +101,61 @@ class SampleStore(abc.ABC):
         pass
 
     def entitiesWithConstitutivePropertyValues(
-        self, values: list[PropertyValue]
+        self, values: list[ConstitutivePropertyValue]
     ) -> list[Entity]:
-        """Returns entities with which have the given constitutive property values
+        """Return entities whose constitutive property values match all of the given values.
 
-        Note: This is a non-optimized base method provided for convenience
-        It will first get all entities then iterate over them.
+        Note: This is a non-optimized base method provided for convenience.
+        It fetches all entities then filters in Python.
 
-        Params:
-            values: A list of PropertyValue instances whose
-            properties are Constitutive Properties
+        Args:
+            values: A list of ``ConstitutivePropertyValue`` instances.  Every
+                item must have a ``ConstitutivePropertyDescriptor`` as its
+                ``property`` field; a ``ValueError`` is raised otherwise.
 
         Returns:
-            A list of Entities in the receiver which have constitutivePropertyValues.
-            If there are no matches the list will be empty.
-        """
+            A list of entities whose constitutive property values include every
+            value in *values*.  Returns an empty list when there are no matches.
 
-        def _same(entity: Entity, searchValues: list[PropertyValue]) -> bool:
-            # Does this entity have the same properties
-            unmatchedProperties = [
+        Raises:
+            ValueError: If any item in *values* is not a
+                ``ConstitutivePropertyValue`` (i.e. its ``property`` field is not
+                a ``ConstitutivePropertyDescriptor``).
+        """
+        from ado.schema.property import ConstitutivePropertyDescriptor
+
+        non_constitutive_values = [
+            val
+            for val in values
+            if not isinstance(val.property, ConstitutivePropertyDescriptor)
+        ]
+        if non_constitutive_values:
+            invalid_properties = ", ".join(
+                repr(v.property) for v in non_constitutive_values
+            )
+            raise ValueError(
+                f"entitiesWithConstitutivePropertyValues received non-constitutive "
+                f"property values: {invalid_properties}"
+            )
+
+        def _same(
+            entity: Entity, search_values: list[ConstitutivePropertyValue]
+        ) -> bool:
+            unmatched_props = [
                 val
-                for val in searchValues
+                for val in search_values
                 if entity.valueForProperty(val.property) is None
             ]
-            if len(unmatchedProperties) == 0:
-                unmatchedValues = [
-                    val
-                    for val in searchValues
-                    if entity.valueForProperty(val.property).value != val.value
-                ]
+            if unmatched_props:
+                return False
+            return all(
+                entity.valueForProperty(val.property).value == val.value
+                for val in search_values
+            )
 
-                return len(unmatchedValues) == 0
-            return False
-
-        all_entities = self.entities
-        return [e for e in all_entities if _same(e, values)]
+        return [
+            e for e in self.get_entities(require_measurements=False) if _same(e, values)
+        ]
 
     @property
     @abc.abstractmethod

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -63,8 +63,8 @@ class SampleStore(abc.ABC):
         """Return all entities with their measurement results.
 
         Deprecated:
-            On ``SQLSampleStore``, this property emits a ``DeprecationWarning``.
-            Prefer ``get_entities(require_measurements=True)`` for new code.
+            This property emits a ``DeprecationWarning`` on all concrete
+            implementations. Prefer ``get_entities()`` for new code.
         """
 
     @property

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -155,7 +155,7 @@ class SampleStore(abc.ABC):
             )
 
         return [
-            e for e in self.get_entities(require_measurements=False) if _same(e, values)
+            e for e in self.get_entities(require_measurements=True) if _same(e, values)
         ]
 
     @property

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -76,7 +76,8 @@ class SampleStore(abc.ABC):
     def get_entities(
         self,
         identifiers: str | set[str] | None = None,
-        require_measurements: bool = False,
+        *,
+        require_measurements: bool,
         refresh: bool = False,
     ) -> list[Entity]:  # pragma: nocover
         """Retrieve entities from the store.
@@ -88,7 +89,7 @@ class SampleStore(abc.ABC):
                 - ``set[str]``: an explicit subset of entity identifiers.
             require_measurements: When ``True``, measurement results are
                 fetched and attached to every returned entity.
-                Defaults to ``False``.
+                Must be supplied explicitly by the caller.
             refresh: When ``True``, cached data is evicted before fetching.
                 Defaults to ``False``.
 

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -60,7 +60,12 @@ class SampleStore(abc.ABC):
     @property
     @abc.abstractmethod
     def entities(self) -> list[Entity]:  # pragma: nocover
-        pass
+        """Return all entities with their measurement results.
+
+        Deprecated:
+            On ``SQLSampleStore``, this property emits a ``DeprecationWarning``.
+            Prefer ``get_entities(require_measurements=True)`` for new code.
+        """
 
     @property
     @abc.abstractmethod

--- a/ado/core/samplestore/csv.py
+++ b/ado/core/samplestore/csv.py
@@ -434,6 +434,33 @@ class CSVSampleStore(PassiveSampleStore):
     def entities(self) -> list[Entity]:
         return self._entities
 
+    def get_entities(
+        self,
+        identifiers: str | set[str] | None = None,
+        require_measurements: bool = False,
+        refresh: bool = False,
+    ) -> list[Entity]:
+        """Retrieve entities from the CSV store.
+
+        Args:
+            identifiers: Which entities to return.
+                - ``None`` (default): all entities.
+                - ``str``: a single entity identifier.
+                - ``set[str]``: an explicit subset of entity identifiers.
+            require_measurements: Ignored; CSV entities always carry their
+                measurements. Included for interface compatibility.
+            refresh: Ignored; CSV stores have no cache. Included for interface
+                compatibility.
+
+        Returns:
+            List of ``Entity`` objects.
+        """
+        if identifiers is None:
+            return list(self._entities)
+        if isinstance(identifiers, str):
+            identifiers = {identifiers}
+        return [e for e in self._entities if e.identifier in identifiers]
+
     @property
     def numberOfEntities(self) -> int:
         return len(self._entities)

--- a/ado/core/samplestore/csv.py
+++ b/ado/core/samplestore/csv.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import pydantic
@@ -432,6 +433,16 @@ class CSVSampleStore(PassiveSampleStore):
 
     @property
     def entities(self) -> list[Entity]:
+        """Deprecated: use ``get_entities()`` instead.
+
+        Returns all entities with their measurement results attached.
+        This property is deprecated and will be removed in a future release.
+        """
+        warnings.warn(
+            "CSVSampleStore.entities is deprecated. Use get_entities() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._entities
 
     def get_entities(

--- a/ado/core/samplestore/csv.py
+++ b/ado/core/samplestore/csv.py
@@ -448,7 +448,8 @@ class CSVSampleStore(PassiveSampleStore):
     def get_entities(
         self,
         identifiers: str | set[str] | None = None,
-        require_measurements: bool = False,
+        *,
+        require_measurements: bool,
         refresh: bool = False,
     ) -> list[Entity]:
         """Retrieve entities from the CSV store.

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -380,6 +380,8 @@ class SQLSampleStore(ActiveSampleStore):
         self._last_insert_id = (
             0  # Track last processed insert_id for incremental refresh
         )
+        # Tracks which entity identifiers have had all measurements fetched and attached.
+        self._entities_with_measurements_loaded: set[str] = set()
         # Experiment-catalog cache.  _UNSET means "not yet computed".
         self._experiment_catalog: object = _UNSET
 
@@ -453,50 +455,48 @@ class SQLSampleStore(ActiveSampleStore):
 
     @property
     def entities(self) -> list[Entity]:
-        if not self._all_entities_loaded:
-            # Initial load: delegate to refresh with force_fetch_all_entities=True
-            self.log.debug(f"Initial load of entities for {self._tablename}")
-            self.refresh(force_fetch_all_entities=True)
+        """Deprecated: use ``get_entities(require_measurements=True)`` instead.
 
-        return list(self._entities.values())
+        Returns all entities with all their measurement results attached.
+        This property is deprecated and will be removed in a future release.
+        """
+        warnings.warn(
+            "SQLSampleStore.entities is deprecated. "
+            "Use get_entities(require_measurements=True) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_entities(require_measurements=True)
 
     def _fetch_entities(self, entity_ids: set[str] | None = None) -> dict[str, Entity]:
-        """
-        Fetch entities from the database.
+        """Fetch entities from the database and merge them into ``self._entities``.
 
         Parameters:
             entity_ids: Optional set of entity identifiers to fetch.
                        If None or empty set, fetches all entities.
 
         Returns:
-            Dictionary mapping entity_identifier -> Entity object
+            Dictionary mapping entity_identifier -> Entity object for the
+            newly fetched entities (callers may use this for counting).
 
         Raises:
             SystemError: If database query fails
             FailedToDecodeStoredEntityError: If entity JSON is invalid
         """
+        from sqlalchemy import select
+
         # Treat empty set same as None - fetch all entities
         if entity_ids is not None and len(entity_ids) == 0:
             entity_ids = None
 
-        # Build query based on whether we're filtering
-        if entity_ids is None:
-            query = sqlalchemy.text(
-                f"SELECT identifier, representation FROM {self._tablename}"  # noqa: S608 - self._tablename is not untrusted
-            )
-            params = {}
-        else:
-            # Use parameterized query for filtering
-            placeholders = ", ".join([f":id{i}" for i in range(len(entity_ids))])
-            query = sqlalchemy.text(
-                f"SELECT identifier, representation FROM {self._tablename} "  # noqa: S608 - self._tablename is not untrusted
-                f"WHERE identifier IN ({placeholders})"
-            )
-            params = {f"id{i}": eid for i, eid in enumerate(entity_ids)}
+        entity_table = self._metadata.tables[self._tablename]
+        stmt = select(entity_table.c.identifier, entity_table.c.representation)
+        if entity_ids is not None:
+            stmt = stmt.where(entity_table.c.identifier.in_(entity_ids))
 
         try:
             with self.engine.begin() as connectable:
-                cur = connectable.execute(query, params)
+                cur = connectable.execute(stmt)
         except SQLAlchemyError as error:
             msg = f"Unable to fetch entities from sample store {self._tablename}"
             self.log.critical(f"{msg}. Error: {error}")
@@ -519,26 +519,34 @@ class SQLSampleStore(ActiveSampleStore):
             f"Fetched {len(entities)} entities"
             + (f" (filtered from {len(entity_ids)} requested)" if entity_ids else "")
         )
+        # Always merge fetched entities into the cache.
+        self._entities.update(entities)
         return entities
 
     def _fetch_measurement_results(
-        self, min_insert_id: int = 0
-    ) -> tuple[dict[str, list[ValidMeasurementResult]], int]:
-        """
-        Fetch measurement results from database starting from a specific insert_id.
+        self,
+        min_insert_id: int = 0,
+        entity_ids: set[str] | None = None,
+    ) -> tuple[dict[str, list[ValidMeasurementResult]], int, int]:
+        """Fetch measurement results from the database and attach them to cached entities.
 
-        This method fetches results, validates them, and groups them by entity_id.
-        Only valid measurement results are included in the returned dictionary.
-        All validation happens here, so callers don't need to validate again.
+        Fetches results, validates them, groups them by entity_id, attaches
+        ``ValidMeasurementResult`` objects to the corresponding entities in
+        ``self._entities``, and updates ``self._entities_with_measurements_loaded``
+        for every entity that was in scope (even those with no results).
 
         Parameters:
             min_insert_id: Minimum insert_id to fetch (exclusive).
                           Use 0 to fetch all results.
+            entity_ids: Optional set of entity identifiers to restrict the
+                       query to.  When ``None`` (default) all entities are
+                       considered.
 
         Returns:
             Tuple of:
             - Dictionary mapping entity_id -> list of ValidMeasurementResult objects
             - Maximum insert_id seen (or min_insert_id if no results)
+            - Total number of measurement results successfully attached to entities
 
         Raises:
             SystemError: If database query fails
@@ -546,16 +554,23 @@ class SQLSampleStore(ActiveSampleStore):
         """
         from collections import defaultdict
 
-        query = sqlalchemy.text(f"""
-            SELECT insert_id, entity_id, data
-            FROM {self._tablename}_measurement_results
-            WHERE insert_id > :min_insert_id
-            ORDER BY insert_id
-            """)  # noqa: S608 - self._tablename is not untrusted
+        from sqlalchemy import select
+
+        if entity_ids is not None and len(entity_ids) == 0:
+            entity_ids = None
+
+        res_table = self._result_table
+        stmt = (
+            select(res_table.c.insert_id, res_table.c.entity_id, res_table.c.data)
+            .where(res_table.c.insert_id > min_insert_id)
+            .order_by(res_table.c.insert_id)
+        )
+        if entity_ids is not None:
+            stmt = stmt.where(res_table.c.entity_id.in_(entity_ids))
 
         try:
             with self.engine.begin() as connectable:
-                cur = connectable.execute(query, {"min_insert_id": min_insert_id})
+                cur = connectable.execute(stmt)
         except SQLAlchemyError as error:
             msg = f"Unable to fetch measurement results from sample store {self._tablename}"
             self.log.critical(f"{msg}. Error: {error}")
@@ -574,11 +589,10 @@ class SQLSampleStore(ActiveSampleStore):
                 continue
 
             try:
-                result_dict = json.loads(result_data)
-                if not result_dict.get("measurements", None):
+                if not result_data.get("measurements", None):
                     continue
 
-                measurement_result = ValidMeasurementResult.model_validate(result_dict)
+                measurement_result = ValidMeasurementResult.model_validate(result_data)
                 results_by_entity[entity_id].append(measurement_result)
             except Exception as error:
                 raise FailedToDecodeStoredMeasurementResultForEntityError(
@@ -587,17 +601,40 @@ class SQLSampleStore(ActiveSampleStore):
                     cause=error,
                 ) from error
 
+        # Attach results to cached entities and update the measurement-loaded tracking set.
+        total_attached = 0
+        for entity_id, measurement_results in results_by_entity.items():
+            if entity_id not in self._entities:
+                continue
+            for measurement_result in measurement_results:
+                try:
+                    self._entities[entity_id].add_measurement_result(
+                        result=measurement_result
+                    )
+                except DuplicateMeasurementResultError:  # noqa: PERF203
+                    pass
+                else:
+                    total_attached += 1
+
+        # Mark every requested entity (including those with no results) as loaded.
+        requested_entity_ids = (
+            entity_ids if entity_ids is not None else set(self._entities)
+        )
+        self._entities_with_measurements_loaded.update(
+            requested_entity_ids.intersection(self._entities)
+        )
+
         total_results = sum(len(results) for results in results_by_entity.values())
         self.log.debug(
             f"Fetched {total_results} measurement results for {len(results_by_entity)} entities "
-            f"(insert_id range: {min_insert_id + 1} to {max_insert_id})"
+            f"(insert_id range: {min_insert_id + 1} to {max_insert_id}), "
+            f"attached {total_attached}"
         )
 
-        return dict(results_by_entity), max_insert_id
+        return dict(results_by_entity), max_insert_id, total_attached
 
     def refresh(self, force_fetch_all_entities: bool = False) -> tuple[int, int]:
-        """
-        Refresh entities and fetch new measurement results.
+        """Refresh entities and fetch new measurement results.
 
         This method efficiently syncs the local cache with the database by:
         1. Fetching only new measurement results (insert_id > _last_insert_id)
@@ -617,8 +654,6 @@ class SQLSampleStore(ActiveSampleStore):
 
         Example:
             >>> store = SQLSampleStore(...)
-            >>> initial_count = len(store.entities)
-            >>> # Another process adds measurements
             >>> new_entities, new_results = store.refresh()
             >>> print(f"Fetched {new_entities} new entities and {new_results} new measurements")
         """
@@ -631,67 +666,61 @@ class SQLSampleStore(ActiveSampleStore):
 
         # Phase 1: Fetch entities
         if force_fetch_all_entities:
-            # Initial load: fetch all entities
-            self._entities = self._fetch_entities(entity_ids=None)
-            new_entities_count = len(self._entities)
+            # Initial load: clear cache then re-fetch everything.
+            self._entities.clear()
+            self._entities_with_measurements_loaded.clear()
+            new_entities = self._fetch_entities(entity_ids=None)
+            new_entities_count = len(new_entities)
             self._all_entities_loaded = True
             self.log.debug(f"Fetched all {new_entities_count} entities")
 
-        # Phase 2: Fetch new measurement results (already validated and grouped)
-        results_by_entity, max_insert_id = self._fetch_measurement_results(
-            min_insert_id=self._last_insert_id
+        # Phase 2: Fetch new measurement results (already validated, grouped, and attached
+        # to self._entities as a side effect of _fetch_measurement_results).
+        _results_by_entity, max_insert_id, total_measurements = (
+            self._fetch_measurement_results(min_insert_id=self._last_insert_id)
         )
 
-        if not results_by_entity:
+        if not _results_by_entity:
             self.log.debug("No new measurement results found")
             return (new_entities_count, 0)
 
-        # Phase 3: Fetch missing entities
-        # Doing it every time even if force_fetch_all_entities is True to avoid
-        # the off-chance where another process adds an entity and some results
-        # in the time it takes to fetch all the entities + all the measurements.
-        # This avoid the chance of having results for which we have no entity.
-        new_entity_ids = set(results_by_entity.keys())
+        # Phase 3: Fetch missing entities.
+        # Done even when force_fetch_all_entities=True to handle the race where
+        # another process inserts an entity+results after our entity fetch but
+        # before our measurement fetch.
+        new_entity_ids = set(_results_by_entity.keys())
         missing_entity_ids = new_entity_ids - set(self._entities.keys())
 
         if missing_entity_ids:
             self.log.debug(f"Fetching {len(missing_entity_ids)} new entities")
             new_entities = self._fetch_entities(entity_ids=missing_entity_ids)
-            self._entities.update(new_entities)
-            new_entities_count = len(new_entities)
+            fetched_count = len(new_entities)
+            if not force_fetch_all_entities:
+                new_entities_count = fetched_count
 
-            if len(missing_entity_ids) != new_entities_count:
+            if len(missing_entity_ids) != fetched_count:
                 self.log.warning(
                     f"Expected to find {len(missing_entity_ids)} new entities but "
-                    f"{new_entities_count} were retrieved. This suggests another process "
+                    f"{fetched_count} were retrieved. This suggests another process "
                     f"is updating the sample store concurrently."
                 )
 
-        # Phase 4: Attach measurements to entities (no validation needed - already done)
-        total_measurements = 0
-        for entity_id, measurement_results in results_by_entity.items():
-            for measurement_result in measurement_results:
-                # We have fetched results starting from self._last_insert_id, which
-                # means:
-                #   1.  Somebody else (e.g., another distributed process) could have
-                #       added results to the sample store.
-                #   2.  We ourselves could've added results to the sample store via
-                #       add_measurement_results.
-                # At the moment we can't know the `insert_id` of the results we add
-                # to avoid them. If we did, we would still have to fetch results
-                # starting from self._last_insert_id because someone else could have
-                # added results, but we would also be able to add a NOT IN to avoid
-                # ones we are already aware of.
-                # As it stands, then, we need to be careful not to add measurement
-                # results twice.
-                try:
-                    self._entities[entity_id].add_measurement_result(
-                        result=measurement_result
-                    )
-                except DuplicateMeasurementResultError:  # noqa: PERF203
-                    pass
-                else:
-                    total_measurements += 1
+            # Attach the already-fetched results to the newly cached entities.
+            # _fetch_measurement_results ran before these entities were in cache,
+            # so they were skipped during the attachment pass.
+            for entity_id in missing_entity_ids:
+                if entity_id not in self._entities:
+                    continue
+                for measurement_result in _results_by_entity.get(entity_id, []):
+                    try:
+                        self._entities[entity_id].add_measurement_result(
+                            result=measurement_result
+                        )
+                    except DuplicateMeasurementResultError:  # noqa: PERF203
+                        pass
+                    else:
+                        total_measurements += 1
+                self._entities_with_measurements_loaded.add(entity_id)
 
         # Update tracking
         self._last_insert_id = max_insert_id
@@ -808,6 +837,91 @@ class SQLSampleStore(ActiveSampleStore):
             )
 
         return cached_entities + list(entities_dict.values())
+
+    def get_entities(
+        self,
+        identifiers: str | set[str] | None = None,
+        require_measurements: bool = False,
+        refresh: bool = False,
+    ) -> list[Entity]:
+        """Retrieve entities from the store with optional measurement attachment.
+
+        This is the preferred method for fetching entities.  It maximises cache
+        reuse — only data that is not already cached is fetched from the database.
+
+        Args:
+            identifiers: Which entities to return.
+                - ``None`` (default): all entities.
+                - ``str``: a single entity identifier (normalised to a one-item set).
+                - ``set[str]``: an explicit subset of entity identifiers.
+            require_measurements: When ``True``, measurement results are fetched
+                and attached to every returned entity before the list is returned.
+                Entities that already have their measurements loaded (tracked via
+                ``_entities_with_measurements_loaded``) are not re-queried.
+                Defaults to ``False``.
+            refresh: When ``True``, the relevant cache entries are evicted before
+                fetching so that the database is always re-queried.
+                - For ``identifiers=None``: clears all cached data and resets
+                  ``_last_insert_id`` to 0.
+                - For a specific subset: removes only those ids from ``_entities``
+                  and ``_entities_with_measurements_loaded``; the global
+                  ``_last_insert_id`` cursor is preserved.
+                Defaults to ``False``.
+
+        Returns:
+            List of ``Entity`` objects.  When ``identifiers`` is a subset, only
+            entities that exist in the store are included (missing ids are silently
+            omitted).
+        """
+        # --- normalise identifiers ---
+        if isinstance(identifiers, str):
+            requested_ids: set[str] | None = {identifiers}
+        else:
+            requested_ids = identifiers  # None or set[str]
+
+        # --- selective cache invalidation ---
+        if refresh:
+            if requested_ids is None:
+                self._entities.clear()
+                self._entities_with_measurements_loaded.clear()
+                self._all_entities_loaded = False
+                self._last_insert_id = 0
+            else:
+                for eid in requested_ids:
+                    self._entities.pop(eid, None)
+                self._entities_with_measurements_loaded.difference_update(requested_ids)
+
+        # --- entity fetch ---
+        if requested_ids is None:
+            if not self._all_entities_loaded:
+                self._fetch_entities(entity_ids=None)
+                self._all_entities_loaded = True
+        else:
+            uncached_ids = requested_ids.difference(self._entities)
+            if uncached_ids:
+                self._fetch_entities(entity_ids=uncached_ids)
+
+        # --- optional measurement fetch ---
+        if require_measurements:
+            if requested_ids is None:
+                missing_measurement_ids = set(self._entities).difference(
+                    self._entities_with_measurements_loaded
+                )
+            else:
+                missing_measurement_ids = requested_ids.difference(
+                    self._entities_with_measurements_loaded
+                )
+
+            if missing_measurement_ids:
+                self._fetch_measurement_results(
+                    min_insert_id=0,
+                    entity_ids=missing_measurement_ids,
+                )
+
+        # --- build result list ---
+        if requested_ids is None:
+            return list(self._entities.values())
+        return [self._entities[eid] for eid in requested_ids if eid in self._entities]
 
     def entities_in_operations(self, operation_ids: str | set[str]) -> list[Entity]:
         """Get entities sampled in one or more operations.

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -841,7 +841,8 @@ class SQLSampleStore(ActiveSampleStore):
     def get_entities(
         self,
         identifiers: str | set[str] | None = None,
-        require_measurements: bool = False,
+        *,
+        require_measurements: bool,
         refresh: bool = False,
     ) -> list[Entity]:
         """Retrieve entities from the store with optional measurement attachment.

--- a/tests/core/test_entitysource.py
+++ b/tests/core/test_entitysource.py
@@ -295,6 +295,22 @@ def test_base_entity_with_constitutive_property_values(
     assert len(ents) == 5
 
 
+def test_entities_with_constitutive_property_values_rejects_non_constitutive(
+    ml_multi_cloud_csv_sample_store: CSVSampleStore,
+) -> None:
+    """Passing a PropertyValue whose property is not a ConstitutivePropertyDescriptor raises ValueError."""
+    from ado.schema.property_value import PropertyValue
+
+    non_constitutive_value = PropertyValue(
+        value=1.0,
+        property=AbstractPropertyDescriptor(identifier="wallClockRuntime"),
+    )
+    with pytest.raises(ValueError, match="non-constitutive"):
+        ml_multi_cloud_csv_sample_store.entitiesWithConstitutivePropertyValues(
+            [non_constitutive_value]  # type: ignore[list-item]
+        )
+
+
 def test_csv_sample_store_type_parsing(
     ml_multi_cloud_csv_sample_store: CSVSampleStore,
 ) -> None:

--- a/tests/operators/test_discovery_space_manager.py
+++ b/tests/operators/test_discovery_space_manager.py
@@ -64,8 +64,9 @@ def test_internal_state_direct_init(
         )
         assert numberEntities == pfas_space.sample_store.numberOfEntities
         assert experiments == pfas_space.measurementSpace.experiments
-        assert firstEntity == pfas_space.sample_store.entities[0]
-        assert lastEntity == pfas_space.sample_store.entities[-1]
+        all_entities = pfas_space.sample_store.get_entities()
+        assert firstEntity == all_entities[0]
+        assert lastEntity == all_entities[-1]
     finally:
         ray.kill(state)
 

--- a/tests/operators/test_discovery_space_manager.py
+++ b/tests/operators/test_discovery_space_manager.py
@@ -64,7 +64,7 @@ def test_internal_state_direct_init(
         )
         assert numberEntities == pfas_space.sample_store.numberOfEntities
         assert experiments == pfas_space.measurementSpace.experiments
-        all_entities = pfas_space.sample_store.get_entities()
+        all_entities = pfas_space.sample_store.get_entities(require_measurements=False)
         assert firstEntity == all_entities[0]
         assert lastEntity == all_entities[-1]
     finally:

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -642,7 +642,9 @@ def test_entity_identifiers_in_sample_store(
     ml_multi_cloud_sample_store: SQLSampleStore,
 ) -> None:
 
-    expected_identifiers = [e.identifier for e in ml_multi_cloud_sample_store.entities]
+    expected_identifiers = [
+        e.identifier for e in ml_multi_cloud_sample_store.get_entities()
+    ]
     retrieved_identifiers = ml_multi_cloud_sample_store.entity_identifiers()
 
     assert len(expected_identifiers) == len(retrieved_identifiers)
@@ -735,7 +737,7 @@ def test_entities_by_identifiers_list_input(
 ) -> None:
     """Test entities_with_identifiers accepts list input."""
     # Get some entity identifiers from the store
-    all_entities = ml_multi_cloud_sample_store.entities
+    all_entities = ml_multi_cloud_sample_store.get_entities()
     assert len(all_entities) > 0
 
     # Test with list input
@@ -751,7 +753,7 @@ def test_entities_by_identifiers_set_input(
 ) -> None:
     """Test entities_with_identifiers accepts set input."""
     # Get some entity identifiers from the store
-    all_entities = ml_multi_cloud_sample_store.entities
+    all_entities = ml_multi_cloud_sample_store.get_entities()
     assert len(all_entities) > 0
 
     # Test with set input
@@ -767,7 +769,7 @@ def test_entities_by_identifiers_subset(
 ) -> None:
     """Test entities_with_identifiers returns only requested entities."""
     # Get all entities from the store
-    all_entities = ml_multi_cloud_sample_store.entities
+    all_entities = ml_multi_cloud_sample_store.get_entities()
     assert len(all_entities) >= 3
 
     # Request only a subset
@@ -804,7 +806,7 @@ def test_entities_by_identifiers_mixed_existing_nonexistent(
     ml_multi_cloud_sample_store: SQLSampleStore,
 ) -> None:
     """Test entities_with_identifiers with mix of existing and non-existent identifiers."""
-    all_entities = ml_multi_cloud_sample_store.entities
+    all_entities = ml_multi_cloud_sample_store.get_entities()
     assert len(all_entities) > 0
 
     # Mix of existing and non-existent
@@ -827,7 +829,7 @@ def test_entities_by_identifiers_partial_cache_reuse(
     ml_multi_cloud_sample_store: SQLSampleStore,
 ) -> None:
     """Test entities_with_identifiers reuses cached entities and only queries the rest."""
-    all_entities = ml_multi_cloud_sample_store.entities
+    all_entities = ml_multi_cloud_sample_store.get_entities()
     assert len(all_entities) >= 3
 
     # Pre-warm the cache with only the first entity

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -643,7 +643,8 @@ def test_entity_identifiers_in_sample_store(
 ) -> None:
 
     expected_identifiers = [
-        e.identifier for e in ml_multi_cloud_sample_store.get_entities()
+        e.identifier
+        for e in ml_multi_cloud_sample_store.get_entities(require_measurements=False)
     ]
     retrieved_identifiers = ml_multi_cloud_sample_store.entity_identifiers()
 
@@ -737,7 +738,7 @@ def test_entities_by_identifiers_list_input(
 ) -> None:
     """Test entities_with_identifiers accepts list input."""
     # Get some entity identifiers from the store
-    all_entities = ml_multi_cloud_sample_store.get_entities()
+    all_entities = ml_multi_cloud_sample_store.get_entities(require_measurements=False)
     assert len(all_entities) > 0
 
     # Test with list input
@@ -753,7 +754,7 @@ def test_entities_by_identifiers_set_input(
 ) -> None:
     """Test entities_with_identifiers accepts set input."""
     # Get some entity identifiers from the store
-    all_entities = ml_multi_cloud_sample_store.get_entities()
+    all_entities = ml_multi_cloud_sample_store.get_entities(require_measurements=False)
     assert len(all_entities) > 0
 
     # Test with set input
@@ -769,7 +770,7 @@ def test_entities_by_identifiers_subset(
 ) -> None:
     """Test entities_with_identifiers returns only requested entities."""
     # Get all entities from the store
-    all_entities = ml_multi_cloud_sample_store.get_entities()
+    all_entities = ml_multi_cloud_sample_store.get_entities(require_measurements=False)
     assert len(all_entities) >= 3
 
     # Request only a subset
@@ -806,7 +807,7 @@ def test_entities_by_identifiers_mixed_existing_nonexistent(
     ml_multi_cloud_sample_store: SQLSampleStore,
 ) -> None:
     """Test entities_with_identifiers with mix of existing and non-existent identifiers."""
-    all_entities = ml_multi_cloud_sample_store.get_entities()
+    all_entities = ml_multi_cloud_sample_store.get_entities(require_measurements=False)
     assert len(all_entities) > 0
 
     # Mix of existing and non-existent
@@ -829,7 +830,7 @@ def test_entities_by_identifiers_partial_cache_reuse(
     ml_multi_cloud_sample_store: SQLSampleStore,
 ) -> None:
     """Test entities_with_identifiers reuses cached entities and only queries the rest."""
-    all_entities = ml_multi_cloud_sample_store.get_entities()
+    all_entities = ml_multi_cloud_sample_store.get_entities(require_measurements=False)
     assert len(all_entities) >= 3
 
     # Pre-warm the cache with only the first entity

--- a/tests/samplestore/get/test_get_entities.py
+++ b/tests/samplestore/get/test_get_entities.py
@@ -1,0 +1,262 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Tests for SQLSampleStore.get_entities()."""
+
+from collections.abc import Callable
+
+import pytest
+
+from ado.core.samplestore.sql import SQLSampleStore
+from ado.schema.entity import Entity
+from ado.schema.result import (
+    MeasurementResult,
+    MeasurementResultStateEnum,
+)
+
+
+def test_get_entities_returns_all_entities_without_measurements(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+) -> None:
+    """get_entities() with no arguments returns all entities, no measurements."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(4)
+    for e in entities:
+        e.measurement_results = []
+
+    # Add measurements to DB too
+    add_entities_to_sample_store(store, entities)
+    for entity in entities:
+        result = random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity, 1, MeasurementResultStateEnum.VALID
+        )
+        store.add_measurement_results([result], skip_relationship_to_request=True)
+
+    result_entities = store.get_entities()
+
+    assert len(result_entities) == 4
+    # No measurements should be attached (require_measurements defaults to False)
+    assert all(len(e.measurement_results) == 0 for e in result_entities)
+
+
+def test_get_entities_single_string_identifier(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """get_entities('id') with a single string returns exactly that entity."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(3)
+    add_entities_to_sample_store(store, entities)
+
+    target_id = entities[1].identifier
+    result = store.get_entities(target_id)
+
+    assert len(result) == 1
+    assert result[0].identifier == target_id
+
+
+def test_get_entities_require_measurements_attaches_results(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+) -> None:
+    """get_entities(require_measurements=True) attaches measurements and updates tracking."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(3)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(store, entities)
+
+    for entity in entities:
+        result = random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity, 1, MeasurementResultStateEnum.VALID
+        )
+        store.add_measurement_results([result], skip_relationship_to_request=True)
+
+    result_entities = store.get_entities(require_measurements=True)
+
+    assert len(result_entities) == 3
+    assert all(len(e.measurement_results) == 1 for e in result_entities)
+
+    # All ids should now be in the measurements-loaded tracking set
+    entity_ids = {e.identifier for e in entities}
+    assert entity_ids.issubset(store._entities_with_measurements_loaded)
+
+
+def test_get_entities_require_measurements_second_call_no_requery(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+) -> None:
+    """Second get_entities(require_measurements=True) call does not re-attach measurements."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(2)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(store, entities)
+
+    for entity in entities:
+        result = random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity, 1, MeasurementResultStateEnum.VALID
+        )
+        store.add_measurement_results([result], skip_relationship_to_request=True)
+
+    _ = store.get_entities(require_measurements=True)
+    loaded_before = set(store._entities_with_measurements_loaded)
+
+    # Second call — all ids already in tracking set, no requery expected
+    result_entities = store.get_entities(require_measurements=True)
+
+    assert all(len(e.measurement_results) == 1 for e in result_entities)
+    # Tracking set unchanged (no new ids added)
+    assert store._entities_with_measurements_loaded == loaded_before
+
+
+def test_get_entities_no_measurements_entity_still_marked_loaded(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """Entity with no measurements in DB still appears in _entities_with_measurements_loaded."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(2)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(store, entities)
+    # Add NO measurements to the DB
+
+    result_entities = store.get_entities(require_measurements=True)
+
+    assert len(result_entities) == 2
+    entity_ids = {e.identifier for e in entities}
+    # Even with no measurements, entities should be marked as checked
+    assert entity_ids.issubset(store._entities_with_measurements_loaded)
+
+
+def test_get_entities_refresh_subset_evicts_and_refetches(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """get_entities({'id'}, refresh=True) evicts only requested ids and re-fetches them."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(3)
+    add_entities_to_sample_store(store, entities)
+
+    # Warm cache
+    _ = store.get_entities()
+    assert len(store._entities) == 3
+
+    target_id = entities[0].identifier
+    last_insert_id_before = store._last_insert_id
+
+    # Refresh only the first entity
+    result = store.get_entities({target_id}, refresh=True)
+
+    assert len(result) == 1
+    assert result[0].identifier == target_id
+    # Other entities still in cache
+    assert len(store._entities) == 3
+    # _last_insert_id must not have been reset for a subset refresh
+    assert store._last_insert_id == last_insert_id_before
+
+
+def test_get_entities_refresh_all_evicts_everything(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """get_entities(refresh=True) with identifiers=None re-fetches everything."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(3)
+    add_entities_to_sample_store(store, entities)
+
+    # Warm cache and simulate a non-zero last_insert_id
+    store._last_insert_id = 99
+    _ = store.get_entities()
+
+    # Full refresh
+    result = store.get_entities(refresh=True)
+
+    assert len(result) == 3
+    # _last_insert_id should have been reset to 0 then remain 0 (no measurements)
+    assert store._last_insert_id == 0
+
+
+def test_get_entities_refresh_true_require_measurements(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+) -> None:
+    """get_entities(refresh=True, require_measurements=True) re-fetches entities and measurements."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(2)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(store, entities)
+
+    for entity in entities:
+        result = random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity, 1, MeasurementResultStateEnum.VALID
+        )
+        store.add_measurement_results([result], skip_relationship_to_request=True)
+
+    # First warm the cache
+    _ = store.get_entities(require_measurements=True)
+    assert {e.identifier for e in entities}.issubset(
+        store._entities_with_measurements_loaded
+    )
+
+    # Full refresh with measurements
+    result_entities = store.get_entities(refresh=True, require_measurements=True)
+
+    assert len(result_entities) == 2
+    assert all(len(e.measurement_results) == 1 for e in result_entities)
+    assert {e.identifier for e in entities}.issubset(
+        store._entities_with_measurements_loaded
+    )
+
+
+def test_get_entities_deprecated_entities_property(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+) -> None:
+    """Accessing .entities emits DeprecationWarning and returns entities with measurements."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(2)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(store, entities)
+
+    for entity in entities:
+        result = random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity, 1, MeasurementResultStateEnum.VALID
+        )
+        store.add_measurement_results([result], skip_relationship_to_request=True)
+
+    with pytest.warns(
+        DeprecationWarning, match="SQLSampleStore.entities is deprecated"
+    ):
+        result_entities = store.entities
+
+    assert len(result_entities) == 2
+    assert all(len(e.measurement_results) == 1 for e in result_entities)

--- a/tests/samplestore/get/test_get_entities.py
+++ b/tests/samplestore/get/test_get_entities.py
@@ -37,10 +37,10 @@ def test_get_entities_returns_all_entities_without_measurements(
         )
         store.add_measurement_results([result], skip_relationship_to_request=True)
 
-    result_entities = store.get_entities()
+    result_entities = store.get_entities(require_measurements=False)
 
     assert len(result_entities) == 4
-    # No measurements should be attached (require_measurements defaults to False)
+    # No measurements should be attached
     assert all(len(e.measurement_results) == 0 for e in result_entities)
 
 
@@ -55,7 +55,7 @@ def test_get_entities_single_string_identifier(
     add_entities_to_sample_store(store, entities)
 
     target_id = entities[1].identifier
-    result = store.get_entities(target_id)
+    result = store.get_entities(target_id, require_measurements=False)
 
     assert len(result) == 1
     assert result[0].identifier == target_id
@@ -156,14 +156,14 @@ def test_get_entities_refresh_subset_evicts_and_refetches(
     add_entities_to_sample_store(store, entities)
 
     # Warm cache
-    _ = store.get_entities()
+    _ = store.get_entities(require_measurements=False)
     assert len(store._entities) == 3
 
     target_id = entities[0].identifier
     last_insert_id_before = store._last_insert_id
 
     # Refresh only the first entity
-    result = store.get_entities({target_id}, refresh=True)
+    result = store.get_entities({target_id}, refresh=True, require_measurements=False)
 
     assert len(result) == 1
     assert result[0].identifier == target_id
@@ -185,10 +185,10 @@ def test_get_entities_refresh_all_evicts_everything(
 
     # Warm cache and simulate a non-zero last_insert_id
     store._last_insert_id = 99
-    _ = store.get_entities()
+    _ = store.get_entities(require_measurements=False)
 
     # Full refresh
-    result = store.get_entities(refresh=True)
+    result = store.get_entities(refresh=True, require_measurements=False)
 
     assert len(result) == 3
     # _last_insert_id should have been reset to 0 then remain 0 (no measurements)

--- a/tests/samplestore/test_refresh.py
+++ b/tests/samplestore/test_refresh.py
@@ -116,7 +116,9 @@ def test_fetch_measurement_results_all(
     )
 
     # Fetch all measurement results
-    results_by_entity, max_insert_id = store._fetch_measurement_results(min_insert_id=0)
+    results_by_entity, max_insert_id, _ = store._fetch_measurement_results(
+        min_insert_id=0
+    )
 
     assert len(results_by_entity) == 3
     assert max_insert_id > 0
@@ -152,7 +154,7 @@ def test_fetch_measurement_results_incremental(
     )
 
     # Get max insert_id from first batch
-    _, max_insert_id_batch1 = store._fetch_measurement_results(min_insert_id=0)
+    _, max_insert_id_batch1, _ = store._fetch_measurement_results(min_insert_id=0)
 
     # Add second batch of entities with measurements
     entities_batch2 = random_ml_multi_cloud_benchmark_performance_entities(2)
@@ -170,7 +172,7 @@ def test_fetch_measurement_results_incremental(
     )
 
     # Fetch only new results
-    results_by_entity, max_insert_id_batch2 = store._fetch_measurement_results(
+    results_by_entity, max_insert_id_batch2, _ = store._fetch_measurement_results(
         min_insert_id=max_insert_id_batch1
     )
 
@@ -313,7 +315,7 @@ def test_refresh_no_new_data(
     add_entities_to_sample_store(store, entities)
 
     # Trigger initial load
-    _ = store.entities
+    _ = store.get_entities(require_measurements=True)
 
     # Refresh without adding new data
     new_entities_count, new_measurements_count = store.refresh()
@@ -343,7 +345,7 @@ def test_refresh_adds_measurements_to_existing_entities(
     add_entities_to_sample_store(store, entities)
 
     # Trigger initial load
-    initial_entities = store.entities
+    initial_entities = store.get_entities(require_measurements=True)
     assert all(len(e.measurement_results) == 0 for e in initial_entities)
 
     # Add measurements to existing entities directly in DB
@@ -360,7 +362,7 @@ def test_refresh_adds_measurements_to_existing_entities(
     assert new_measurements_count == 2  # New measurements added
 
     # Verify measurements were added to existing entities
-    refreshed_entities = store.entities
+    refreshed_entities = store.get_entities(require_measurements=True)
     assert all(len(e.measurement_results) == 1 for e in refreshed_entities)
 
 
@@ -389,6 +391,10 @@ def test_entities_after_partial_cache_population(
         del store._entities[entity.identifier]
 
     # .entities must trigger a full DB load and return all 5 rows
-    all_identifiers = {e.identifier for e in store.entities}
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        all_identifiers = {e.identifier for e in store.entities}
     expected_identifiers = {e.identifier for e in entities_batch1 + entities_batch2}
     assert all_identifiers == expected_identifiers


### PR DESCRIPTION
## Separate entity fetching from measurement loading in `SampleStore`

Previously, fetching entities from a `SQLSampleStore` always loaded their measurement results at the same time. This PR decouples the two operations so callers can retrieve entities cheaply without paying the cost of loading measurements when they are not needed.

The core change is a new `get_entities()` method on the `SampleStore` base class (and both concrete implementations), which accepts optional filters by identifier, a `require_measurements` flag, and a `refresh` flag for cache invalidation. The old `.entities` property on `SQLSampleStore` is deprecated in favour of this method. Internal measurement fetching was also refactored to track which entities have already had their measurements loaded, avoiding redundant DB queries on repeated calls. Full test coverage for the new API is included.

---

> **AI disclosure:** The code in this PR was generated using [IBM Bob](https://bob.ibm.com/) and was reviewed manually.