### PR TITLE
feat(cli): minify property domain in template space

### DIFF
--- a/ado/cli/resources/discovery_space/template.py
+++ b/ado/cli/resources/discovery_space/template.py
@@ -53,6 +53,8 @@ def template_discovery_space(parameters: AdoTemplateCommandParameters) -> None:
     serialise_pydantic_model(
         model=model_instance,
         output_path=parameters.output_file,
+        exclude_none=True,
+        context={"minimize_output": True},
     )
 
     if parameters.include_schema:

--- a/ado/cli/utils/pydantic/serializers.py
+++ b/ado/cli/utils/pydantic/serializers.py
@@ -13,10 +13,20 @@ def serialise_pydantic_model(
     model: pydantic.BaseModel,
     output_path: Path | None,
     suppress_success_message: bool = False,
+    context: dict | None = None,
+    exclude_none: bool = False,
+    exclude_unset: bool = False,
+    exclude_defaults: bool = False,
 ) -> None:
     from ado.utilities.output import pydantic_model_as_yaml
 
-    yaml_content = pydantic_model_as_yaml(model)
+    yaml_content = pydantic_model_as_yaml(
+        model,
+        exclude_none=exclude_none,
+        exclude_unset=exclude_unset,
+        exclude_defaults=exclude_defaults,
+        context=context,
+    )
 
     if output_path is None:
         # Write to stdout

--- a/tests/ado/template/test_ado_template_space.py
+++ b/tests/ado/template/test_ado_template_space.py
@@ -115,3 +115,41 @@ def test_template_space_from_experiment_with_actuator_prefix(
         == "peptide_mineralization"
     )
     assert space_configuration.experiments[0].actuatorIdentifier == "robotic_lab"
+
+
+def test_template_space_from_experiment_minified_domains(
+    tmp_path: pathlib.Path, random_identifier: Callable[[], str]
+) -> None:
+    """Template output omits variableType and null fields from each property domain."""
+    runner = CliRunner()
+    file_name = tmp_path / random_identifier()
+    result = runner.invoke(
+        ado,
+        [
+            "template",
+            "space",
+            "--from-experiment",
+            "peptide_mineralization",
+            "--output-file",
+            file_name,
+        ],
+    )
+    assert result.exit_code == 0
+
+    raw = yaml.safe_load(file_name.read_text())
+    for prop_entry in raw.get("entitySpace", []):
+        prop_name = prop_entry.get("identifier", "<unknown>")
+        domain_dict = prop_entry.get("propertyDomain", {})
+        assert "variableType" not in domain_dict, (
+            f"variableType should be absent from {prop_name!r} in template output"
+        )
+        assert (
+            "domainRange" not in domain_dict or domain_dict["domainRange"] is not None
+        ), f"domainRange should be absent (or non-null) in {prop_name!r}"
+        assert "interval" not in domain_dict or domain_dict["interval"] is not None, (
+            f"interval should be absent (or non-null) in {prop_name!r}"
+        )
+        prob_fn = domain_dict.get("probabilityFunction", {})
+        assert "parameters" not in prob_fn or prob_fn["parameters"] is not None, (
+            f"probabilityFunction.parameters should be absent (or non-null) in {prop_name!r}"
+        )


### PR DESCRIPTION
## Summary

Reduces noise in the `ado template space` CLI output by minifying property domain definitions — removing redundant fields (`variableType`, null-valued `domainRange`, `interval`, `probabilityFunction.parameters`) so the generated template YAML contains only the information a user actually needs to fill in.

Resolves #362

## High-level Changes

- **Template command** now passes `exclude_none=True` and `minimize_output` serialisation context when rendering a space template.
- **Serialiser utility** (`serialise_pydantic_model`) accepts new optional parameters (`context`, `exclude_none`, `exclude_unset`, `exclude_defaults`) and forwards them to the YAML serialiser.
- **Tests** add a new case asserting that the generated template YAML no longer contains `variableType` or null-valued domain fields.

## Impact

Users running `ado template space` will receive cleaner, less cluttered YAML output. No changes to runtime behaviour, stored resources, or existing APIs — serialisation options default to their previous values, so all other call sites are unaffected.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.