### PR TITLE
test: add flaky marker to lhc sampler test for Python 3.14

### DIFF
--- a/tests/ado/create/test_ado_create_operation.py
+++ b/tests/ado/create/test_ado_create_operation.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import pathlib
+import sys
 from collections.abc import Callable
 
 import pytest
@@ -200,6 +201,13 @@ def test_create_operation_success_with_discovery_space(
 
 
 @requires_sqlite_3_38
+@pytest.mark.flaky(
+    reruns=3,
+    reruns_delay=5,
+    condition=sys.version_info >= (3, 14),
+    only_rerun="OutOfMemoryError",
+    reason="numba OOM on Python 3.14 when JIT compilation fails for nevergrad",
+)
 def test_create_ml_multi_cloud_operation_success_lhc_sampler(
     tmp_path: pathlib.Path,
     ml_multi_cloud_sample_store_configuration_file: pathlib.Path,


### PR DESCRIPTION
## Summary

Marks a flaky integration test with `pytest-rerunfailures` to handle intermittent out-of-memory failures caused by numba JIT compilation issues in nevergrad on Python 3.14.

## High-level Changes

- The LHC sampler integration test is now decorated with `@pytest.mark.flaky` so it automatically retries (up to 3 times, with a 5-second delay) when an `OutOfMemoryError` is raised, but only on Python 3.14 and above.

## Impact

No behaviour change in production code. CI pipelines running on Python 3.14 will be less likely to report spurious test failures caused by the known numba/nevergrad JIT memory issue.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.