### PR TITLE
fix(core): derive experiment reference from result data instead of dedicated column

### DIFF
--- a/ado/core/samplestore/orm/measurements_filtering.py
+++ b/ado/core/samplestore/orm/measurements_filtering.py
@@ -24,7 +24,6 @@ MEASUREMENT_REQUEST_COLUMN_MAPPINGS = {
     "status": "status",
     "timestamp": "timestamp",
     "type": "type",
-    "experimentReference": "experiment_reference",
 }
 
 # Direct column mappings for measurement results

--- a/ado/core/samplestore/sql.py
+++ b/ado/core/samplestore/sql.py
@@ -279,7 +279,9 @@ class SQLSampleStore(ActiveSampleStore):
                 "insert_id", Integer, primary_key=True, autoincrement=True
             ),
             sqlalchemy.Column("uid", CHAR(36), nullable=False, unique=True, index=True),
-            sqlalchemy.Column("experiment_reference", Text(3145728), nullable=False),
+            sqlalchemy.Column(
+                "experiment_reference", Text(length=3145728), nullable=False
+            ),
             sqlalchemy.Column("operation_id", String(256), nullable=False),
             sqlalchemy.Column("request_index", Integer, nullable=False),
             sqlalchemy.Column("request_id", String(256), nullable=False),
@@ -1515,7 +1517,6 @@ class SQLSampleStore(ActiveSampleStore):
     def measurement_requests_count_for_operation(
         self,
         operation_id: str,
-        experiment_filter: str | None = None,
         status_filter: MeasurementRequestStateEnum | None = None,
     ) -> int:
 
@@ -1530,10 +1531,6 @@ class SQLSampleStore(ActiveSampleStore):
             query_text += "AND status = :status_filter "
             query_parameters["status_filter"] = status_filter.value
 
-        if experiment_filter:
-            query_text += "AND experiment_reference = :experiment_filter "
-            query_parameters["experiment_filter"] = experiment_filter
-
         try:
             with self.engine.begin() as connectable:
                 query = sqlalchemy.text(query_text).bindparams(**query_parameters)
