### PR TITLE
feat(core): add --upgrade-entities-and-results hint to samplestore deprecation warnings

### DIFF
--- a/ado/core/resources.py
+++ b/ado/core/resources.py
@@ -134,6 +134,7 @@ def warn_deprecated_resource_model_in_use(
     removed_from_ado_version: str,
     deprecated_fields: str | list[str] | None = None,
     latest_format_documentation_url: str | None = None,
+    include_entities_and_results_hint: bool = False,
 ) -> None:
     from rich.console import Console
 
@@ -176,8 +177,14 @@ def warn_deprecated_resource_model_in_use(
         f"[b]This fallback will be removed with ado "
         f"[b cyan]{removed_from_ado_version}[/b cyan][/b]."
     )
+    entities_flag = (
+        " --upgrade-entities-and-results"
+        if include_entities_and_results_hint
+        and affected_resource == CoreResourceKinds.SAMPLESTORE
+        else ""
+    )
     manual_upgrade_hint = (
-        f"Run [b cyan]ado upgrade {resource_name}s[/b cyan] to upgrade the stored {resource_name}s. "
+        f"Run [b cyan]ado upgrade {resource_name}s{entities_flag}[/b cyan] to upgrade the stored {resource_name}s. "
         f"Update your {resource_name} YAML files to use the latest format{doc_url}."
     )
 

--- a/ado/core/samplestore/csv.py
+++ b/ado/core/samplestore/csv.py
@@ -28,6 +28,7 @@ def warn_deprecated_csv_sample_store_model_in_use(
     removed_from_version: str = "1.6.0",
     deprecated_fields: str | list[str] | None = None,
     latest_format_documentation_url: str | None = None,
+    include_entities_and_results_hint: bool = False,
 ) -> None:
     """Warn that a deprecated CSV sample store model format is being auto-upgraded
 
@@ -66,8 +67,11 @@ def warn_deprecated_csv_sample_store_model_in_use(
         f"[b]This behavior will be removed with ADO "
         f"[b cyan]{removed_from_version}[/b cyan][/b]."
     )
+    entities_flag = (
+        " --upgrade-entities-and-results" if include_entities_and_results_hint else ""
+    )
     manual_upgrade_hint = (
-        f"Run [b cyan]ado upgrade {resource_name}s[/b cyan] to upgrade the stored {resource_name}s.\n\t"
+        f"Run [b cyan]ado upgrade {resource_name}s{entities_flag}[/b cyan] to upgrade the stored {resource_name}s.\n\t"
         f"Update your {resource_name} YAML files to use the latest format{doc_url}."
     )
 


### PR DESCRIPTION
## Summary

Improves the deprecation warnings shown when a legacy samplestore format is detected. When the stored entities and results also need to be migrated, the warning now includes the `--upgrade-entities-and-results` flag in the suggested upgrade command, giving users the exact command to run instead of an incomplete one.

## High-level Changes

- Added an `include_entities_and_results_hint` flag to the two deprecation-warning helpers in `ado/core/resources.py` and `ado/core/samplestore/csv.py`.
- When the flag is set, the suggested `ado upgrade samplestores` command shown in the warning is automatically extended with `--upgrade-entities-and-results`.

## Impact

No behaviour change for callers that do not opt in to the new flag. Callers that pass `include_entities_and_results_hint=True` will display a more complete and actionable upgrade command to users encountering samplestore deprecation warnings.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.