### PR TITLE
build(core): remove editable marker from workspace packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,17 +144,17 @@ members = [
 
 [tool.uv.sources]
 ado-autoconf = { path = "plugins/custom_experiments/autoconf", editable = true }
-ado-ray-tune = { workspace = true, editable = true }
+ado-ray-tune = { workspace = true }
 ado-sfttrainer = { path = "plugins/actuators/sfttrainer", editable = true }
 ado-trim = { path = "plugins/operators/trim", editable = true }
-ado-vllm-performance = { workspace = true, editable = true }
-ado-anomalous-series = { workspace = true, editable = true }
-density-test = { workspace = true, editable = true }
-optimization-test-functions = { workspace = true, editable = true }
-pfas-custom-functions = { workspace = true, editable = true }
+ado-vllm-performance = { workspace = true }
+ado-anomalous-series = { workspace = true }
+density-test = { workspace = true }
+optimization-test-functions = { workspace = true }
+pfas-custom-functions = { workspace = true }
 ado-profile-space = { path = "plugins/operators/profile_space", editable = true }
-robotic-lab = { workspace = true, editable = true }
-trim-custom-experiments = { workspace = true, editable = true }
+robotic-lab = { workspace = true }
+trim-custom-experiments = { workspace = true }
 detect-secrets = { git = "https://github.com/ibm/detect-secrets.git", rev = "master" }
 
 [tool.uv-dynamic-versioning]


### PR DESCRIPTION
## Summary

Removes redundant `editable = true` markers from workspace package entries in `pyproject.toml`. For packages already declared as `{ workspace = true }`, the `editable` flag is implicit and specifying it explicitly is unnecessary.

## High-level Changes

- **`pyproject.toml`**: Removed `editable = true` from all `[tool.uv.sources]` entries that also carry `workspace = true`. Packages referenced by path (non-workspace) are unaffected.

## Impact

No functional change. Workspace packages are always installed in editable mode by uv, so removing the explicit flag has no effect on behaviour, dependency resolution, or the development workflow. This is a housekeeping change to keep the configuration clean and aligned with uv conventions.

---

*This code and PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.*