### PR TITLE
test: add retry support for known flaky tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
   "pytest-cov>=7.0.0",
   "pytest-env>=1.1.0",
   "pytest-recording>=0.13.4",
+  "pytest-rerunfailures>=16.4",
   "pytest-timeout>=2.4.0",
   "pytest-xdist>=3.6.1",
   "ruff>=0.12.1",

--- a/tests/actuators/test_executor_supervision_integration.py
+++ b/tests/actuators/test_executor_supervision_integration.py
@@ -131,6 +131,7 @@ def drain_queue(queue: MeasurementQueue, timeout: float) -> MeasurementRequest |
         return None
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(60)
 def test_supervisor_pending_resource_timeout_emits_invalid(
     measurement_queue: MeasurementQueue,
@@ -157,6 +158,7 @@ def test_supervisor_pending_resource_timeout_emits_invalid(
         supervisor.stop()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(60)
 def test_supervisor_pending_node_assignment_not_timed_out_by_default(
     measurement_queue: MeasurementQueue,
@@ -181,6 +183,7 @@ def test_supervisor_pending_node_assignment_not_timed_out_by_default(
         ray.cancel(ref, force=True, recursive=True)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(30)
 def test_supervisor_running_task_not_timed_out(
     measurement_queue: MeasurementQueue,
@@ -204,6 +207,7 @@ def test_supervisor_running_task_not_timed_out(
         ray.cancel(ref, force=True, recursive=True)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(30)
 def test_supervisor_completed_task_no_supervisor_put(
     measurement_queue: MeasurementQueue,
@@ -224,6 +228,7 @@ def test_supervisor_completed_task_no_supervisor_put(
         supervisor.stop()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(30)
 def test_default_task_state_lookup_unschedulable_task_returns_pending_node_assignment() -> (
     None
@@ -248,6 +253,7 @@ def test_default_task_state_lookup_unschedulable_task_returns_pending_node_assig
         ray.cancel(ref, force=True, recursive=True)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(30)
 def test_supervisor_executor_exception_emits_invalid(
     measurement_queue: MeasurementQueue,
@@ -271,6 +277,7 @@ def test_supervisor_executor_exception_emits_invalid(
         supervisor.stop()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(30)
 def test_mark_completed_prevents_duplicate_launch_failure(
     measurement_queue: MeasurementQueue,

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -513,6 +513,7 @@ def test_random_walk_fail_invalid_config(
         pytest.fail("Expected exception to be raised and none was")
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_run_ray_tune_operation(
     ml_multi_cloud_space: DiscoverySpace,
     raytuneConf: DiscoveryOperationResourceConfiguration,

--- a/tests/operators/test_trim_example_integration.py
+++ b/tests/operators/test_trim_example_integration.py
@@ -78,6 +78,7 @@ _TRIM_TEST_AUTOGLUON_FIT_ARGS = {
 }
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.timeout(900)
 def test_trim_example_operation_succeeds(
     trim_minimal_discovery_space: DiscoverySpace,

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,6 @@ dependencies = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
 ]
 
 [package.metadata]
@@ -98,6 +97,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-recording" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -161,6 +161,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-env", specifier = ">=1.1.0" },
     { name = "pytest-recording", specifier = ">=0.13.4" },
+    { name = "pytest-rerunfailures", specifier = ">=16.4" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.12.1" },
@@ -246,7 +247,6 @@ dependencies = [
     { name = "aim" },
     { name = "jwt" },
     { name = "psutil", version = "7.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "psutil", version = "7.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "transformers" },
 ]
 
@@ -265,10 +265,8 @@ dependencies = [
     { name = "ado-core" },
     { name = "autogluon-tabular", extra = ["catboost", "xgboost"] },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "pandas" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
 ]
 
 [package.metadata]
@@ -330,11 +328,9 @@ dependencies = [
     { name = "filelock" },
     { name = "jinja2" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "psutil", version = "7.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "psutil", version = "7.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "requests" },
@@ -1834,7 +1830,6 @@ version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
@@ -7311,6 +7306,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -9141,7 +9149,6 @@ dependencies = [
     { name = "ml-dtypes" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
     { name = "psutil", version = "7.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "setuptools", marker = "python_version < '0'" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
     { name = "tqdm" },
     { name = "typing-extensions" },


### PR DESCRIPTION
## Summary

Adds automatic retry support for known flaky tests to improve CI reliability. Tests that depend on timing or Ray scheduling are non-deterministic by nature; this change makes them self-heal on transient failures instead of blocking pipelines.

## High-level Changes

- Added `pytest-rerunfailures` as a dev dependency.
- Marked known flaky integration tests (Ray executor supervision, Ray Tune operator, TRIM example) with `@pytest.mark.flaky(reruns=3, reruns_delay=2)` so they are retried up to 3 times before being reported as a failure.
- Updated `uv.lock` to include the new dependency and clean up stale unreachable markers.

## Impact

No production code is changed. CI pipelines will be less prone to spurious failures on timing-sensitive or Ray-dependent tests. Test behaviour is unchanged when tests pass on the first attempt.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.