### PR TITLE
refactor(test): move ado and run_experiment CLI tests into pytest suite

### DIFF
--- a/tests/actuators/test_run_experiment.py
+++ b/tests/actuators/test_run_experiment.py
@@ -1,0 +1,23 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""CLI tests for the run_experiment command."""
+
+import pytest
+from typer.testing import CliRunner
+
+from ado.utilities.run_experiment import app
+
+_DENSITY_POINT = "examples/density_example/point.yaml"
+_OPT_FUNCTIONS_POINT = "examples/optimization_test_functions/point.yaml"
+
+
+@pytest.mark.parametrize(
+    "point_file",
+    [_DENSITY_POINT, _OPT_FUNCTIONS_POINT],
+)
+def test_run_experiment_point_yaml_succeeds(point_file: str) -> None:
+    """run_experiment <point.yaml> must exit 0 and report a valid measurement."""
+    runner = CliRunner()
+    result = runner.invoke(app, [point_file])
+    assert result.exit_code == 0, result.output

--- a/tests/ado/describe/test_ado_describe.py
+++ b/tests/ado/describe/test_ado_describe.py
@@ -72,6 +72,20 @@ def test_describe_peptide_mineralization_experiment() -> None:
     assert "Measures adsorption of peptide lanthanide combinations" in result.output
 
 
+def test_describe_calculate_density_experiment() -> None:
+    runner = CliRunner()
+    result = runner.invoke(ado, ["describe", "experiment", "calculate_density"])
+    assert result.exit_code == 0
+    assert "calculate_density" in result.output
+
+
+def test_describe_vllm_test_deployment_experiment() -> None:
+    runner = CliRunner()
+    result = runner.invoke(ado, ["describe", "experiment", "test-deployment-v1"])
+    assert result.exit_code == 0
+    assert "test-deployment-v1" in result.output
+
+
 @requires_sqlite_3_38
 def test_describe_datacontainer_with_use_latest(
     tmp_path: pathlib.Path,

--- a/tests/ado/get/test_ado_get.py
+++ b/tests/ado/get/test_ado_get.py
@@ -79,6 +79,13 @@ def test_get_robotic_lab_actuator() -> None:
         assert rendered_output in result.output
 
 
+def test_get_vllm_performance_actuator_details() -> None:
+    runner = CliRunner()
+    result = runner.invoke(ado, ["get", "actuators", "vllm_performance", "--details"])
+    assert result.exit_code == 0
+    assert "vllm_performance" in result.output
+
+
 @requires_sqlite_3_38
 def test_field_filtering(
     tmp_path: pathlib.Path,

--- a/tests/ado/get/test_ado_get_operators.py
+++ b/tests/ado/get/test_ado_get_operators.py
@@ -1,0 +1,15 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import pytest
+from typer.testing import CliRunner
+
+from ado.cli.core.cli import app as ado
+
+
+@pytest.mark.parametrize("operator_name", ["ray_tune", "random_walk"])
+def test_get_operator(operator_name: str) -> None:
+    runner = CliRunner()
+    result = runner.invoke(ado, ["get", "operator", operator_name])
+    assert result.exit_code == 0
+    assert operator_name in result.output

--- a/tests/ado/template/test_ado_template_operation.py
+++ b/tests/ado/template/test_ado_template_operation.py
@@ -1,0 +1,17 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+import pytest
+from typer.testing import CliRunner
+
+from ado.cli.core.cli import app as ado
+
+
+@pytest.mark.parametrize("operator_name", ["ray_tune", "random_walk"])
+def test_template_operation(operator_name: str) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        ado, ["template", "operation", f"--operator-name={operator_name}"]
+    )
+    assert result.exit_code == 0, result.output
+    assert operator_name in result.output

--- a/tests/ado/template/test_ado_template_space.py
+++ b/tests/ado/template/test_ado_template_space.py
@@ -59,6 +59,32 @@ def test_template_space_from_experiment(
     assert len(space_configuration.entitySpace) == 3
 
 
+def test_template_space_from_vllm_experiment(
+    tmp_path: pathlib.Path, random_identifier: Callable[[], str]
+) -> None:
+    runner = CliRunner()
+    file_name = tmp_path / random_identifier()
+    result = runner.invoke(
+        ado,
+        [
+            "template",
+            "space",
+            "--from-experiment",
+            "test-deployment-v1",
+            "--output-file",
+            file_name,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    space_configuration = DiscoverySpaceConfiguration.model_validate(
+        yaml.safe_load(file_name.read_text())
+    )
+    assert (
+        space_configuration.experiments[0].experimentIdentifier == "test-deployment-v1"
+    )
+    assert space_configuration.experiments[0].actuatorIdentifier == "vllm_performance"
+
+
 def test_template_space_from_experiment_with_actuator_prefix(
     tmp_path: pathlib.Path, random_identifier: Callable[[], str]
 ) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -85,10 +85,6 @@ commands=
     # SFTTrainer tests (skipped on Python 3.13 and 3.14 due to compatibility issues)
     !py313-!py314: pytest -n auto --dist worksteal -rx -vv --log-level=INFO --color=yes plugins/actuators/sfttrainer/ado_actuators/sfttrainer/tests/
 
-    # Test custom experiment examples
-    ado describe experiment calculate_density
-    run_experiment examples/density_example/point.yaml
-
     # Autoconf plugin tests (skipped on Python 3.14 due to fastai/spacy compatibility issues)
     !py314: pytest -n auto --dist worksteal -rx -vv --log-level=INFO --color=yes plugins/custom_experiments/autoconf/autoconf/test/
 
@@ -99,21 +95,7 @@ commands=
     pytest -n auto --dist worksteal -rx -vv --log-level=INFO --color=yes plugins/actuators/vllm_performance/tests/
 
     # Ray Tune operator functionality tests
-    ado get operator ray_tune
-    ado template operation --operator-name=ray_tune
     pytest -n auto --dist worksteal -rx -vv --log-level=INFO --color=yes plugins/operators/ray_tune/tests/
-
-    # Random Walk operator functionality tests
-    ado get operator random_walk
-    ado template operation --operator-name=random_walk
-
-    # vLLM Performance actuator tests
-    ado get actuators vllm_performance --details
-    ado describe experiment test-deployment-v1
-    ado template space --from-experiment test-deployment-v1
-
-    # Run experiment command tests
-    run_experiment examples/optimization_test_functions/point.yaml
 
     # Cplex Custom experiment
     uv pip install plugins/custom_experiments/cplex_mip


### PR DESCRIPTION
## Summary

Migrates a collection of ad-hoc CLI smoke tests that were previously run as bare shell commands inside `tox.ini` into the pytest suite, where they can benefit from parallel execution, structured reporting, and standard pytest tooling.

## High-level Changes

- **New pytest tests added** — the CLI surface area previously covered by bare shell commands in `tox.ini` is now covered by proper pytest test cases, including `ado get`, `ado describe`, `ado template`, and `run_experiment`.
- **`tox.ini` cleaned up** — all bare `ado` and `run_experiment` shell commands that duplicated the above coverage have been removed, leaving only `pytest` invocations in the tox pipeline.

## Impact

No production code is changed; the impact is entirely on the test infrastructure. Test coverage for the `ado` and `run_experiment` CLIs is now tracked by pytest, making failures easier to diagnose (structured output, exit codes, captured stdout) and enabling parallel execution via `pytest-xdist`. The `tox.ini` is simpler and no longer mixes shell commands with pytest invocations for this surface area.

---

> **AI Disclosure** — The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.