### PR TITLE
refactor(core): remove mistyped property value workaround

### DIFF
--- a/ado/schema/property_value.py
+++ b/ado/schema/property_value.py
@@ -93,23 +93,10 @@ class PropertyValue(pydantic.BaseModel):
         valueType = context.data.get("valueType")
         if valueType:
             if valueType == ValueTypeEnum.NUMERIC_VALUE_TYPE:
-                if isinstance(value, str):
-                    import logging
-
-                    logger = logging.getLogger()
-                    logger.warning(
-                        f"TEMP: Detected string value, {value}, assigned NUMERIC_TYPE assuming due to prior bug. Will upgrade"
+                if type(value) not in {float, int} and value is not None:
+                    raise ValueError(
+                        f"ValueType was numeric but value was of type {type(value)}"
                     )
-                elif isinstance(value, list):
-                    import logging
-
-                    logger = logging.getLogger()
-                    logger.warning(
-                        f"TEMP: Detected list value, {value}, assigned NUMERIC_TYPE assuming due to prior bug. Will upgrade"
-                    )
-                else:
-                    if type(value) not in {float, int} and value is not None:
-                        raise ValueError("Validation failed for NUMERIC_VALUE_TYPE")
             elif valueType == ValueTypeEnum.STRING_VALUE_TYPE:
                 if not isinstance(value, str):
                     raise ValueError(
@@ -155,17 +142,6 @@ class PropertyValue(pydantic.BaseModel):
                 self.valueType = ValueTypeEnum.BLOB_VALUE_TYPE
             elif isinstance(self.value, list):
                 self.valueType = ValueTypeEnum.VECTOR_VALUE_TYPE
-        elif self.valueType == ValueTypeEnum.NUMERIC_VALUE_TYPE and isinstance(
-            self.value, str
-        ):
-            # TEMPORARY
-            self.valueType = ValueTypeEnum.STRING_VALUE_TYPE
-        elif self.valueType == ValueTypeEnum.NUMERIC_VALUE_TYPE and isinstance(
-            self.value, list
-        ):
-            # TEMPORARY
-            self.valueType = ValueTypeEnum.VECTOR_VALUE_TYPE
-
         return self
 
     def __str__(self) -> str:

--- a/tests/schema/test_property_value.py
+++ b/tests/schema/test_property_value.py
@@ -142,30 +142,16 @@ def test_property_value_checks_value_type(
     # Values with the same type are fine, values of different types should fail
     test_type, test_value = test_value_example
     if test_type is not example_type:
-        # Due to a bug, as a temp measure special behaviour has been enabled
-        # Because it is temporary, we xfail it.
-        # This indicates it should fail but currently is being allows
-        #
-        # Passing str value with NUMERIC_VALUE_TYPE will change it to STRING_VALUE_TYPE
-        if type(test_value) is str and example_type is ValueTypeEnum.NUMERIC_VALUE_TYPE:
-            ConstitutivePropertyValue(
-                value=test_value, property=prop.descriptor(), valueType=example_type
-            )
-            pytest.xfail(
-                "Automatically changing value type from NUMERIC_VALUE_TYPE to STRING_VALUE_TYPE to match string value."
-                " This is being allowed temporarily but should fail"
-            )
-        elif (
+        if (
+            type(test_value) is str and example_type is ValueTypeEnum.NUMERIC_VALUE_TYPE
+        ) or (
             type(test_value) is list
             and example_type is ValueTypeEnum.NUMERIC_VALUE_TYPE
         ):
-            ConstitutivePropertyValue(
-                value=test_value, property=prop.descriptor(), valueType=example_type
-            )
-            pytest.xfail(
-                "Automatically changing value type from NUMERIC_VALUE_TYPE to VECTOR_VALUE_TYPE to match list value."
-                " This is being allowed temporarily but should fail"
-            )
+            with pytest.raises(pydantic.ValidationError):
+                ConstitutivePropertyValue(
+                    value=test_value, property=prop.descriptor(), valueType=example_type
+                )
         elif type(test_value) is str and example_type is ValueTypeEnum.BLOB_VALUE_TYPE:
             # strings with BLOB_VALUE_TYPE are ALLOWED to be converted to bytes
             # i.e. this is not the same case as previous two


### PR DESCRIPTION
## Summary

Removes a temporary workaround that silently coerced mistyped `PropertyValue` instances — where a `string` or `list` value was stored with `NUMERIC_VALUE_TYPE` — into the correct type. Instead, passing a mismatched value now raises a hard validation error, enforcing strict type correctness.

Closes #367 

## High-level Changes

- **`ado/schema/property_value.py`**: Removed the `TEMP` warning log paths and silent type-coercion logic that automatically upgraded `NUMERIC_VALUE_TYPE` values typed as `str` or `list` to `STRING_VALUE_TYPE` or `VECTOR_VALUE_TYPE` respectively. Validation now raises a `ValueError` with a descriptive message when the value type does not match the declared `valueType`.
- **`tests/schema/test_property_value.py`**: Replaced the `pytest.xfail` markers (which documented the previously tolerated misbehaviour) with `pytest.raises(pydantic.ValidationError)` assertions, confirming the cases now correctly fail.

## Impact

Any `PropertyValue` instances that were previously persisted or created with a `NUMERIC_VALUE_TYPE` label but holding a `str` or `list` value can no longer be loaded or constructed. This is a **breaking change** for any data that relied on the old silent coercion; such records would need to be corrected at the source to carry the right `valueType`. All other value-type combinations are unaffected.

---

> **AI Disclosure**: The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and were reviewed manually.