### PR TITLE
feat(cli): add --upgrade-entities-and-results flag to upgrade command

### DIFF
--- a/ado/cli/commands/upgrade.py
+++ b/ado/cli/commands/upgrade.py
@@ -37,6 +37,17 @@ def upgrade_resource(
             metavar=f"[{'|'.join(m.value for m in AdoUpgradeSupportedResourceTypes)}]",
         ),
     ],
+    upgrade_entities_and_results: Annotated[
+        bool,
+        typer.Option(
+            "--upgrade-entities-and-results",
+            help=(
+                "Also upgrade stored entities and measurement results in each sample store. "
+                "Only applies to the samplestore resource type. "
+                "This can take a long time for large stores."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """
     Upgrade resources and contexts.
@@ -55,6 +66,7 @@ def upgrade_resource(
 
     parameters = AdoUpgradeCommandParameters(
         ado_configuration=ado_configuration,
+        upgrade_entities_and_results=upgrade_entities_and_results,
     )
 
     method_mapping = {

--- a/ado/cli/models/parameters.py
+++ b/ado/cli/models/parameters.py
@@ -137,3 +137,4 @@ class AdoTemplateCommandParameters(pydantic.BaseModel):
 
 class AdoUpgradeCommandParameters(pydantic.BaseModel):
     ado_configuration: AdoConfiguration
+    upgrade_entities_and_results: bool

--- a/ado/cli/resources/sample_store/upgrade.py
+++ b/ado/cli/resources/sample_store/upgrade.py
@@ -6,10 +6,93 @@ from ado.core import CoreResourceKinds
 
 
 def upgrade_sample_store(parameters: AdoUpgradeCommandParameters) -> None:
+    from rich.status import Status
+
+    from ado.cli.utils.generic.wrappers import get_sql_store
+    from ado.cli.utils.output.prints import (
+        ADO_SPINNER_QUERYING_DB,
+        ERROR,
+        SUCCESS,
+        console_print,
+    )
     from ado.cli.utils.resources.handlers import (
         handle_ado_upgrade,
     )
+    from ado.core.samplestore.base import (
+        FailedToDecodeStoredEntityError,
+        FailedToDecodeStoredMeasurementResultForEntityError,
+        SampleStore,
+    )
 
+    # Step 1: upgrade SampleStoreResource metastore records (unchanged behaviour).
     handle_ado_upgrade(
         parameters=parameters, resource_type=CoreResourceKinds.SAMPLESTORE
     )
+
+    if not parameters.upgrade_entities_and_results:
+        console_print(SUCCESS)
+        return
+
+    # Step 2: open each sample store and upgrade entities and results.
+    # Only runs when --upgrade-entities-and-results is passed, as it can be slow.
+    sql_store = get_sql_store(
+        project_context=parameters.ado_configuration.project_context
+    )
+
+    with Status(ADO_SPINNER_QUERYING_DB) as status:
+        resources = sql_store.getResourcesOfKind(
+            kind=CoreResourceKinds.SAMPLESTORE.value
+        )
+
+        total = len(resources)
+        for idx, resource in enumerate(resources.values()):
+            store_id = resource.identifier
+            progress = f"[{idx + 1}/{total}]"
+
+            try:
+                status.update(
+                    f"Upgrading entities in store [b cyan]{store_id}[/b cyan] {progress}"
+                )
+                store = SampleStore.from_resource(resource)
+                n_entities = store.upgrade_entities()
+
+                status.update(
+                    f"Upgrading measurement results in store [b cyan]{store_id}[/b cyan] {progress}"
+                )
+                n_results = store.upgrade_measurement_results()
+
+            except FailedToDecodeStoredEntityError as e:
+                status.stop()
+                console_print(
+                    f"{ERROR}Store [b cyan]{store_id}[/b cyan]: "
+                    f"failed to decode entity [b]{e.entity_identifier}[/b].\n"
+                    f"  Cause: {e.cause}"
+                )
+                return
+
+            except FailedToDecodeStoredMeasurementResultForEntityError as e:
+                status.stop()
+                console_print(
+                    f"{ERROR}Store [b cyan]{store_id}[/b cyan]: "
+                    f"failed to decode measurement result for entity [b]{e.entity_identifier}[/b].\n"
+                    f"  Cause: {e.cause}"
+                )
+                return
+
+            except SystemError as e:
+                status.stop()
+                console_print(
+                    f"{ERROR}Store [b cyan]{store_id}[/b cyan]: "
+                    f"unexpected row-count mismatch during upgrade.\n"
+                    f"  Cause: {e}"
+                )
+                return
+
+            status.stop()
+            console_print(
+                f"  {progress} Store [b cyan]{store_id}[/b cyan]: "
+                f"upgraded {n_entities} entities, {n_results} measurement results"
+            )
+            status.start()
+
+    console_print(SUCCESS)

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -1013,6 +1013,73 @@ class SQLSampleStore(ActiveSampleStore):
                     f"Failed to insert entity batch starting from {index}. Error: {error}"
                 ) from error
 
+    def upgrade_entities(self) -> int:
+        """Re-serialize all entity rows through the current Pydantic model in a single atomic UPDATE.
+
+        Returns:
+            Number of entity rows upgraded.
+
+        Raises:
+            FailedToDecodeStoredEntityError: If any entity cannot be deserialized.
+            SystemError: If the SQL UPDATE does not match the expected row count.
+        """
+        from sqlalchemy import select
+
+        entity_table = self._metadata.tables[self._tablename]
+        stmt = select(entity_table.c.identifier, entity_table.c.representation)
+
+        with self.engine.begin() as conn:
+            rows = list(conn.execute(stmt))
+            expected_count = len(rows)
+            if expected_count == 0:
+                return 0
+
+            values = []
+            for entity_identifier, entity_representation in rows:
+                try:
+                    entity = Entity.model_validate(json.loads(entity_representation))
+                except Exception as error:
+                    raise FailedToDecodeStoredEntityError(
+                        entity_identifier=entity_identifier,
+                        entity_representation=entity_representation,
+                        cause=error,
+                    ) from error
+                values.append(
+                    {
+                        "identifier": entity_identifier,
+                        "representation": entity.model_dump_json(
+                            exclude_defaults=True, exclude={"measurement_results"}
+                        ),
+                    }
+                )
+
+            # b_ prefix avoids a name collision: SQLAlchemy uses column names as
+            # implicit bind parameters in the executemany VALUES clause, so the
+            # explicit WHERE-clause parameters need distinct names.
+            result = conn.execute(
+                entity_table.update()
+                .where(
+                    entity_table.c.identifier == sqlalchemy.bindparam("b_identifier")
+                )
+                .values(representation=sqlalchemy.bindparam("b_representation")),
+                [
+                    {
+                        "b_identifier": v["identifier"],
+                        "b_representation": v["representation"],
+                    }
+                    for v in values
+                ],
+            )
+
+        if result.rowcount != expected_count:
+            raise SystemError(
+                f"upgrade_entities: expected to update {expected_count} rows "
+                f"but updated {result.rowcount}"
+            )
+
+        self.log.debug(f"upgrade_entities: upgraded {expected_count} entity rows")
+        return expected_count
+
     def add_external_entities(self, entities: list[Entity]) -> None:
 
         existing_entity_ids = self.entity_identifiers()
@@ -1341,6 +1408,73 @@ class SQLSampleStore(ActiveSampleStore):
             return
 
         self.add_relationship_between_request_and_results(request_db_id, results)
+
+    def upgrade_measurement_results(self) -> int:
+        """Re-serialize all measurement result rows through the current Pydantic model in a single atomic UPDATE.
+
+        Returns:
+            Number of measurement result rows upgraded.
+
+        Raises:
+            FailedToDecodeStoredMeasurementResultForEntityError: If any result
+                cannot be deserialized.
+            SystemError: If the SQL UPDATE does not match the expected row count.
+        """
+        from sqlalchemy import select
+
+        res_table = self._result_table
+        stmt = select(res_table.c.uid, res_table.c.data)
+
+        with self.engine.begin() as conn:
+            rows = list(conn.execute(stmt))
+            expected_count = len(rows)
+            if expected_count == 0:
+                return 0
+
+            values = []
+            for uid, result_data in rows:
+                try:
+                    if "reason" in result_data:
+                        measurement_result = InvalidMeasurementResult.model_validate(
+                            result_data
+                        )
+                    else:
+                        measurement_result = ValidMeasurementResult.model_validate(
+                            result_data
+                        )
+                except Exception as error:
+                    raise FailedToDecodeStoredMeasurementResultForEntityError(
+                        entity_identifier=result_data.get("entityIdentifier", uid),
+                        result_representation=result_data,
+                        cause=error,
+                    ) from error
+                values.append(
+                    {
+                        "uid": uid,
+                        "data": json.loads(measurement_result.model_dump_json()),
+                    }
+                )
+
+            # b_ prefix avoids a name collision: SQLAlchemy uses column names as
+            # implicit bind parameters in the executemany VALUES clause, so the
+            # explicit WHERE-clause parameters need distinct names.
+            result = conn.execute(
+                res_table.update()
+                .where(res_table.c.uid == sqlalchemy.bindparam("b_uid"))
+                .values(data=sqlalchemy.bindparam("b_data")),
+                [{"b_uid": v["uid"], "b_data": v["data"]} for v in values],
+            )
+
+        if result.rowcount != expected_count:
+            raise SystemError(
+                f"upgrade_measurement_results: expected to update {expected_count} rows "
+                f"but updated {result.rowcount}"
+            )
+
+        self.log.debug(
+            f"upgrade_measurement_results: upgraded {expected_count} result rows"
+        )
+        return expected_count
 
     def add_relationship_between_request_and_results(
         self,

--- a/ado/metastore/sqlstore.py
+++ b/ado/metastore/sqlstore.py
@@ -1197,12 +1197,8 @@ class SQLResourceStore(ResourceStore):
             try:
                 with session.begin():
                     session.execute(
-                        sqlalchemy.text(f"DROP TABLE sqlsource_{identifier}")
-                    )
-
-                    session.execute(
                         sqlalchemy.text(
-                            f"DROP TABLE sqlsource_{identifier}_measurement_requests"
+                            f"DROP TABLE sqlsource_{identifier}_measurement_requests_results"
                         )
                     )
 
@@ -1214,8 +1210,12 @@ class SQLResourceStore(ResourceStore):
 
                     session.execute(
                         sqlalchemy.text(
-                            f"DROP TABLE sqlsource_{identifier}_measurement_requests_results"
+                            f"DROP TABLE sqlsource_{identifier}_measurement_requests"
                         )
+                    )
+
+                    session.execute(
+                        sqlalchemy.text(f"DROP TABLE sqlsource_{identifier}")
                     )
             except Exception as e:
                 session.rollback()

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -1397,7 +1397,7 @@ When required, you can run this command to update all resources of a given kind
 in the database.
 
 ```shell
-ado upgrade RESOURCE_TYPE
+ado upgrade RESOURCE_TYPE [--upgrade-entities-and-results]
 ```
 
 Where:
@@ -1416,12 +1416,30 @@ Where:
 
     <!-- prettier-ignore-end -->
 
+- `--upgrade-entities-and-results` is an **optional** flag, only applicable to
+  `samplestore`. When passed, also upgrades stored entities and measurement
+  results in each sample store. Omit this flag for a fast metadata-only upgrade;
+  pass it only when entity or measurement result schemas have changed, as it can
+  take a long time for large stores.
+
 ### Examples
 
 #### Upgrade all operation resources
 
 ```shell
 ado upgrade operations
+```
+
+#### Upgrade all sample store resources (metadata only)
+
+```shell
+ado upgrade samplestores
+```
+
+#### Upgrade all sample store resources including entities and measurement results
+
+```shell
+ado upgrade samplestores --upgrade-entities-and-results
 ```
 
 ## ado version

--- a/tests/samplestore/test_upgrade.py
+++ b/tests/samplestore/test_upgrade.py
@@ -1,0 +1,210 @@
+# Copyright IBM Corporation 2025, 2026
+# SPDX-License-Identifier: MIT
+
+"""Tests for SQLSampleStore.upgrade_entities() and upgrade_measurement_results()."""
+
+import json
+import uuid
+from collections.abc import Callable
+
+import sqlalchemy
+
+from ado.core.samplestore.sql import SQLSampleStore
+from ado.schema.entity import Entity
+from ado.schema.result import (
+    InvalidMeasurementResult,
+    MeasurementResultStateEnum,
+    ValidMeasurementResult,
+)
+
+
+def test_upgrade_entities_round_trips_and_returns_count(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """upgrade_entities() rewrites entity rows and returns the correct count."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(3)
+    add_entities_to_sample_store(store, entities)
+
+    entity_table = store._metadata.tables[store._tablename]
+    target = entities[0]
+
+    # Overwrite the stored representation with model_dump_json() WITHOUT
+    # exclude_defaults=True.  This includes "measurement_results": []  and
+    # every other default field. After upgrade the row should match the
+    # canonical form produced by model_dump_json(exclude_defaults=True,
+    # exclude={"measurement_results"}).
+    pre_upgrade_json = target.model_dump_json()
+    with store.engine.begin() as conn:
+        conn.execute(
+            entity_table.update()
+            .where(entity_table.c.identifier == target.identifier)
+            .values(representation=pre_upgrade_json)
+        )
+
+    # Verify pre-upgrade state contains default/excluded fields
+    with store.engine.begin() as conn:
+        row = conn.execute(
+            sqlalchemy.select(entity_table.c.representation).where(
+                entity_table.c.identifier == target.identifier
+            )
+        ).fetchone()
+    pre = json.loads(row[0])
+    # model_dump_json() without exclude_defaults includes measurement_results
+    assert "measurement_results" in pre
+
+    # Run upgrade
+    count = store.upgrade_entities()
+    assert count == 3
+
+    # Verify the row now matches the canonical Pydantic serialisation
+    with store.engine.begin() as conn:
+        row = conn.execute(
+            sqlalchemy.select(entity_table.c.representation).where(
+                entity_table.c.identifier == target.identifier
+            )
+        ).fetchone()
+    post = json.loads(row[0])
+    expected = json.loads(
+        target.model_dump_json(exclude_defaults=True, exclude={"measurement_results"})
+    )
+    assert post == expected
+    # measurement_results excluded from the canonical form
+    assert "measurement_results" not in post
+
+
+def test_upgrade_entities_empty_store_returns_zero(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+) -> None:
+    """upgrade_entities() on an empty store returns 0."""
+    store = random_sql_sample_store()
+    count = store.upgrade_entities()
+    assert count == 0
+
+
+def _make_old_format_result(entity_identifier: str) -> dict:
+    """Build the old (uncompressed) ValidMeasurementResult wire format.
+
+    In the old format each ObservedPropertyValue contains the full
+    experimentReference inside its property dict. The new compressed format
+    stores experimentReference once at the top level.
+    """
+    exp_ref = {
+        "experimentIdentifier": "benchmark_performance",
+        "actuatorIdentifier": "replay",
+    }
+    measurement = {
+        "value": 0.42,
+        "property": {
+            "targetProperty": {"identifier": "wallClockRuntime"},
+            "experimentReference": exp_ref,  # OLD: redundant per measurement
+        },
+    }
+    return {
+        "uid": str(uuid.uuid4()),
+        "entityIdentifier": entity_identifier,
+        "measurements": [measurement],
+        # OLD format: no top-level experimentReference
+    }
+
+
+def test_upgrade_measurement_results_compresses_old_format(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """upgrade_measurement_results() re-serializes old-format rows to compressed format."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(1)
+    add_entities_to_sample_store(store, entities)
+    entity = entities[0]
+
+    # Insert an old-format result row directly via SQL.
+    res_table = store._result_table
+    old_data = _make_old_format_result(entity.identifier)
+    with store.engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.insert(res_table).values(
+                uid=old_data["uid"],
+                entity_id=entity.identifier,
+                data=old_data,
+            )
+        )
+
+    # Verify it is stored in old format (experimentReference inside each measurement's property)
+    with store.engine.begin() as conn:
+        row = conn.execute(
+            sqlalchemy.select(res_table.c.data).where(
+                res_table.c.uid == old_data["uid"]
+            )
+        ).fetchone()
+    stored_before = row[0]
+    assert "experimentReference" in stored_before["measurements"][0]["property"]
+    assert "experimentReference" not in stored_before  # not at top level yet
+
+    # Run upgrade
+    count = store.upgrade_measurement_results()
+    assert count == 1
+
+    # Verify the row is now in the new compressed format
+    with store.engine.begin() as conn:
+        row = conn.execute(
+            sqlalchemy.select(res_table.c.data).where(
+                res_table.c.uid == old_data["uid"]
+            )
+        ).fetchone()
+    stored_after = row[0]
+
+    # New format: experimentReference at top level
+    assert "experimentReference" in stored_after
+    # New format: measurements should NOT contain redundant experimentReference
+    assert "experimentReference" not in stored_after["measurements"][0]["property"]
+
+
+def test_upgrade_measurement_results_empty_store_returns_zero(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+) -> None:
+    """upgrade_measurement_results() on an empty store returns 0."""
+    store = random_sql_sample_store()
+    count = store.upgrade_measurement_results()
+    assert count == 0
+
+
+def test_upgrade_measurement_results_preserves_invalid_results(
+    random_sql_sample_store: Callable[[], SQLSampleStore],
+    random_ml_multi_cloud_benchmark_performance_entities: Callable[[int], list[Entity]],
+    random_ml_multi_cloud_benchmark_performance_measurement_results: Callable[
+        [Entity, int, MeasurementResultStateEnum | None],
+        ValidMeasurementResult | InvalidMeasurementResult,
+    ],
+    add_entities_to_sample_store: Callable[[SQLSampleStore, list[Entity]], None],
+) -> None:
+    """upgrade_measurement_results() correctly handles InvalidMeasurementResult rows."""
+    store = random_sql_sample_store()
+    entities = random_ml_multi_cloud_benchmark_performance_entities(1)
+    add_entities_to_sample_store(store, entities)
+    entity = entities[0]
+
+    result = random_ml_multi_cloud_benchmark_performance_measurement_results(
+        entity, 1, MeasurementResultStateEnum.INVALID
+    )
+    assert isinstance(result, InvalidMeasurementResult)
+
+    store.add_measurement_results([result], skip_relationship_to_request=True)
+
+    count = store.upgrade_measurement_results()
+    assert count == 1
+
+    # Verify the row can still be deserialized as InvalidMeasurementResult
+    res_table = store._result_table
+    with store.engine.begin() as conn:
+        row = conn.execute(
+            sqlalchemy.select(res_table.c.data).where(res_table.c.uid == result.uid)
+        ).fetchone()
+    stored = row[0]
+    assert "reason" in stored
+    reloaded = InvalidMeasurementResult.model_validate(stored)
+    assert reloaded.reason == result.reason
+    assert reloaded.entityIdentifier == entity.identifier


### PR DESCRIPTION
## Summary

Adds a new `--upgrade-entities-and-results` flag to the `ado upgrade` command that, when passed for the `samplestore` resource type, re-serialises all stored entities and measurement results through the current Pydantic models. Without the flag, the existing fast metadata-only upgrade behaviour is unchanged.

## High-level Changes

- **New CLI flag**: `ado upgrade samplestores --upgrade-entities-and-results` triggers a deeper upgrade of stored data in addition to the standard metadata upgrade.
- **New upgrade methods on `SQLSampleStore`**: Two new methods re-serialise entity rows and measurement result rows atomically via SQL bulk updates, migrating data from older formats (e.g. uncompressed `experimentReference` placement) to the current canonical form.
- **Bug fix in sample store deletion**: The table drop order during sample store deletion has been corrected to avoid FK/dependency errors.
- **Documentation**: The CLI reference is updated with descriptions and examples for the new flag.
- **Tests**: A new test file covers round-trip upgrades, empty-store edge cases, old-format migration, and handling of invalid measurement results.

## Impact

Only `ado upgrade samplestores` is affected. Existing behaviour without the new flag is unchanged. Users with large sample stores should expect the `--upgrade-entities-and-results` upgrade to take a significant amount of time proportional to the number of stored entities and results. No schema or API changes affect other resource types.

---

> **AI Disclosure**: The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.