### PR TITLE
fix(core): handle null value filtering in JSON_CONTAINS query on mysql

### DIFF
--- a/ado/metastore/sql/statements.py
+++ b/ado/metastore/sql/statements.py
@@ -338,7 +338,12 @@ def resource_filter_by_arbitrary_selection(
     return (
         f"{statement_preamble} {simulate_json_contains_on_sqlite(path, candidate)}"
         if dialect == "sqlite"
-        else f"{statement_preamble} JSON_CONTAINS(data, '{candidate}', '{path}')"
+        else (
+            f"{statement_preamble} "
+            f"(JSON_CONTAINS(data, '{candidate}', '{path}') "
+            f"OR ('{candidate}' = 'null' "
+            f"AND NOT JSON_CONTAINS_PATH(data, 'one', '{path}')))"
+        )
     )
 
 


### PR DESCRIPTION
## Summary

Fixes a bug in the metastore SQL query layer where filtering resources by a field value of `null` would silently return no results instead of matching records where the field is absent or null.

## High-level Changes

- **`ado/metastore/sql/statements.py`**: Updated the MySQL/non-SQLite branch of the `resource_filter_by_arbitrary_selection` query builder to handle `null` filter values. When the candidate value is `null`, the condition now also matches records where the JSON path does not exist, using `JSON_CONTAINS_PATH` as a complementary check.

## Impact

Querying metastore resources by a `null` field value now correctly returns records where the field is absent from the JSON payload (in addition to those where it is explicitly set to `null`). SQLite behaviour is unchanged. No schema or API changes.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.