### PR TITLE
perf(core): do not load entity measurements when computing space stats

### DIFF
--- a/ado/cli/utils/resources/formatters.py
+++ b/ado/cli/utils/resources/formatters.py
@@ -413,52 +413,44 @@ def format_ado_get_stats_for_spaces(
 
     space_ids: set[str] = set(df["IDENTIFIER"])
 
-    # Query 1: for each space, get its child operations.
-    # Returns {space_id: {CoreResourceKinds.OPERATION: set[operation_id]}}
-    space_child_relationships: dict[str, dict[CoreResourceKinds, set[str]]] = (
+    # Single traversal in both directions (identifiers only) to get child
+    # operation IDs (down) and parent samplestore IDs (up) in one SQL query.
+    # Returns {space_id: {CoreResourceKinds.OPERATION: set[str],
+    #                      CoreResourceKinds.SAMPLESTORE: set[str]}}
+    space_relationships: dict[str, dict[CoreResourceKinds, set[str]]] = typing.cast(
+        "dict[str, dict[CoreResourceKinds, set[str]]]",
         sql_store.get_resources_by_relationship(
             kind=CoreResourceKinds.DISCOVERYSPACE,
             identifier=space_ids,
-            hierarchy_direction="down",
+            hierarchy_direction="both",
             max_hops=1,
             identifiers_only=True,
-        )
+        ),
     )
 
-    # Build space_id_to_operation_ids: {space_id: set[operation_id]}
-    space_id_to_operation_ids: dict[str, set[str]] = {}
-    for space_id in space_ids:
-        space_children_by_kind = space_child_relationships.get(space_id, {})
-        space_id_to_operation_ids[space_id] = space_children_by_kind.get(
-            CoreResourceKinds.OPERATION, set()
+    # Collect deduplicated samplestore IDs across all spaces, then hydrate once.
+    all_samplestore_ids: set[str] = {
+        samplestore_id
+        for space_id in space_ids
+        for samplestore_id in space_relationships.get(space_id, {}).get(
+            CoreResourceKinds.SAMPLESTORE, set()
         )
-
-    # Query 2: for each space, get its parent sample store(s),
-    # returning hydrated SampleStoreResource objects.
-    # Returns {space_id: {CoreResourceKinds.SAMPLESTORE: {samplestore_id: SampleStoreResource}}}
-    space_parent_relationships: dict[
-        str, dict[CoreResourceKinds, dict[str, ADOResource]]
-    ] = sql_store.get_resources_by_relationship(
-        kind=CoreResourceKinds.DISCOVERYSPACE,
-        identifier=space_ids,
-        hierarchy_direction="up",
-        max_hops=1,
-        identifiers_only=False,
+    }
+    samplestore_id_to_resource: dict[str, ADOResource] = sql_store.getResources(
+        list(all_samplestore_ids)
     )
 
-    # Invert to {samplestore_id: set[space_id]}, keeping the hydrated resource.
-    samplestore_id_to_resource: dict[str, ADOResource] = {}
+    # Build {samplestore_id: set[space_id]} from the traversal result.
     samplestore_id_to_space_ids: dict[str, set[str]] = {}
-    for space_id, space_parents_by_kind in space_parent_relationships.items():
-        samplestore_resources = space_parents_by_kind.get(
-            CoreResourceKinds.SAMPLESTORE, {}
-        )
-        for samplestore_id, samplestore_resource in samplestore_resources.items():
-            samplestore_id_to_resource[samplestore_id] = samplestore_resource
+    for space_id in space_ids:
+        for samplestore_id in space_relationships.get(space_id, {}).get(
+            CoreResourceKinds.SAMPLESTORE, set()
+        ):
             samplestore_id_to_space_ids.setdefault(samplestore_id, set()).add(space_id)
 
     from ado.core.discoveryspace.stats import (
         DiscoverySpaceStatistics,
+        lightweight_space_statistics,
         space_statistics_for_spaces,
     )
 
@@ -505,10 +497,12 @@ def format_ado_get_stats_for_spaces(
             )
         )
     else:
-        # Lightweight path: issue a metastore stats query and one
-        # space_entity_statistics query per distinct sample store.
-        metastore_stats = sql_store.get_space_metastore_stats(space_ids)
-
+        # Lightweight path: one entity_identifiers_in_operations query per
+        # distinct sample store, then a single lightweight_space_statistics
+        # call that issues the metastore stats query for all spaces at once.
+        entity_ids_by_space_id: dict[str, set[str]] = {
+            space_id: set() for space_id in space_ids
+        }
         for index, (samplestore_id, samplestore_space_ids) in enumerate(
             samplestore_id_to_space_ids.items(), start=1
         ):
@@ -519,24 +513,31 @@ def format_ado_get_stats_for_spaces(
             sample_store = SampleStore.from_resource(
                 samplestore_id_to_resource[samplestore_id]
             )
-            operation_ids_per_space = {
-                space_id: space_id_to_operation_ids[space_id]
+            operation_id_to_space_id = {
+                op_id: space_id
                 for space_id in samplestore_space_ids
-            }
-            entity_stats_per_space = sample_store.space_entity_statistics(
-                space_ids_to_operation_ids=operation_ids_per_space
-            )
-            for space_id, entity_stats in entity_stats_per_space.items():
-                all_stats[space_id] = DiscoverySpaceStatistics(
-                    number_of_experiments=metastore_stats[
-                        space_id
-                    ].number_of_experiments,
-                    number_of_operations=metastore_stats[space_id].number_of_operations,
-                    number_of_explore_operations=metastore_stats[
-                        space_id
-                    ].number_of_explore_operations,
-                    number_measured_entities=entity_stats.number_measured_entities or 0,
+                for op_id in space_relationships.get(space_id, {}).get(
+                    CoreResourceKinds.OPERATION, set()
                 )
+            }
+            if operation_id_to_space_id:
+                entity_ids_by_operation_id = (
+                    sample_store.entity_identifiers_in_operations(
+                        set(operation_id_to_space_id.keys()), group_by_operation=True
+                    )
+                )
+                for op_id, entity_ids in entity_ids_by_operation_id.items():
+                    entity_ids_by_space_id[operation_id_to_space_id[op_id]].update(
+                        entity_ids
+                    )
+
+        all_stats.update(
+            lightweight_space_statistics(
+                space_ids=space_ids,
+                entity_ids_by_space_id=entity_ids_by_space_id,
+                metastore=sql_store,
+            )
+        )
 
     # Attach lightweight columns; spaces with no data show 0.
     df["EXPERIMENTS"] = df["IDENTIFIER"].apply(

--- a/ado/core/discoveryspace/space.py
+++ b/ado/core/discoveryspace/space.py
@@ -616,25 +616,41 @@ class DiscoverySpace:
                 f"Unable to store space {self._identifier} as no metadata storage provided"
             )
 
-    def sampledEntities(self) -> list[Entity]:
-        """Returns the entities sampled so far in the space"""
+    def sampledEntities(self, *, require_measurements: bool = True) -> list[Entity]:
+        """Returns the entities sampled so far in the space.
+
+        Args:
+            require_measurements: When ``True`` (default), measurement results
+                are guaranteed to be attached to each entity.  Pass ``False`` to
+                load only constitutive properties (measurement results may still
+                be present if already loaded).
+        """
 
         operation_ids = self.operations
 
         if not operation_ids:
             return []
 
-        sampled_entities = self.sample_store.entities_in_operations(operation_ids)
+        entity_ids = set(
+            self.sample_store.entity_identifiers_in_operations(operation_ids)
+        )
+        sampled_entities = self.sample_store.get_entities(
+            identifiers=entity_ids, require_measurements=require_measurements
+        )
 
         # TODO: Consider removing isEntitySpace check
         # The additional check of isEntityInSpace should not be required if things are working correctly
         # However if an entity was incorrectly sampled during an operation, due to a bug say, this will correct for it
         return [e for e in sampled_entities if self.entitySpace.isEntityInSpace(e)]
 
-    def matchingEntities(self) -> list[Entity]:
-        """Returns all entities in the sample store that match the space
+    def matchingEntities(self, *, require_measurements: bool = True) -> list[Entity]:
+        """Returns all entities in the sample store that match the space.
 
-        Note: They do not have to have any measurements from the measurement space
+        Args:
+            require_measurements: When ``True`` (default), measurement results
+                are guaranteed to be attached to each entity.  Pass ``False`` to
+                load only constitutive properties (measurement results may still
+                be present if already loaded).
 
         If
         - ExplicitEntitySpace defined -> filter on the space
@@ -642,7 +658,9 @@ class DiscoverySpace:
         """
 
         # Get all entities in the store
-        all_entities = self.sample_store.entities
+        all_entities = self.sample_store.get_entities(
+            require_measurements=require_measurements
+        )
         if self.entitySpace is None:
             return all_entities
 

--- a/ado/core/discoveryspace/stats.py
+++ b/ado/core/discoveryspace/stats.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import math
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, NamedTuple
 
 import pydantic
+
+from ado.cli.utils.output.prints import ADO_SPINNER_GETTING_OUTPUT_READY
+from ado.core.resources import CoreResourceKinds
 
 if TYPE_CHECKING:
     from rich.status import Status
@@ -12,6 +15,17 @@ if TYPE_CHECKING:
     from ado.core.discoveryspace.space import DiscoverySpace
     from ado.core.samplestore.base import ActiveSampleStore
     from ado.metastore.base import ResourceStore
+
+
+class _SpaceSamplingState(NamedTuple):
+    """Intermediate per-space values stashed at the end of Pass 1."""
+
+    sampled_ids: set[str]
+    matching_ids: set[str]
+    size_of_entity_space: int | None
+    number_unmeasured: int | float | None
+    number_matching: int
+    number_measured: int
 
 
 class DiscoverySpaceStatistics(pydantic.BaseModel):
@@ -162,27 +176,22 @@ class DiscoverySpaceStatistics(pydantic.BaseModel):
 
 def lightweight_space_statistics(
     space_ids: set[str],
-    space_ids_to_operation_ids: dict[str, set[str]],
+    entity_ids_by_space_id: "dict[str, set[str]]",
     metastore: "ResourceStore",
-    sample_store: "ActiveSampleStore",
 ) -> "dict[str, DiscoverySpaceStatistics]":
     """Compute lightweight statistics for spaces given only their IDs and stores.
 
-    Unlike :func:`space_statistics_for_spaces`, this function does not require
-    :class:`~ado.core.discoveryspace.space.DiscoverySpace` instances —
-    it only needs the space IDs, the operation-ID mapping, and the two stores.
     Heavy fields (``size_of_entity_space``, ``number_unmeasured_entities``,
     ``number_matching_entities``, ``number_matching_entities_with_measurements``)
     are always ``None``.
 
     Args:
         space_ids: Set of space URIs to compute statistics for.
-        space_ids_to_operation_ids: Mapping from each space URI to the set of
-            operation IDs that belong to that space.
+        entity_ids_by_space_id: Mapping from each space URI to the set of
+            entity IDs sampled in that space (empty set for spaces with no
+            operations).
         metastore: The :class:`~ado.metastore.base.ResourceStore` to
             query for operation/experiment counts.
-        sample_store: The :class:`~ado.core.samplestore.base.ActiveSampleStore`
-            to query for measured-entity counts.
 
     Returns:
         ``dict[space_id, DiscoverySpaceStatistics]`` keyed by space URI.
@@ -193,18 +202,10 @@ def lightweight_space_statistics(
     metastore_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
         metastore.get_space_metastore_stats(space_ids)
     )
-    sample_store_stats_by_space_id: dict[str, DiscoverySpaceStatistics] = (
-        sample_store.space_entity_statistics(
-            space_ids_to_operation_ids=space_ids_to_operation_ids,
-        )
-    )
 
     missing = space_ids - metastore_stats_by_space_id.keys()
     if missing:
         raise KeyError(f"Metastore returned no statistics for space(s): {missing}")
-    missing = space_ids - sample_store_stats_by_space_id.keys()
-    if missing:
-        raise KeyError(f"Sample store returned no statistics for space(s): {missing}")
 
     return {
         space_id: DiscoverySpaceStatistics(
@@ -217,9 +218,7 @@ def lightweight_space_statistics(
             number_of_explore_operations=metastore_stats_by_space_id[
                 space_id
             ].number_of_explore_operations,
-            number_measured_entities=sample_store_stats_by_space_id[
-                space_id
-            ].number_measured_entities,
+            number_measured_entities=len(entity_ids_by_space_id.get(space_id, set())),
             size_of_entity_space=None,
             number_unmeasured_entities=None,
             number_matching_entities=None,
@@ -269,18 +268,51 @@ def space_statistics_for_spaces(
 
     metastore = spaces[0].metadataStore
 
+    # Flat map: operation_id → space_id (each operation belongs to one space).
+    entity_ids_by_space_id: dict[str, set[str]] = {}
     lightweight_stats: dict[str, DiscoverySpaceStatistics] = {}
+    total = len(spaces)
+    lightweight_idx = 0
     for store_spaces in spaces_by_sample_store.values():
-        group_space_ids = {s.uri for s in store_spaces}
-        group_operation_ids = {s.uri: set(s.operations) for s in store_spaces}
-        lightweight_stats.update(
-            lightweight_space_statistics(
-                space_ids=group_space_ids,
-                space_ids_to_operation_ids=group_operation_ids,
-                metastore=metastore,
-                sample_store=store_spaces[0].sample_store,
+        sample_store: ActiveSampleStore = store_spaces[0].sample_store
+        group_space_ids: set[str] = {s.uri for s in store_spaces}
+        for space in store_spaces:
+            lightweight_idx += 1
+            if spinner is not None:
+                spinner.update(
+                    f"Computing lightweight statistics for {space.uri} ({lightweight_idx}/{total})"
+                )
+
+        ops_by_space: dict[str, dict[CoreResourceKinds, set[str]]] = (
+            metastore.get_resources_by_relationship(  # type: ignore[assignment]
+                kind=CoreResourceKinds.DISCOVERYSPACE,
+                identifier=group_space_ids,
+                hierarchy_direction="down",
+                max_hops=1,
+                identifiers_only=True,
             )
         )
+        operation_id_to_space_id: dict[str, str] = {
+            op_id: space_id
+            for space_id, kinds in ops_by_space.items()
+            for op_id in kinds.get(CoreResourceKinds.OPERATION, set())
+        }
+        group_entity_ids: dict[str, set[str]] = {s.uri: set() for s in store_spaces}
+        if operation_id_to_space_id:
+            entity_identifiers_by_operation = (
+                sample_store.entity_identifiers_in_operations(
+                    set(operation_id_to_space_id.keys()), group_by_operation=True
+                )
+            )
+            for operation_id, ids in entity_identifiers_by_operation.items():
+                group_entity_ids[operation_id_to_space_id[operation_id]].update(ids)
+        entity_ids_by_space_id.update(group_entity_ids)
+        group_stats: dict[str, DiscoverySpaceStatistics] = lightweight_space_statistics(
+            space_ids=group_space_ids,
+            entity_ids_by_space_id=group_entity_ids,
+            metastore=metastore,
+        )
+        lightweight_stats.update(group_stats)
 
     if lightweight_only:
         return lightweight_stats
@@ -289,9 +321,18 @@ def space_statistics_for_spaces(
     # Heavy path — requires DiscoverySpace instances for Python-side work.
     # ------------------------------------------------------------------
 
-    result: dict[str, DiscoverySpaceStatistics] = {}
-    total = len(spaces)
+    # Intermediate results collected during Pass 1 (keyed by space URI).
+    # Each entry stores everything needed to compute the final statistics once
+    # the batched entity_experiment_references results are available.
+    intermediate: dict[str, _SpaceSamplingState] = {}
 
+    # Per-store accumulator: union of all entity IDs (matching + sampled) that
+    # need experiment-reference lookups, keyed by sample-store identifier.
+    entity_identifiers_by_sample_store: dict[str, set[str]] = {}
+
+    # ------------------------------------------------------------------
+    # Pass 1: entity fetching and matching — no entity_experiment_references
+    # ------------------------------------------------------------------
     for idx, space in enumerate(spaces, start=1):
         if spinner is not None:
             spinner.update(
@@ -300,7 +341,6 @@ def space_statistics_for_spaces(
         base = lightweight_stats[space.uri]
         number_measured = base.number_measured_entities
 
-        # Heavy path
         size_of_entity_space: int | None = None
         if (
             space.entitySpace is not None
@@ -316,9 +356,23 @@ def space_statistics_for_spaces(
         elif not space.entitySpace.isDiscreteSpace:
             number_unmeasured = math.inf
         else:
-            number_unmeasured = size_of_entity_space - number_measured
+            # size_of_entity_space is always set when isDiscreteSpace is True
+            number_unmeasured = (size_of_entity_space or 0) - number_measured
 
-        sampled_entities = space.sampledEntities()
+        # We already know which entities have been sampled in operations on this
+        # space so there is no need to call sampledEntities().
+        sampled_entity_ids = entity_ids_by_space_id.get(space.uri, set())
+        sampled_entities = space.sample_store.get_entities(
+            identifiers=sampled_entity_ids, require_measurements=False
+        )
+
+        # Filter to entities that actually belong to this space. This also
+        # confirms the entity was found in the store — IDs not present in the
+        # store are silently dropped by get_entities, so any entity that
+        # survived to this point was genuinely retrieved.
+        sampled_entities = [
+            e for e in sampled_entities if space.entitySpace.isEntityInSpace(e)
+        ]
 
         # If the space has been completely sampled, sampled entities == matching
         # entities, so we can skip the more expensive matchingEntities() call.
@@ -328,29 +382,97 @@ def space_statistics_for_spaces(
         ):
             matching_entities = sampled_entities
         else:
-            matching_entities = space.matchingEntities()
-        number_matching = len(matching_entities)
+            matching_entities = space.matchingEntities(require_measurements=False)
 
-        measurement_exp_refs = set(space.measurementSpace.experimentReferences)
+        # Re-derive IDs from the filtered entity objects rather than reusing
+        # sampled_entity_ids, because the filter above may have dropped some.
+        sampled_ids = {
+            e.identifier for e in sampled_entities if e.identifier is not None
+        }
+        matching_ids = {
+            e.identifier for e in matching_entities if e.identifier is not None
+        }
+
+        # Accumulate all entity IDs that will need experiment-reference lookups
+        # for this store group, to be queried in a single batch after Pass 1.
+        store_id = space.sample_store.identifier
+        if store_id not in entity_identifiers_by_sample_store:
+            entity_identifiers_by_sample_store[store_id] = set()
+
+        entity_identifiers_by_sample_store[store_id].update(matching_ids)
+        entity_identifiers_by_sample_store[store_id].update(sampled_ids)
+
+        intermediate[space.uri] = _SpaceSamplingState(
+            sampled_ids=sampled_ids,
+            matching_ids=matching_ids,
+            size_of_entity_space=size_of_entity_space,
+            number_unmeasured=number_unmeasured,
+            number_matching=len(matching_entities),
+            number_measured=number_measured,
+        )
+
+    if spinner:
+        spinner.update(ADO_SPINNER_GETTING_OUTPUT_READY)
+
+    # ------------------------------------------------------------------
+    # Batch: one entity_experiment_references call per sample-store group
+    # ------------------------------------------------------------------
+    exp_refs_by_store: dict[str, dict] = {}
+    for store_id, entity_identifiers in entity_identifiers_by_sample_store.items():
+        store = spaces_by_sample_store[store_id][0].sample_store
+        exp_refs_by_store[store_id] = store.entity_experiment_references(
+            entity_identifiers
+        )
+
+    # ------------------------------------------------------------------
+    # Pass 2: Python-only — distribute batched results to each space
+    # ------------------------------------------------------------------
+    result: dict[str, DiscoverySpaceStatistics] = {}
+
+    for space in spaces:
+        base = lightweight_stats[space.uri]
+        r = intermediate[space.uri]
+        sampled_ids = r.sampled_ids
+        matching_ids = r.matching_ids
+        size_of_entity_space = r.size_of_entity_space
+        number_unmeasured = r.number_unmeasured
+        number_matching = r.number_matching
+        number_measured = r.number_measured
+
+        store_id = space.sample_store.identifier
+        store_exp_refs = exp_refs_by_store.get(store_id, {})
+
+        # Slice the store-level batch result down to only the entities this space needs.
+        exp_refs_by_matching_entity = {
+            k: store_exp_refs[k] for k in matching_ids if k in store_exp_refs
+        }
+        exp_refs_by_sampled_entity = {
+            k: store_exp_refs[k] for k in sampled_ids if k in store_exp_refs
+        }
+
+        exp_refs_in_measurement_space = set(space.measurementSpace.experimentReferences)
         experiments_in_measurement_space = len(space.measurementSpace.experiments)
-        number_matching_with_measurements = sum(
-            1
-            for e in matching_entities
-            if len(e.observedPropertyValues) > 0
-            and not measurement_exp_refs.isdisjoint(set(e.experimentReferences))
-        )
-        matching_entities_with_all_measurements = sum(
-            1
-            for e in matching_entities
-            if len(measurement_exp_refs.intersection(e.experimentReferences))
-            == experiments_in_measurement_space
-        )
+
+        number_matching_with_measurements = 0
+        matching_entities_with_all_measurements = 0
+        for entity_id in matching_ids:
+            entity_exp_refs = exp_refs_by_matching_entity.get(entity_id, set())
+            n_measured = len(
+                exp_refs_in_measurement_space.intersection(entity_exp_refs)
+            )
+            if n_measured > 0:
+                number_matching_with_measurements += 1
+            if n_measured == experiments_in_measurement_space:
+                matching_entities_with_all_measurements += 1
 
         sampled_entities_with_all_measurements = sum(
             1
-            for e in sampled_entities
-            if len(e.observedPropertyValues) > 0
-            and len(measurement_exp_refs.intersection(e.experimentReferences))
+            for entity_id in sampled_ids
+            if len(
+                exp_refs_in_measurement_space.intersection(
+                    exp_refs_by_sampled_entity.get(entity_id, set())
+                )
+            )
             == experiments_in_measurement_space
         )
         entities_with_partial_measurements = (

--- a/ado/core/samplestore/base.py
+++ b/ado/core/samplestore/base.py
@@ -23,7 +23,6 @@ from ado.schema.property_value import ConstitutivePropertyValue
 from ado.schema.request import MeasurementRequest
 
 if typing.TYPE_CHECKING:
-    from ado.core.discoveryspace.stats import DiscoverySpaceStatistics
     from ado.core.operation.stats import OperationMeasurementStatistics
     from ado.core.samplestore.config import (
         SampleStoreConfiguration,
@@ -32,6 +31,7 @@ if typing.TYPE_CHECKING:
     )
     from ado.core.samplestore.resource import SampleStoreResource
     from ado.schema.observed_property import ObservedProperty
+    from ado.schema.reference import ExperimentReference
 
 
 class SampleStore(abc.ABC):
@@ -553,6 +553,27 @@ class ActiveSampleStore(SampleStore, ABC):
             List of Entity objects that were sampled in the specified operation(s).
         """
 
+    @abc.abstractmethod
+    def entity_identifiers_in_operations(
+        self,
+        operation_ids: str | set[str],
+        group_by_operation: bool = False,
+    ) -> "set[str] | dict[str, set[str]]":
+        """Get the set of entity identifiers sampled in one or more operations.
+
+        Args:
+            operation_ids: A single operation identifier or a set of operation
+                identifiers to look up entity identifiers for.
+            group_by_operation: When True, return a dict mapping each operation
+                ID to its set of entity identifiers. When False (default),
+                return a flat set of entity identifiers across all operations.
+
+        Returns:
+            A flat set of entity identifier strings when group_by_operation is
+            False, or a dict mapping operation ID to set of entity identifiers
+            when group_by_operation is True.
+        """
+
     def entities_in_operation(self, operation_ids: str | set[str]) -> list[Entity]:
         """Deprecated: use entities_in_operations instead."""
         warnings.warn(
@@ -587,34 +608,35 @@ class ActiveSampleStore(SampleStore, ABC):
         """
 
     @abc.abstractmethod
-    def space_entity_statistics(
-        self,
-        space_ids_to_operation_ids: dict[str, set[str]],
-    ) -> "dict[str, DiscoverySpaceStatistics]":
-        """Compute entity-level statistics for one or more discovery spaces.
-
-        Issues a single SQL query for all spaces at once, then groups results
-        by space ID in Python.
-
-        The ``number_matching_entities`` and
-        ``number_matching_entities_with_measurements`` fields require
-        Python-side ``isEntityInSpace`` evaluation and are not computed here;
-        they are always returned as ``None``.
+    def entities_with_valid_measurements(
+        self, entity_identifiers: set[str]
+    ) -> set[str]:
+        """Return the subset of entity_identifiers that has at least one valid measurement.
 
         Args:
-            space_ids_to_operation_ids: Mapping of space ID to the set of
-                operation IDs that belong to that space.  Spaces with an empty
-                operation-ID set are returned with ``number_measured_entities``
-                equal to ``0``.  An empty mapping returns an empty dict.
+            entity_identifiers: Set of entity identifier strings to check.  An empty
+                set returns an empty set without issuing any query.
 
         Returns:
-            A ``dict`` keyed by space ID.  Each value is a
-            :class:`~ado.core.discoveryspace.stats.DiscoverySpaceStatistics`
-            with ``number_measured_entities`` populated and all other fields at
-            their defaults (``None``).
+            Subset of *entity_identifiers* (possibly equal) for which at least one
+            valid measurement result exists.  Always a subset of the input.
+        """
 
-        Raises:
-            SystemError: If the underlying SQL query fails.
+    @abc.abstractmethod
+    def entity_experiment_references(
+        self, entity_identifiers: set[str]
+    ) -> "dict[str, set[ExperimentReference]]":
+        """Return the experiment references covered by valid measurements per entity.
+
+        Args:
+            entity_identifiers: Set of entity identifier strings to query.  An empty
+                set returns an empty dict without issuing any query.
+
+        Returns:
+            ``dict`` mapping each entity identifier to the set of
+            :class:`~ado.schema.reference.ExperimentReference` objects for which it
+            has at least one valid measurement result.  Entity identifiers with no
+            valid results are omitted from the returned dict.
         """
 
 

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -15,7 +15,6 @@ from sqlalchemy.exc import InvalidRequestError, SQLAlchemyError
 import ado.core.samplestore.config
 import ado.core.samplestore.csv
 import ado.metastore.sql.statements
-from ado.core.discoveryspace.stats import DiscoverySpaceStatistics
 from ado.core.samplestore.base import (
     ActiveSampleStore,
     FailedToDecodeStoredEntityError,
@@ -575,7 +574,6 @@ class SQLSampleStore(ActiveSampleStore):
             msg = f"Unable to fetch measurement results from sample store {self._tablename}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
-
         results_by_entity = defaultdict(list)
         max_insert_id = min_insert_id
 
@@ -1530,6 +1528,104 @@ class SQLSampleStore(ActiveSampleStore):
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 
+    def entities_with_valid_measurements(
+        self, entity_identifiers: set[str]
+    ) -> set[str]:
+        """Return the subset of entity_identifiers that has at least one valid measurement.
+
+        Args:
+            entity_identifiers: Set of entity identifier strings to check.
+
+        Returns:
+            Subset of *entity_identifiers* for which at least one valid measurement
+            result exists.
+
+        Raises:
+            SystemError: If the underlying SQL query fails.
+        """
+        if not entity_identifiers:
+            return set()
+
+        try:
+            from sqlalchemy import select
+
+            res_table = self._result_table
+            # A measurement result is valid when the ``reason`` field is absent
+            # from its stored JSON blob.
+            stmt = (
+                select(res_table.c.entity_id)
+                .where(res_table.c.entity_id.in_(entity_identifiers))
+                .where(
+                    sqlalchemy.func.json_extract(res_table.c.data, "$.reason").is_(None)
+                )
+                .distinct()
+            )
+            with self.engine.begin() as connectable:
+                rows = connectable.execute(stmt).fetchall()
+            return {row.entity_id for row in rows}
+        except SQLAlchemyError as error:
+            msg = "Unable to get entities with valid measurement"
+            self.log.critical(f"{msg}. Error: {error}")
+            raise SystemError(f"{msg}. Error: {error}") from error
+
+    def entity_experiment_references(
+        self, entity_identifiers: set[str]
+    ) -> "dict[str, set[ExperimentReference]]":
+        """Return the experiment references covered by valid measurements per entity.
+
+        Args:
+            entity_identifiers: Set of entity identifier strings to query.
+
+        Returns:
+            ``dict`` mapping each entity identifier (only those with ≥1 valid result)
+            to the set of :class:`~ado.schema.reference.ExperimentReference` objects
+            for which they have a valid result.
+
+        Raises:
+            SystemError: If the underlying SQL query fails.
+        """
+        if not entity_identifiers:
+            return {}
+
+        # Uses COALESCE to handle both the current (compressed) and legacy
+        # serialization formats stored in the database:
+        # - Current format: ``experimentReference`` at top level of the ``data`` blob.
+        # - Legacy format: ``experimentReference`` inside the first measurement's property.
+        try:
+            from sqlalchemy import select
+
+            res_table = self._result_table
+            exp_ref_col = sqlalchemy.func.coalesce(
+                sqlalchemy.func.json_extract(res_table.c.data, "$.experimentReference"),
+                sqlalchemy.func.json_extract(
+                    res_table.c.data,
+                    "$.measurements[0].property.experimentReference",
+                ),
+            ).label("experiment_reference_json")
+            stmt = (
+                select(res_table.c.entity_id, exp_ref_col)
+                .where(res_table.c.entity_id.in_(entity_identifiers))
+                .where(
+                    sqlalchemy.func.json_extract(res_table.c.data, "$.reason").is_(None)
+                )
+                .distinct()
+            )
+
+            with self.engine.begin() as connectable:
+                rows = connectable.execute(stmt).fetchall()
+            result: dict[str, set[ExperimentReference]] = {}
+            for row in rows:
+                blob = row.experiment_reference_json
+                if blob is None:
+                    continue
+                exp_ref = ExperimentReference.model_validate_json(blob)
+                result.setdefault(row.entity_id, set()).add(exp_ref)
+            return result
+        except SQLAlchemyError as error:
+            msg = "Unable to get entity experiment references"
+            self.log.critical(f"{msg}. Error: {error}")
+            raise SystemError(f"{msg}. Error: {error}") from error
+
     def operation_measurement_statistics(
         self, operation_ids: set[str] | None = None
     ) -> "list[OperationMeasurementStatistics]":
@@ -1716,126 +1812,6 @@ class SQLSampleStore(ActiveSampleStore):
             msg = f"Unable to get statistics for sample store {self._tablename}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
-
-    def space_entity_statistics(
-        self,
-        space_ids_to_operation_ids: dict[str, set[str]],
-    ) -> "dict[str, DiscoverySpaceStatistics]":
-        """Compute entity-level statistics for one or more discovery spaces.
-
-        Issues a single SQL query that fetches all distinct
-        ``(operation_id, entity_id)`` pairs across every operation referenced
-        in *space_ids_to_operation_ids*, then groups the results by space ID
-        in Python.  This approach is portable across all supported backends
-        (SQLite, MySQL).
-
-        ``number_matching_entities`` and
-        ``number_matching_entities_with_measurements`` are not computed here
-        (they require Python-side ``isEntityInSpace`` evaluation) and are
-        always ``None`` in the returned models.
-
-        Args:
-            space_ids_to_operation_ids: Mapping of space ID to the set of
-                operation IDs that belong to that space.  Spaces with an empty
-                operation-ID set are returned with ``number_measured_entities``
-                equal to ``0``.  An empty mapping returns an empty dict.
-
-        Returns:
-            A ``dict`` keyed by space ID.  Each value is a
-            :class:`~ado.core.discoveryspace.stats.DiscoverySpaceStatistics`
-            with ``number_measured_entities`` populated and all other fields at
-            their defaults (``None``).
-
-        Raises:
-            SystemError: If the underlying SQL query fails.
-        """
-        if not space_ids_to_operation_ids:
-            return {}
-
-        # Separate spaces that have no operations (return 0 immediately) from
-        # those that need a DB query.
-        empty_space_ids = {
-            space_id
-            for space_id, operation_ids in space_ids_to_operation_ids.items()
-            if not operation_ids
-        }
-        spaces_to_query = {
-            space_id: operation_ids
-            for space_id, operation_ids in space_ids_to_operation_ids.items()
-            if operation_ids
-        }
-
-        result: dict[str, DiscoverySpaceStatistics] = {
-            space_id: DiscoverySpaceStatistics(
-                number_of_experiments=0,
-                number_of_operations=0,
-                number_of_explore_operations=0,
-                number_measured_entities=0,
-            )
-            for space_id in empty_space_ids
-        }
-
-        if not spaces_to_query:
-            return result
-
-        # Flat set of all operation IDs across all queried spaces.
-        operation_ids = {
-            operation_id
-            for operation_ids in spaces_to_query.values()
-            for operation_id in operation_ids
-        }
-        # Reverse map: operation_id → space_id (each operation belongs to one space).
-        operation_id_to_space_id: dict[str, str] = {
-            operation_id: space_id
-            for space_id, operation_ids in spaces_to_query.items()
-            for operation_id in operation_ids
-        }
-
-        try:
-            from sqlalchemy import select
-
-            req_table = self._request_table
-            reqres_table = self._request_result_table
-            res_table = self._result_table
-
-            # Fetch all distinct (operation_id, entity_id) pairs in one query.
-            stmt = (
-                select(
-                    req_table.c.operation_id,
-                    res_table.c.entity_id,
-                )
-                .select_from(req_table)
-                .join(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
-                .join(res_table, reqres_table.c.result_uid == res_table.c.uid)
-                .where(req_table.c.operation_id.in_(operation_ids))
-                .distinct()
-            )
-
-            with self.engine.begin() as connectable:
-                rows = connectable.execute(stmt).fetchall()
-
-            # Group distinct entity IDs per space in Python.
-            entity_ids_by_space_id: dict[str, set[str]] = {
-                space_id: set() for space_id in spaces_to_query
-            }
-            for row in rows:
-                space_id = operation_id_to_space_id[row.operation_id]
-                entity_ids_by_space_id[space_id].add(row.entity_id)
-
-            for space_id, entity_ids in entity_ids_by_space_id.items():
-                result[space_id] = DiscoverySpaceStatistics(
-                    number_of_experiments=0,
-                    number_of_operations=0,
-                    number_of_explore_operations=0,
-                    number_measured_entities=len(entity_ids),
-                )
-
-        except SQLAlchemyError as error:
-            msg = f"Unable to get entity statistics for spaces {set(spaces_to_query)}"
-            self.log.critical(f"{msg}. Error: {error}")
-            raise SystemError(f"{msg}. Error: {error}") from error
-
-        return result
 
     def measurement_requests_for_operation(
         self,

--- a/tests/samplestore/get/test_get.py
+++ b/tests/samplestore/get/test_get.py
@@ -1390,146 +1390,259 @@ def test_operation_measurement_statistics_empty_set(
         sample_store.operation_measurement_statistics(operation_ids=set())
 
 
-def test_space_entity_statistics_empty_mapping(
+# ---------------------------------------------------------------------------
+# entities_with_valid_measurements
+# ---------------------------------------------------------------------------
+
+
+def test_entities_with_valid_measurements_empty_input(
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """An empty mapping returns an empty dict."""
+    """Empty input returns an empty set without a DB round-trip."""
     sample_store, _requests, _ids = simulate_ml_multi_cloud_random_walk_operation()
 
-    result = sample_store.space_entity_statistics(space_ids_to_operation_ids={})
+    result = sample_store.entities_with_valid_measurements(set())
+
+    assert result == set()
+
+
+def test_entities_with_valid_measurements_all_valid(
+    random_identifier: Callable[[], str],
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """All entities with valid results → full input set returned."""
+    operation_id = random_identifier()
+    number_entities = 3
+
+    sample_store, requests, _ = simulate_ml_multi_cloud_random_walk_operation(
+        number_entities=number_entities,
+        number_requests=1,
+        operation_id=operation_id,
+    )
+
+    entity_ids = {r.entityIdentifier for req in requests for r in req.measurements}
+
+    result = sample_store.entities_with_valid_measurements(entity_ids)
+
+    assert result == entity_ids
+
+
+def test_entities_with_valid_measurements_none_valid(
+    random_identifier: Callable[[], str],
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """No valid results → empty set returned (uses a fresh isolated store)."""
+    from ado.schema.reference import ExperimentReference
+
+    sample_store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(2)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(sample_store, entities)
+
+    results = [
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=e,
+            measurements_per_result=1,
+            status=MeasurementResultStateEnum.INVALID,
+        )
+        for e in entities
+    ]
+    request = ReplayedMeasurement(
+        operation_id=random_identifier(),
+        requestIndex=0,
+        experimentReference=ExperimentReference(
+            experimentIdentifier="benchmark_performance",
+            actuatorIdentifier="replay",
+        ),
+        entities=entities,
+        requestid=random_identifier(),
+        status=MeasurementRequestStateEnum.SUCCESS,
+        measurements=tuple(results),
+    )
+    req_id = sample_store.add_measurement_request(request=request)
+    sample_store.add_measurement_results(
+        results=results,
+        skip_relationship_to_request=False,
+        request_db_id=req_id,
+    )
+
+    entity_ids = {e.identifier for e in entities}
+    result = sample_store.entities_with_valid_measurements(entity_ids)
+
+    assert result == set()
+
+
+def test_entities_with_valid_measurements_mixed(
+    random_identifier: Callable[[], str],
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
+    ],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """Mixed valid/invalid results → only entities with a valid result returned (fresh store)."""
+    from ado.schema.reference import ExperimentReference
+
+    sample_store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(3)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(sample_store, entities)
+
+    # entity 0 → valid, entity 1 → invalid, entity 2 → valid
+    results = [
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=entities[0],
+            measurements_per_result=1,
+            status=MeasurementResultStateEnum.VALID,
+        ),
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=entities[1],
+            measurements_per_result=1,
+            status=MeasurementResultStateEnum.INVALID,
+        ),
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=entities[2],
+            measurements_per_result=1,
+            status=MeasurementResultStateEnum.VALID,
+        ),
+    ]
+    request = ReplayedMeasurement(
+        operation_id=random_identifier(),
+        requestIndex=0,
+        experimentReference=ExperimentReference(
+            experimentIdentifier="benchmark_performance",
+            actuatorIdentifier="replay",
+        ),
+        entities=entities,
+        requestid=random_identifier(),
+        status=MeasurementRequestStateEnum.SUCCESS,
+        measurements=tuple(results),
+    )
+    req_id = sample_store.add_measurement_request(request=request)
+    sample_store.add_measurement_results(
+        results=results,
+        skip_relationship_to_request=False,
+        request_db_id=req_id,
+    )
+
+    entity_ids = {e.identifier for e in entities}
+    result = sample_store.entities_with_valid_measurements(entity_ids)
+
+    expected = {entities[0].identifier, entities[2].identifier}
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# entity_experiment_references
+# ---------------------------------------------------------------------------
+
+
+def test_entity_experiment_references_empty_input(
+    simulate_ml_multi_cloud_random_walk_operation: Callable[
+        [int, int, int, str | None],
+        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    ],
+) -> None:
+    """Empty input returns an empty dict without a DB round-trip."""
+    sample_store, _requests, _ids = simulate_ml_multi_cloud_random_walk_operation()
+
+    result = sample_store.entity_experiment_references(set())
 
     assert result == {}
 
 
-def test_space_entity_statistics_empty_operations_for_space(
+def test_entity_experiment_references_all_valid(
     random_identifier: Callable[[], str],
     simulate_ml_multi_cloud_random_walk_operation: Callable[
         [int, int, int, str | None],
         tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
     ],
 ) -> None:
-    """A space mapped to an empty operation set returns 0 measured entities."""
-    space_id = random_identifier()
-    sample_store, _requests, _ids = simulate_ml_multi_cloud_random_walk_operation()
+    """All entities with valid results → every entity mapped to its experiment reference."""
+    from ado.schema.reference import ExperimentReference
 
-    result = sample_store.space_entity_statistics(
-        space_ids_to_operation_ids={space_id: set()},
-    )
-
-    assert result[space_id].number_measured_entities == 0
-    assert result[space_id].number_matching_entities is None
-    assert result[space_id].number_matching_entities_with_measurements is None
-
-
-def test_space_entity_statistics_single_operation(
-    random_identifier: Callable[[], str],
-    simulate_ml_multi_cloud_random_walk_operation: Callable[
-        [int, int, int, str | None],
-        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
-    ],
-) -> None:
-    """A single space/operation returns the correct distinct entity count."""
-    space_id = random_identifier()
     operation_id = random_identifier()
     number_entities = 3
-    number_requests = 2
 
     sample_store, requests, _ = simulate_ml_multi_cloud_random_walk_operation(
         number_entities=number_entities,
-        number_requests=number_requests,
+        number_requests=1,
         operation_id=operation_id,
     )
 
-    expected_entities = {
-        result.entityIdentifier
-        for request in requests
-        for result in request.measurements
-    }
-
-    result = sample_store.space_entity_statistics(
-        space_ids_to_operation_ids={space_id: {operation_id}},
+    entity_ids = {r.entityIdentifier for req in requests for r in req.measurements}
+    expected_exp_ref = ExperimentReference(
+        experimentIdentifier="benchmark_performance",
+        actuatorIdentifier="replay",
     )
 
-    assert result[space_id].number_measured_entities == len(expected_entities)
-    assert result[space_id].number_matching_entities is None
-    assert result[space_id].number_matching_entities_with_measurements is None
+    result = sample_store.entity_experiment_references(entity_ids)
+
+    assert set(result.keys()) == entity_ids
+    for exp_refs in result.values():
+        assert expected_exp_ref in exp_refs
 
 
-def test_space_entity_statistics_multiple_operations(
+def test_entity_experiment_references_only_invalid_results(
     random_identifier: Callable[[], str],
-    simulate_ml_multi_cloud_random_walk_operation: Callable[
-        [int, int, int, str | None],
-        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None], MeasurementResult
     ],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
 ) -> None:
-    """Multiple operations in one space: entities counted distinctly across all ops."""
-    space_id = random_identifier()
-    op_id_a = random_identifier()
-    op_id_b = random_identifier()
+    """Entity with only invalid results → not included in output dict (fresh store)."""
+    from ado.schema.reference import ExperimentReference
 
-    sample_store, requests_a, _ = simulate_ml_multi_cloud_random_walk_operation(
-        number_entities=2,
-        number_requests=1,
-        operation_id=op_id_a,
+    sample_store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(2)
+    for e in entities:
+        e.measurement_results = []
+    add_entities_to_sample_store(sample_store, entities)
+
+    results = [
+        random_ml_multi_cloud_benchmark_performance_measurement_results(
+            entity=e,
+            measurements_per_result=1,
+            status=MeasurementResultStateEnum.INVALID,
+        )
+        for e in entities
+    ]
+    request = ReplayedMeasurement(
+        operation_id=random_identifier(),
+        requestIndex=0,
+        experimentReference=ExperimentReference(
+            experimentIdentifier="benchmark_performance",
+            actuatorIdentifier="replay",
+        ),
+        entities=entities,
+        requestid=random_identifier(),
+        status=MeasurementRequestStateEnum.SUCCESS,
+        measurements=tuple(results),
     )
-    _, requests_b, _ = simulate_ml_multi_cloud_random_walk_operation(
-        number_entities=2,
-        number_requests=1,
-        operation_id=op_id_b,
-    )
-
-    all_entity_ids = {
-        result.entityIdentifier
-        for requests in (requests_a, requests_b)
-        for request in requests
-        for result in request.measurements
-    }
-
-    result = sample_store.space_entity_statistics(
-        space_ids_to_operation_ids={space_id: {op_id_a, op_id_b}},
-    )
-
-    assert result[space_id].number_measured_entities == len(all_entity_ids)
-    assert result[space_id].number_matching_entities is None
-    assert result[space_id].number_matching_entities_with_measurements is None
-
-
-def test_space_entity_statistics_multiple_spaces(
-    random_identifier: Callable[[], str],
-    simulate_ml_multi_cloud_random_walk_operation: Callable[
-        [int, int, int, str | None],
-        tuple[SQLSampleStore, list[MeasurementRequest], list[str]],
-    ],
-) -> None:
-    """Multiple spaces in one call each get correct independent entity counts."""
-    space_id_a = random_identifier()
-    space_id_b = random_identifier()
-    op_id_a = random_identifier()
-    op_id_b = random_identifier()
-
-    sample_store, requests_a, _ = simulate_ml_multi_cloud_random_walk_operation(
-        number_entities=3,
-        number_requests=1,
-        operation_id=op_id_a,
-    )
-    _, requests_b, _ = simulate_ml_multi_cloud_random_walk_operation(
-        number_entities=2,
-        number_requests=1,
-        operation_id=op_id_b,
+    req_id = sample_store.add_measurement_request(request=request)
+    sample_store.add_measurement_results(
+        results=results,
+        skip_relationship_to_request=False,
+        request_db_id=req_id,
     )
 
-    expected_a = {r.entityIdentifier for req in requests_a for r in req.measurements}
-    expected_b = {r.entityIdentifier for req in requests_b for r in req.measurements}
+    entity_ids = {e.identifier for e in entities}
+    result = sample_store.entity_experiment_references(entity_ids)
 
-    result = sample_store.space_entity_statistics(
-        space_ids_to_operation_ids={
-            space_id_a: {op_id_a},
-            space_id_b: {op_id_b},
-        },
-    )
-
-    assert result[space_id_a].number_measured_entities == len(expected_a)
-    assert result[space_id_b].number_measured_entities == len(expected_b)
+    assert result == {}


### PR DESCRIPTION
## Summary

Eliminates full measurement-blob loading when computing discovery space statistics (`ado get stats`). Previously, the stats path hydrated every entity's measurement results (full JSON blobs) just to count measured entities and check experiment references. The change fetches only the data actually needed — entity identifiers and experiment references — via targeted SQL queries, reducing memory pressure and query cost, especially for large sample stores.

## High-level Changes

- **`ado/core/samplestore/base.py` / `sql.py`**: Replaced the monolithic `space_entity_statistics()` method with two focused, composable primitives — `entity_identifiers_in_operations()` (returns entity IDs grouped by operation) and `entity_experiment_references()` (returns experiment references per entity from valid results only, without deserialising measurement blobs). Added `entities_with_valid_measurements()` as an additional lightweight helper.
- **`ado/core/discoveryspace/stats.py`**: Refactored `space_statistics_for_spaces()` into a two-pass approach: Pass 1 fetches entities without loading measurements (`require_measurements=False`) and accumulates entity IDs; a single batched `entity_experiment_references()` call per sample store follows; Pass 2 distributes the batch result to each space in pure Python. `lightweight_space_statistics()` now accepts pre-computed `entity_ids_by_space_id` instead of taking a `SampleStore` and issuing its own query.
- **`ado/core/discoveryspace/space.py`**: `sampledEntities()` and `matchingEntities()` gained a `require_measurements` keyword argument, allowing callers to opt out of loading measurement blobs when only constitutive properties are needed.
- **`ado/cli/utils/resources/formatters.py`**: Merged two separate metastore traversals (child operations + parent sample stores) into a single bidirectional `get_resources_by_relationship` call, then hydrates sample stores with a single `getResources` batch call instead of per-space hydration.
- **Tests**: Replaced `test_space_entity_statistics_*` tests with equivalent coverage for the new `entities_with_valid_measurements` and `entity_experiment_references` APIs.

## Impact

`ado get stats` for spaces with large sample stores will use significantly less memory and issue fewer/lighter SQL queries. No user-facing behaviour changes — statistics values are identical. The internal `space_entity_statistics()` API has been removed and replaced; any out-of-tree code calling it directly will need to be updated.

---

> **AI Disclosure:** This code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and were reviewed manually.