@@ -1546,7 +1543,6 @@ class SQLSampleStore(ActiveSampleStore):
     def measurement_results_count_for_operation(
         self,
         operation_id: str,
-        experiment_filter: str | None = None,
         status_filter: MeasurementResultStateEnum | None = None,
     ) -> int:
         result_state_map = {
@@ -1560,10 +1556,6 @@ class SQLSampleStore(ActiveSampleStore):
                         FROM {self._tablename}_measurement_requests
                         WHERE operation_id = :operation_id
                         """  # noqa: S608 - self._tablename is not untrusted
-
-        if experiment_filter:
-            inner_query += "AND experiment_reference = :experiment_filter"
-            query_parameters["experiment_filter"] = experiment_filter
 
         query_text = f"""
                         SELECT COUNT(uid)
@@ -1893,9 +1885,11 @@ class SQLSampleStore(ActiveSampleStore):
     def samplestore_statistics(self) -> "SampleStoreStatistics":
         """Compute aggregate statistics for this sample store in a single query.
 
-        Issues exactly one query that returns three scalar counts via subqueries:
-        total entities, total measurement results, and distinct experiment
-        references.
+        Issues two queries: the first returns entity and result counts; the
+        second fetches DISTINCT experiment-reference JSON blobs from the results
+        table. Python then deduplicates them via ``ExperimentReference.__eq__``
+        / ``__hash__`` because doing so purely in SQL would be fragile and
+        dialect-specific.
 
         Returns:
             A :class:`~ado.core.samplestore.stats.SampleStoreStatistics`
@@ -1909,7 +1903,6 @@ class SQLSampleStore(ActiveSampleStore):
         from ado.core.samplestore.stats import SampleStoreStatistics
 
         entity_table = self._metadata.tables[self._tablename]
-        req_table = self._request_table
         res_table = self._result_table
 
         # Equivalent SQL:
@@ -1918,9 +1911,7 @@ class SQLSampleStore(ActiveSampleStore):
         #     (SELECT COUNT(identifier)
         #        FROM sqlsource_{id})                              AS number_of_entities,
         #     (SELECT COUNT(uid)
-        #        FROM sqlsource_{id}_measurement_results)          AS number_of_results,
-        #     (SELECT COUNT(DISTINCT experiment_reference)
-        #        FROM sqlsource_{id}_measurement_requests)         AS number_of_experiments
+        #        FROM sqlsource_{id}_measurement_results)          AS number_of_results
 
         stmt = select(
             select(func.count(entity_table.c.identifier))
@@ -1929,19 +1920,38 @@ class SQLSampleStore(ActiveSampleStore):
             select(func.count(res_table.c.uid))
             .scalar_subquery()
             .label("number_of_results"),
-            select(func.count(func.distinct(req_table.c.experiment_reference)))
-            .scalar_subquery()
-            .label("number_of_experiments"),
         )
+
+        # Fetch DISTINCT experiment-reference JSON blobs from results.
+        # DB-level DISTINCT collapses exact-version duplicates cheaply; Python
+        # then deduplicates by major-version hash via ExperimentReference.__hash__.
+        exp_ref_json = func.coalesce(
+            func.json_extract(res_table.c.data, "$.experimentReference"),
+            func.json_extract(
+                res_table.c.data,
+                "$.measurements[0].property.experimentReference",
+            ),
+        )
+        distinct_exp_ref_stmt = select(exp_ref_json).select_from(res_table).distinct()
 
         try:
             with self.engine.begin() as connectable:
-                row = connectable.execute(stmt).one()
-                return SampleStoreStatistics(
-                    number_of_entities=row.number_of_entities or 0,
-                    number_of_results=row.number_of_results or 0,
-                    number_of_experiments=row.number_of_experiments or 0,
-                )
+                counts_row = connectable.execute(stmt).one()
+                distinct_exp_ref_rows = connectable.execute(
+                    distinct_exp_ref_stmt
+                ).fetchall()
+
+            distinct_exp_refs = {
+                ExperimentReference.model_validate_json(exp_ref_json_blob)
+                for (exp_ref_json_blob,) in distinct_exp_ref_rows
+                if exp_ref_json_blob is not None
+            }
+
+            return SampleStoreStatistics(
+                number_of_entities=counts_row.number_of_entities or 0,
+                number_of_results=counts_row.number_of_results or 0,
+                number_of_experiments=len(distinct_exp_refs),
+            )
         except SQLAlchemyError as error:
             msg = f"Unable to get statistics for sample store {self._tablename}"
             self.log.critical(f"{msg}. Error: {error}")
@@ -1977,10 +1987,18 @@ class SQLSampleStore(ActiveSampleStore):
             reqres_table = self._request_result_table
             res_table = self._result_table
 
+            from sqlalchemy import func
+
             stmt = (
                 select(
                     req_table.c.uid,
-                    req_table.c.experiment_reference,
+                    func.coalesce(
+                        func.json_extract(res_table.c.data, "$.experimentReference"),
+                        func.json_extract(
+                            res_table.c.data,
+                            "$.measurements[0].property.experimentReference",
+                        ),
+                    ).label("experiment_reference"),
                     req_table.c.operation_id,
                     req_table.c.request_index,
                     req_table.c.request_id,
@@ -2046,25 +2064,47 @@ class SQLSampleStore(ActiveSampleStore):
     def measurement_request_by_id(
         self, measurement_request_id: str
     ) -> MeasurementRequest:
+        from sqlalchemy import func, select
+
+        req_table = self._request_table
+        reqres_table = self._request_result_table
+        res_table = self._result_table
+
+        stmt = (
+            select(
+                req_table.c.uid,
+                func.coalesce(
+                    func.json_extract(res_table.c.data, "$.experimentReference"),
+                    func.json_extract(
+                        res_table.c.data,
+                        "$.measurements[0].property.experimentReference",
+                    ),
+                ).label("experiment_reference"),
+                req_table.c.operation_id,
+                req_table.c.request_index,
+                req_table.c.request_id,
+                req_table.c.type,
+                req_table.c.status,
+                req_table.c.metadata,
+                req_table.c.timestamp,
+                res_table.c.entity_id,
+                res_table.c.data,
+            )
+            .select_from(req_table)
+            .join(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
+            .join(res_table, reqres_table.c.result_uid == res_table.c.uid)
+            .where(req_table.c.request_id == measurement_request_id)
+            .order_by(
+                req_table.c.request_index,
+                req_table.c.insert_id,
+                reqres_table.c.entity_index,
+                reqres_table.c.insert_id,
+            )
+        )
 
         try:
             with self.engine.begin() as connectable:
-                query = sqlalchemy.text(f"""
-                    SELECT req.uid, req.experiment_reference, req.operation_id,
-                           req.request_index, req.request_id, req.type, req.status,
-                           req.metadata, req.timestamp, res.entity_id, res.data
-                    FROM (
-                        SELECT *
-                        FROM {self._tablename}_measurement_requests
-                        WHERE request_id = :measurement_request_id
-                    ) req
-                    JOIN {self._tablename}_measurement_requests_results reqres ON reqres.request_uid = req.uid
-                    JOIN {self._tablename}_measurement_results res ON reqres.result_uid = res.uid
-                    ORDER BY req.request_index, req.insert_id , reqres.entity_index , reqres.insert_id
-                    """).bindparams(  # noqa: S608 - self._tablename is not untrusted
-                    measurement_request_id=measurement_request_id
-                )
-                cur = connectable.execute(query)
+                cur = connectable.execute(stmt)
         except SQLAlchemyError as error:
             msg = f"Unable to get the measurement request for measurement request id {measurement_request_id}"
             self.log.critical(f"{msg}. Error: {error}")
@@ -2223,9 +2263,13 @@ class SQLSampleStore(ActiveSampleStore):
                 continue
 
             #
+            if experiment_reference is None:
+                raise ValueError(
+                    f"Missing experiment reference JSON for measurement request uid={uid}"
+                )
             if request_type == ReplayedMeasurement.__name__:
                 request = ReplayedMeasurement(
-                    experimentReference=ExperimentReference.referenceFromString(
+                    experimentReference=ExperimentReference.model_validate_json(
                         experiment_reference
                     ),
                     entities=[entity],
@@ -2238,7 +2282,7 @@ class SQLSampleStore(ActiveSampleStore):
                 )
             else:
                 request = MeasurementRequest(
-                    experimentReference=ExperimentReference.referenceFromString(
+                    experimentReference=ExperimentReference.model_validate_json(
                         experiment_reference
                     ),
                     entities=[entity],
@@ -2259,26 +2303,48 @@ class SQLSampleStore(ActiveSampleStore):
         return list(entries.values())
 
     def experiments_in_operation(self, operation_id: str) -> list[Experiment]:
+        from sqlalchemy import func, select
+
+        req_table = self._request_table
+        reqres_table = self._request_result_table
+        res_table = self._result_table
+
+        exp_ref_json = func.coalesce(
+            func.json_extract(res_table.c.data, "$.experimentReference"),
+            func.json_extract(
+                res_table.c.data,
+                "$.measurements[0].property.experimentReference",
+            ),
+        ).label("experiment_reference_json")
+
+        distinct_exp_ref_stmt = (
+            select(exp_ref_json)
+            .select_from(req_table)
+            .join(reqres_table, reqres_table.c.request_uid == req_table.c.uid)
+            .join(res_table, reqres_table.c.result_uid == res_table.c.uid)
+            .where(req_table.c.operation_id == operation_id)
+            .distinct()
+        )
+
         try:
             with self.engine.begin() as connectable:
-                query = sqlalchemy.text(f"""
-                    SELECT DISTINCT(experiment_reference)
-                    FROM {self._tablename}_measurement_requests
-                    WHERE operation_id = :operation_id
-                    """).bindparams(  # noqa: S608 - self._tablename is not untrusted
-                    operation_id=operation_id
-                )
-                cur = connectable.execute(query)
+                distinct_exp_ref_rows = connectable.execute(
+                    distinct_exp_ref_stmt
+                ).fetchall()
         except SQLAlchemyError as error:
             msg = f"Unable to get the experiments for operation {operation_id}"
             self.log.critical(f"{msg}. Error: {error}")
             raise SystemError(f"{msg}. Error: {error}") from error
 
+        distinct_exp_refs = {
+            ExperimentReference.model_validate_json(row.experiment_reference_json)
+            for row in distinct_exp_ref_rows
+            if row.experiment_reference_json is not None
+        }
+
         return [
-            self.experimentCatalog().experimentForReference(
-                ExperimentReference.referenceFromString(e[0])
-            )
-            for e in cur
+            self.experimentCatalog().experimentForReference(ref)
+            for ref in distinct_exp_refs
         ]
 
     def entity_identifiers_in_operations(

--- a/tests/samplestore/test_samplestore_stats.py
+++ b/tests/samplestore/test_samplestore_stats.py
@@ -34,11 +34,14 @@ def test_samplestore_statistics_reflect_simulation(
     """After a simulation the result count increases by number_entities * number_requests.
 
     The ml_multi_cloud store is pre-seeded from the CSV fixture (entities and
-    results are already present, but no experiment references).  We snapshot
-    the store before the simulation to capture that baseline, then assert:
+    results are already present).  The simulation uses the same experiment
+    (benchmark_performance@replay) that is already present in the pre-seeded
+    results, so the number_of_experiments count is unchanged after the
+    simulation.  We snapshot the store before the simulation to capture that
+    baseline, then assert:
     - the result delta equals number_entities * number_requests
