### PR TITLE
docs: add versioned documentation publishing via mike

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ dev_addr: '127.0.0.1:8000'
 copyright: Copyright IBM Research.
 # Extra links as icons at the bottom of the page
 extra:
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/ibm/ado
@@ -126,6 +128,7 @@ markdown_extensions:
     toc_depth: 4
 plugins:
   - search:
+  - mike:
   - minify:
       minify_html: true
       minify_js: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
 ]
 docs = [
   "htmlmin>=0.1.12",
+  "mike>=2.1.2",
   "mkdocs>=1.6.1",
   "mkdocs-github-admonitions-plugin>=0.1.1",
   "mkdocs-include-markdown-plugin>=7.1.6",

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,6 @@ dependencies = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
 ]
 
 [package.metadata]
@@ -108,6 +107,7 @@ dev = [
 ]
 docs = [
     { name = "htmlmin" },
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-github-admonitions-plugin" },
     { name = "mkdocs-include-markdown-plugin" },
@@ -170,6 +170,7 @@ dev = [
 ]
 docs = [
     { name = "htmlmin", specifier = ">=0.1.12" },
+    { name = "mike", specifier = ">=2.1.2" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-github-admonitions-plugin", specifier = ">=0.1.1" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.6" },
@@ -244,7 +245,6 @@ dependencies = [
     { name = "aim" },
     { name = "jwt" },
     { name = "psutil", version = "7.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "psutil", version = "7.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "transformers" },
 ]
 
@@ -263,10 +263,8 @@ dependencies = [
     { name = "ado-core" },
     { name = "autogluon-tabular", extra = ["catboost", "xgboost"] },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "pandas" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
 ]
 
 [package.metadata]
@@ -328,11 +326,9 @@ dependencies = [
     { name = "filelock" },
     { name = "jinja2" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "psutil", version = "7.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "psutil", version = "7.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "requests" },
@@ -1832,7 +1828,6 @@ version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
@@ -4152,6 +4147,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -9094,7 +9106,6 @@ dependencies = [
     { name = "ml-dtypes" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
     { name = "psutil", version = "7.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "setuptools", marker = "python_version < '0'" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -9951,6 +9962,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/d5/8a1f8eb603e2d35fbb0ecd1e309d0c5c18a0ecfc8c0a8f04088bbc8f833b/vcrpy-8.3.0.tar.gz", hash = "sha256:46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212", size = 96117, upload-time = "2026-07-04T14:27:01.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/77/cb4219be91508399cbcb6143bad89462cfb16f6c638458f454a5d46ac95a/vcrpy-8.3.0-py3-none-any.whl", hash = "sha256:bd66e6143746778157f00e2a922527a8d96b2fdc350be8988a45a29c843815b9", size = 46530, upload-time = "2026-07-04T14:27:00.546Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds versioned documentation publishing support to the ado project by integrating [mike](https://github.com/jimporter/mike), a MkDocs plugin that manages multiple versions of a documentation site.

## High-level Changes

- **`mkdocs.yml`**: Configured `mike` as the version provider under `extra.version` and registered it in the `plugins` list.
- **`pyproject.toml`**: Added `mike>=2.1.2` to the `docs` dependency group.
- **`uv.lock`**: Lock file updated to include `mike` and its transitive dependencies.

## Impact

Documentation can now be published and served in versioned form (e.g. `1.0`, `latest`), allowing users to browse docs for specific releases without the previous content being overwritten. No changes to runtime code, APIs, or tests — this is a documentation tooling change only.

---

> **AI Disclosure**: The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.