### PR TITLE
docs: update deprecated model docs to use nested dict utilities

### DIFF
--- a/docs/developer-guide/creating-actuator-classes.md
+++ b/docs/developer-guide/creating-actuator-classes.md
@@ -473,6 +473,12 @@ class InferenceActuatorParameters(GenericActuatorParameters):
         from ado.core.actuatorconfiguration.config import (
             warn_deprecated_actuator_parameters_model_in_use,
         )
+        from ado.utilities.dictionaries import (
+            get_nested_value,
+            has_nested_field,
+            remove_nested_field,
+            set_nested_value,
+        )
 
         old_key = "authToken"
         new_key = "authorization_token"
@@ -505,7 +511,7 @@ class InferenceActuatorParameters(GenericActuatorParameters):
 
         else:
             # The old key is not present - all good
-            if old_key not in values:
+            if not has_nested_field(values, old_key):
                 return values
 
             # Notify the user that the authToken
@@ -521,12 +527,13 @@ class InferenceActuatorParameters(GenericActuatorParameters):
             # The user has set both the old
             # and the new key - the new key
             # takes precedence.
-            if new_key in values:
-                values.pop(old_key)
+            if has_nested_field(values, new_key):
+                remove_nested_field(values, old_key)
             # Set the old value in the
             # new field
             else:
-                values[new_key] = values.pop(old_key)
+                set_nested_value(values, new_key, get_nested_value(values, old_key))
+                remove_nested_field(values, old_key)
 
         return values
 ```

--- a/docs/developer-guide/creating-operators.md
+++ b/docs/developer-guide/creating-operators.md
@@ -337,10 +337,16 @@ class MyOperatorOptions(pydantic.BaseModel):
         from ado.modules.operators.base import (
             warn_deprecated_operator_parameters_model_in_use,
         )
+        from ado.utilities.dictionaries import (
+            get_nested_value,
+            has_nested_field,
+            remove_nested_field,
+            set_nested_value,
+        )
 
         old_key = "my_parameter_name"
         new_key = "my_improved_parameter_name"
-        if old_key in values:
+        if has_nested_field(values, old_key):
             # Notify the user that the my_parameter_name
             # field is deprecated
             warn_deprecated_operator_parameters_model_in_use(
@@ -354,12 +360,13 @@ class MyOperatorOptions(pydantic.BaseModel):
             # The user has set both the old
             # and the new key - the new key
             # takes precedence.
-            if new_key in values:
-                values.pop(old_key)
+            if has_nested_field(values, new_key):
+                remove_nested_field(values, old_key)
             # Set the old value in the
             # new field
             else:
-                values[new_key] = values.pop(old_key)
+                set_nested_value(values, new_key, get_nested_value(values, old_key))
+                remove_nested_field(values, old_key)
 
         return values
 ```


### PR DESCRIPTION
## Summary

Updates the developer guide documentation for actuator classes and operators to replace deprecated direct dictionary access patterns with the dedicated nested dictionary utility functions from `ado.utilities.dictionaries`.

## High-level Changes

- **`docs/developer-guide/creating-actuator-classes.md`**: Updated the deprecated model migration example to use `has_nested_field`, `remove_nested_field`, `set_nested_value`, and `get_nested_value` instead of raw `dict` operations (`in`, `pop`, direct assignment).
- **`docs/developer-guide/creating-operators.md`**: Applied the same update to the operator deprecated model migration example.

## Impact

Documentation-only change. No runtime behaviour is affected. Developers following the guide will now write migration validators that correctly handle nested dictionary structures, consistent with how the rest of the codebase interacts with model data.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.