-    - number_of_experiments grows by exactly 1, because all requests share
-      the same experiment_reference (deduplication).
+    - number_of_experiments is unchanged, because the simulation's experiment
+      was already counted in the pre-seeded store (major-version deduplication).
     """
     number_entities = 3
     number_requests = 4
@@ -58,8 +61,8 @@ def test_samplestore_statistics_reflect_simulation(
         == number_entities * number_requests
     )
 
-    # All requests share the same experiment_reference, so number_of_experiments
-    # grows by exactly 1 regardless of how many requests were made
+    # The simulation uses benchmark_performance@replay, which is already in the
+    # pre-seeded CSV results, so number_of_experiments stays the same.
     experiment_refs = {str(r.experimentReference) for r in requests}
     assert len(experiment_refs) == 1
-    assert after.number_of_experiments == before.number_of_experiments + 1
+    assert after.number_of_experiments == before.number_of_experiments


### PR DESCRIPTION
## Summary

Removes the dependency on the `experiment_reference` denormalised column in the measurement-requests table for deriving experiment context. The experiment reference is now read directly from the JSON payload stored in the measurement-results table, using SQLAlchemy ORM expressions instead of raw SQL strings where applicable.

## High-level Changes

- **Experiment reference sourced from result data**: Queries that previously read `experiment_reference` from the requests table now extract it via `JSON_EXTRACT` on the results table, with a fallback path for the legacy nested format. Python-side deduplication (`ExperimentReference.__hash__`) replaces the previous `COUNT(DISTINCT experiment_reference)` SQL aggregation.
- **`experiment_filter` parameter removed**: The `experiment_reference` column is no longer used as a filter in `measurement_requests_count_for_operation` and `measurement_results_count_for_operation`, so the `experiment_filter` argument has been dropped from both methods.
- **`experimentReference` column mapping removed**: The `experimentReference` → `experiment_reference` entry has been removed from `MEASUREMENT_REQUEST_COLUMN_MAPPINGS` in the filtering layer.
- **Raw SQL replaced with ORM in `measurement_request_by_id`**: The hand-written SQL string for fetching a single request by ID has been replaced with an equivalent SQLAlchemy `select()` statement.
- **`samplestore_statistics` updated**: Now issues two queries instead of one; the second fetches distinct experiment-reference JSON blobs from the results table, and Python deduplicates them by major version.
- **Test updated**: The stats test now reflects that a simulation using an already-present experiment leaves `number_of_experiments` unchanged rather than incrementing it by one.

## Impact

Read paths that surface experiment information — statistics, request lookups, and the experiments-in-operation query — will derive that information from result payloads rather than the requests table. No schema migration is required for existing data as long as results contain the expected JSON fields. The `experiment_filter` parameter is a breaking change for any callers of the two count methods.

---

*The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.*