### PR TITLE
docs: update prints in documentation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "requirements.txt|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-10T10:38:43Z",
+  "generated_at": "2026-07-30T10:09:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -122,7 +122,7 @@
         "hashed_secret": "2db6d21d365f544f7ca3bcfb443ac96898a7a069",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 192,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/developer-guide/creating-actuator-classes.md
+++ b/docs/developer-guide/creating-actuator-classes.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable first-line-h1 -->
 
->[!INFO]
->
-> A [complete template actuator](https://github.com/IBM/ado/tree/main/plugins/actuators/example_actuator)
-> is available.
-> This example actuator is functional out-of-the-box
-> and can be used as the basis to create new actuators.
+!!! tip
+
+    A [complete template actuator](https://github.com/IBM/ado/tree/main/plugins/actuators/example_actuator)
+    is available.
+    This example actuator is functional out-of-the-box
+    and can be used as the basis to create new actuators.
 
 [Custom experiments](creating-custom-experiments.md) cover many use cases for
 extending `ado` with new experiments. However, sometimes you need more control
@@ -16,9 +16,8 @@ For such situations developers can write their own
 [actuators](../concepts/actuators.md). Actuators allow you to control and
 customize the entire experiment submission process giving great flexibility and
 power. You can also expose customization options to users via
-[`actuatorconfigurations`](#enabling-custom-configuration-of-an-actuator).
-Like custom experiments actuator are supplied as plugin **python
-packages**.
+[`actuatorconfigurations`](#enabling-custom-configuration-of-an-actuator). Like
+custom experiments actuator are supplied as plugin **python packages**.
 
 This page gives an overview of how to get started creating your own actuator.
 It's not intended to be comprehensive. After reading this page the best resource
@@ -42,8 +41,8 @@ class that implements a specific interface.
   actuator
 - implements the `catalog()` method
 - _either_
-  - simple case: override `_experiment_implementations()`
-  - complex case: overrides `_get_request_executor`
+    - simple case: override `_experiment_implementations()`
+    - complex case: overrides `_get_request_executor`
 
 The simple case is for when your actuators experiments are independent of each
 other i.e. executing one experiment does not care about other experiments. The
@@ -73,17 +72,23 @@ function for each `Experiment` entry your `ExperimentCatalog`. The
 `_experiment_implementations()` method then returns a dict that maps each
 experiment identifier to the corresponding function e.g.
 
+<!-- markdownlint-disable code-block-style -->
+
 ```python
 def _experiment_implementations(self) -> dict[str, Callable[..., dict[str, Any]]]:
 
     return {"myexperiment": my_experiment_fn()}
 ```
 
+<!-- markdownlint-enable code-block-style -->
+
 The parameter names of the function must be the same as the input property
 identifiers of the `Experiment`. The output of the function must be a dict that
 maps the target property identifiers of the Experiment to their measured values.
 
 For example, for an Experiment instance like
+
+<!-- markdownlint-disable code-block-style -->
 
 ```yaml
 # it's properties which  match what is defined here
@@ -104,7 +109,11 @@ peptide_mineralization:
     - identifier: adsorption_plateau_value
 ```
 
+<!-- markdownlint-enable code-block-style -->
+
 The function would look like
+
+<!-- markdownlint-disable code-block-style -->
 
 ```python
 def peptide_mineralization_fn(peptide_identifier, peptide_concentration):
@@ -112,6 +121,8 @@ def peptide_mineralization_fn(peptide_identifier, peptide_concentration):
     ...
     return {"adsoprtion_timeseries": timeseries, "adsorption_plateau_value": plateau}
 ```
+
+<!-- markdownlint-enable code-block-style -->
 
 ### Complex case: Experiments with shared state
 
@@ -123,6 +134,8 @@ This method that takes a `MeasurementRequest` instance that describes the
 experiment to run. Note, the `use_ray` parameter is used by default
 implementation and can be safely ignored when overridden.
 
+<!-- markdownlint-disable code-block-style -->
+
 ```python
     def _get_request_executor(
         self,
@@ -130,6 +143,8 @@ implementation and can be safely ignored when overridden.
         use_ray: bool = False,
     ) -> Callable[[], MeasurementRequest]:
 ```
+
+<!-- markdownlint-enable code-block-style -->
 
 The `get_request_executor` method must return a zero-argument `Callable` that
 executes the requested experiment and returns a completed `MeasurementRequest`
@@ -152,12 +167,16 @@ method
 
 e.g.
 
+<!-- markdownlint-disable code-block-style -->
+
 ```python
 result = actuator.execute(entities,
                         experiment_reference,
                         requesterid: "script",
                         requestIndex: 0,)
 ```
+
+<!-- markdownlint-enable code-block-style -->
 
 where `entities` is a list of one or more `Entity` instances representing the
 points you want to measure, and `experiment_reference`, is an
@@ -176,26 +195,7 @@ to the following:
 <!-- markdownlint-disable code-block-style -->
 
 ```toml
-[project]
-name = "robotic_lab"  # Change to your preferred name, along with the actual package
-description = "A template for creating an actuator"  # Change to describing your actuator
-dependencies = [
-    "ado-core"
-]
-dynamic = ["version"]
-
-[project.entry-points."ado.actuators"]
-robotic_lab = "robotic_lab_actuator.actuator:RoboticLab"
-
-[build-system]
-requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
-build-backend = "hatchling.build"
-
-[tool.hatch.version]
-source = "uv-dynamic-versioning"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/robotic_lab_actuator"]
+{% include "../../plugins/actuators/example_actuator/pyproject.toml" %}
 ```
 
 <!-- markdownlint-enable code-block-style -->
@@ -726,10 +726,9 @@ at the end of execution
 
 Actuator developers can provide rich, real-time progress output to users running
 experiments, using utilities available in
-`ado.modules.operators.console_output.py`. This is critical for
-long-running operations (such as deployment, environment setup, or
-benchmarking), and helps users visually associate progress with specific
-requests.
+`ado.modules.operators.console_output.py`. This is critical for long-running
+operations (such as deployment, environment setup, or benchmarking), and helps
+users visually associate progress with specific requests.
 
 ### How progress signaling works
 
@@ -745,12 +744,11 @@ using provided Rich message helpers:
 You should send these messages to the `RichConsoleQueue` actor and update or
 stop them when state changes.
 
-> [!INFO]
-> Use the `request id` of the MeasurementRequest you're operating on
-> as the message `id` (and include it in the message `label`).
-> This allows your actuator to support progress for multiple experiments
-> running concurrently, and the UI will clearly indicate which progress
-> output is tied to which experiment request.
+> [!INFO] Use the `request id` of the MeasurementRequest you're operating on as
+> the message `id` (and include it in the message `label`). This allows your
+> actuator to support progress for multiple experiments running concurrently,
+> and the UI will clearly indicate which progress output is tied to which
+> experiment request.
 
 ### Example usage
 
@@ -847,12 +845,10 @@ functions and methods:
 
 - `Experiment.propertyValuesFromEntity` - Get the input values for the
   experiment based on the entity and the experiment definition
-- `ado.utilities.support.observed_property_values_from_dict` - Extract
-  the values related to an experiment from a dictionary of measurements and
-  convert to PropertyValues
-- `ado.utilities.support.create_measurement_result` - Create
-  measurement result
-- `ado.utilities.support.compute_measurement_status` - Compute
-  execution status
-- `ado.utilities.async_task_runner.AsyncTaskRunner` - wait for the
-  completion of an async function and get execution result
+- `ado.utilities.support.observed_property_values_from_dict` - Extract the
+  values related to an experiment from a dictionary of measurements and convert
+  to PropertyValues
+- `ado.utilities.support.create_measurement_result` - Create measurement result
+- `ado.utilities.support.compute_measurement_status` - Compute execution status
+- `ado.utilities.async_task_runner.AsyncTaskRunner` - wait for the completion of
+  an async function and get execution result

--- a/docs/developer-guide/creating-operators.md
+++ b/docs/developer-guide/creating-operators.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable code-block-style -->
 <!-- markdownlint-disable first-line-h1 -->
 
-!!! info end
+!!! tip end
 
     A complete example operator is provided
     [here](https://github.com/IBM/ado/tree/main/plugins/operators/profile_space).
@@ -48,11 +48,20 @@ from ado.modules.operators.collections import (
 
 
 @characterize_operation(
-    name="my_operator",  # The name of your operator.
-    description="Example operator",  # What this operator does
-    configuration_model=MyOperatorOptions,  # A pydantic model that describes your operators input parameters
-    example_configuration=MyOperatorOptions.example_configuration(),  # An example of your operators input parameters
-    version="1.0",  # Version of the operator
+    name="detect_anomalous_series",
+    description="""
+    This operation checks if the behaviour of an observed property versus
+    an independent (constitutive) property is as expected.
+
+    The behaviours that can be checked are: True (all values are 1/True); Constant (all values are the same);
+    Monotonically Increasing; or Monotonically Decreasing.
+
+    The entities in the discovery space can be divided into groups based on a user supplied set of constitutive
+    properties, other than the selected independent property.
+    """,
+    configuration_model=DetectAnomalousSeries,
+    example_configuration=DetectAnomalousSeries.example_configuration(),
+    version="1.0.5",
 )
 def detect_anomalous_series(
     discoverySpace: DiscoverySpace,
@@ -140,7 +149,7 @@ the previous section with the relevant fields called out:
     description="Example operator",
     configuration_model=MyOperatorOptions,  # <- A pydantic model that describes your operators input parameters
     example_configuration=MyOperatorOptions(), # <- An example of your operators input parameters
-    version="1.0",
+    version="1.0.0",
 )
 ```
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -117,9 +117,10 @@ config: ... # The configuration of the resource - different for each different t
 created: "2024-10-03T12:42:35.786484Z" # Creation date
 identifier: space-8f1cfb-91ecfb # Resource identifier
 kind: discoveryspace # Resource kind
-metadata: {} # A field for system metadata. User metadata will be in config.metadata
-status: [] # A status field
-version: v2 # The version of this resource
+metadata: {} # Metadata dictionary
+provenance: ... # Package provenance frozen at resource creation time
+status: [] # A list of status objects describing notable events on the resource
+version: v1 # The version of this resource
 ```
 
 ### Resource status
@@ -140,16 +141,23 @@ All resources have status updates recorded for the following events:
 Here is an example:
 
 ```yaml
-created: "2024-12-19T10:47:03.931824Z"
-identifier: 04535d
+config: ...
+created: "2026-07-09T14:35:23.264745Z"
+identifier: 88341a
 kind: samplestore
 metadata: {}
+provenance:
+  ado:
+    distributionName: ado-core
+    distributionVersion: 2.0.0
 status:
   - event: created
-    recorded_at: "2024-12-19T10:47:03.931840Z"
+    recorded_at: "2026-07-09T14:35:23.264754Z"
   - event: added
-    recorded_at: "2024-12-19T10:47:05.720459Z"
-version: v2
+    recorded_at: "2026-07-09T14:35:23.265368Z"
+  - event: updated
+    recorded_at: "2026-07-24T13:56:36.053942Z"
+version: v1
 ```
 
 ### Programmatic view of resources

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -85,23 +85,16 @@ ado get contexts
 This will output something like
 
 ```terminaloutput
-┌───────┬────────────────────────┬─────────┐
-│ INDEX │ CONTEXT                │ DEFAULT │
-├───────┼────────────────────────┼─────────┤
-│ 0     │ ap-test                │         │
-│ 1     │ ap-testing             │         │
-│ 2     │ caikit-testharness     │         │
-│ 3     │ developer-testing      │         │
-│ 4     │ finetuning             │         │
-│ 5     │ ft-prod                │         │
-│ 6     │ ft-vela                │         │
-│ 7     │ llm-d                  │         │
-│ 8     │ local                  │ ✅      │
-│ 9     │ local-test             │         │
-│ 10    │ mascots2024            │         │
-│ 11    │ playground             │         │
-│ 12    │ resource-store-testing │         │
-└───────┴────────────────────────┴─────────┘
+┌───────┬─────────────────────────┬────────┐
+│ INDEX │ CONTEXT                 │ ACTIVE │
+├───────┼─────────────────────────┼────────┤
+│ 0     │ algorithm-nexus         │        │
+│ 1     │ cplex_mip               │        │
+│ 2     │ geospatial-benchmarking │        │
+│ 3     │ llm-d                   │        │
+│ 4     │ local                   │ ✅     │
+│ 5     │ playground              │        │
+└───────┴─────────────────────────┴────────┘
 ```
 
 Note, the name of the context is the name of the associated project.

--- a/docs/resources/sample-stores.md
+++ b/docs/resources/sample-stores.md
@@ -127,26 +127,11 @@ The [Sample Store types](#sample-store-types) section details how to fill the
 above fields for the different available Sample Store. Here is an example of
 copying data from a CSV file using `CSVSampleStore`:
 
+<!-- markdownlint-disable line-length -->
 ```yaml
-specification:
-  module:
-    moduleName: ado.core.samplestore.sql
-    moduleClass: SQLSampleStore
-copyFrom:
-  - module:
-      moduleClass: CSVSampleStore
-    storageLocation:
-      path: "examples/ml-multi-cloud/ml_export.csv"
-    parameters:
-      generatorIdentifier: "multi-cloud-ml"
-      identifierColumn: "config"
-      experiments:
-        - experimentIdentifier: "benchmark_performance"
-          constitutivePropertyMap:
-            - cpu_type
-          observedPropertyMap:
-            - wallClockRuntime
+{% include-markdown "../../examples/ml-multi-cloud/ml_multicloud_sample_store.yaml" %}
 ```
+<!-- markdownlint-enable line-length -->
 
 ## Accessing the entities in a sample store
 

--- a/docs/user-guide/actuators/working-with-actuators.md
+++ b/docs/user-guide/actuators/working-with-actuators.md
@@ -21,87 +21,70 @@ using the special actuator
 
 ## Listing available Actuators
 
-To see a list of available actuators execute
+To see a list of available actuators, including their description,
+number of experiments, and version, execute
 
 <!-- markdownlint-disable-next-line code-block-style -->
 ```commandline
-ado get actuators
+ado get actuators --details
 ```
 
-You can also use `ado get actuators --details` which in addition
-outputs the description of the actuators, the number of
-experiments they provide and their version. Below is an example
-of the output:
+Below is an example of the output:
 
 <!-- markdownlint-disable line-length -->
 
 ```commandline
-┌────────────────────┬─────────────┬─────────────────────────────────────────────────────┬───────────────────────────┐
-│ ACTUATOR ID        │ EXPERIMENTS │ DESCRIPTION                                         │ VERSION                   │
-├────────────────────┼─────────────┼─────────────────────────────────────────────────────┼───────────────────────────┤
-│ SFTTrainer         │ 5           │ An actuator for benchmarking fine-tuning of         │ 1.5.1.dev13+ga1833142b    │
-│                    │             │ foundation models                                   │                           │
-│ custom_experiments │ 6           │ Actuator for applying user supplied custom          │ 1.5.1.dev8+531c6444.dirty │
-│                    │             │ experiments                                         │                           │
-│ mock               │ 2           │ A actuator class for testing                        │ 1.5.1.dev8+531c6444.dirty │
-│ replay             │ 0           │ Special actuator for handling externally defined    │ 1.5.1.dev8+531c6444.dirty │
-│                    │             │ experiments (experiments we don't have code for)    │                           │
-│ robotic_lab        │ 1           │ A template for creating an actuator                 │ 1.5.1.dev13+ga1833142b    │
-└────────────────────┴─────────────┴─────────────────────────────────────────────────────┴───────────────────────────┘
+┌───────┬────────────────────┬─────────────┬────────────────────────────────────────────────────┬─────────┐
+│ INDEX │ ACTUATOR ID        │ EXPERIMENTS │ DESCRIPTION                                        │ VERSION │
+├───────┼────────────────────┼─────────────┼────────────────────────────────────────────────────┼─────────┤
+│ 0     │ custom_experiments │ 2           │ Actuator for applying user supplied custom         │ 2.0.0   │
+│       │                    │             │ experiments                                        │         │
+│ 1     │ mock               │ 2           │ A actuator class for testing                       │ 2.0.0   │
+│ 2     │ replay             │ 0           │ Special actuator for handling externally defined   │ 2.0.0   │
+│       │                    │             │ experiments (experiments we don't have code for)   │         │
+│ 3     │ vllm_performance   │ 25          │ VLLM performance testing actuator for ado          │ 1.13.1  │
+└───────┴────────────────────┴─────────────┴────────────────────────────────────────────────────┴─────────┘
 ```
 
 <!-- markdownlint-enable line-length -->
 
 ## Listing available Experiments
 
-To see the experiments each actuator provides
+To see the experiments each actuator provides, including their description,
+execute
 
 <!-- markdownlint-disable-next-line code-block-style -->
 ```commandline
-ado get experiments
+ado get experiments --details
 ```
 
-You can also get see the description of each experiment (if provided)
-with `ado get experiments --details`.
 The output will be similar to:
 
 <!-- markdownlint-disable line-length -->
 ```terminaloutput
-┌────────────────────┬─────────────────────────────────────┬─────────────────────────────────────────────────────────┐
-│ ACTUATOR ID        │ EXPERIMENT ID                       │ DESCRIPTION                                             │
-├────────────────────┼─────────────────────────────────────┼─────────────────────────────────────────────────────────┤
-│ SFTTrainer         │ finetune_full_benchmark-v1.0.0      │ Measures the performance of full-finetuning a model for │
-│                    │                                     │ a given (GPU model, number GPUS, batch_size,            │
-│                    │                                     │ model_max_length, number nodes) combination.            │
-│ SFTTrainer         │ finetune_full_stability-v1.0.0      │ Performs 5 full finetune runs of 5 steps each on a      │
-│                    │                                     │ model and reports the fraction of those that resulted   │
-│                    │                                     │ in GPU OOM, Other error, or No Error for a given (GPU   │
-│                    │                                     │ model, number GPUS, batch_size, model_max_length)       │
-│                    │                                     │ combination.                                            │
-│ SFTTrainer         │ finetune_gptq-lora_benchmark-v1.0.0 │ Measures the performance of GPTQ-LORA tuning a model    │
-│                    │                                     │ for a given (GPU model, number GPUS, batch_size,        │
-│                    │                                     │ model_max_length, number nodes) combination.            │
-│ SFTTrainer         │ finetune_lora_benchmark-v1.0.0      │ Measures the performance of LORA tuning a model for a   │
-│                    │                                     │ given (GPU model, number GPUS, batch_size,              │
-│                    │                                     │ model_max_length, number nodes) combination.            │
-│ SFTTrainer         │ finetune_pt_benchmark-v1.0.0        │ Measures the performance of prompt-tuning a model for a │
-│                    │                                     │ given (GPU model, number GPUS, batch_size,              │
-│                    │                                     │ model_max_length, number nodes) combination.            │
-│ custom_experiments │ acid_test                           │                                                         │
-│ custom_experiments │ avoid_oom_recommender               │ An AutoConf recommender that suggests the minimum       │
-│                    │                                     │ number of gpus per worker and number of workers         │
-│                    │                                     │ necessary to execute a Tuning job whilekeeping the per  │
-│                    │                                     │ GPU batch size constant                                 │
-│ custom_experiments │ calculate_density                   │                                                         │
-│ custom_experiments │ min_gpu_recommender                 │ An AutoConf plugin that suggests the minimum number of  │
-│                    │                                     │ gpus per worker and number of workers necessary to      │
-│                    │                                     │ execute a Tuning job                                    │
-│ custom_experiments │ ml-multicloud-cost-v1.0             │                                                         │
-│ custom_experiments │ nevergrad_opt_3d_test_func          │                                                         │
-│ mock               │ test-experiment                     │                                                         │
-│ mock               │ test-experiment-two                 │                                                         │
-│ robotic_lab        │ peptide_mineralization              │ Measures adsorption of peptide lanthanide combinations  │
-└────────────────────┴─────────────────────────────────────┴─────────────────────────────────────────────────────────┘
+┌───────┬────────────────────┬──────────────────────────────────────┬─────────┬──────────────────────────────────────────┐
+│ INDEX │ ACTUATOR ID        │ EXPERIMENT ID                        │ VERSION │ DESCRIPTION                              │
+├───────┼────────────────────┼──────────────────────────────────────┼─────────┼──────────────────────────────────────────┤
+│ 0     │ custom_experiments │ avoid_oom_recommender                │ None    │ An AutoConf recommender that preserves   │
+│       │                    │                                      │         │ the requested number of GPUs if it won't │
+│       │                    │                                      │         │ cause GPU OOM, otherwise recommends the  │
+│       │                    │                                      │         │ minimum number of GPUs needed. Keeps the │
+│       │                    │                                      │         │ per-device batch size constant.          │
+│ 1     │ custom_experiments │ min_gpu_recommender                  │ None    │ An AutoConf plugin that suggests the     │
+│       │                    │                                      │         │ minimum number of gpus per worker and    │
+│       │                    │                                      │         │ number of workers necessary to execute a │
+│       │                    │                                      │         │ Tuning job                               │
+│ 2     │ vllm_performance   │ vllm-bench-deployment                │ 1.0.0   │ VLLM performance testing across compute  │
+│       │                    │                                      │         │ resource and workload configuration      │
+│ 3     │ vllm_performance   │ geospatial-vllm-bench-deployment     │ 1.0.0   │ VLLM performance testing across compute  │
+│       │                    │                                      │         │ resource and workload configuration for  │
+│       │                    │                                      │         │ geospatial models                        │
+│ 4     │ vllm_performance   │ test-agentic-tool-calling            │ 1.0.0   │ Test inference performance of an         │
+│       │                    │                                      │         │ agent-style model deployed by vLLM       │
+│       │                    │                                      │         │ across compute resource and workload     │
+│       │                    │                                      │         │ configurations                           │
+│ ...   │ ...                │ ...                                  │ ...     │ ...                                      │
+└───────┴────────────────────┴──────────────────────────────────────┴─────────┴──────────────────────────────────────────┘
 ```
 <!-- markdownlint-enable line-length -->
 

--- a/docs/user-guide/operators/ray-tune.md
+++ b/docs/user-guide/operators/ray-tune.md
@@ -132,18 +132,18 @@ For example, the default parameters and values for a `ray_tune` operation are:
 
 ```yaml
 orchestratorConfig:
+  failed_metric_value: NaN # This will be used for the value of "metric" for any entities where it could not be measured (for any reason)
   metric_format: target # Format for metric names: "target" (default) or "observed"
-  failed_metric_value: None # This will be used for the value of "metric' for any entities where it could not be measured (for any reason)
   result_dump: none # If specified the best result found will be written to this file
   single_measurement_per_property: true # If true memoization is used. If false already measured entities will be re-measured.
 runtimeConfig:
-  stop: None # A list of Stoppers or None. See below for stoppers
+  stop: null # A list of Stoppers or null. See below for stoppers
 tuneConfig:
+  max_concurrent_trials: 1 # The maximum number of trials to run concurrently
   metric: wallclock_time # The target property identifier to optimize w.r.t
   mode: min # Whether to search for min or max of the target property
-  num_samples: 1 # The number of samples to draw
   search_alg:
-    name: ax # The name of the optimization algorithm to use
+    name: bayesopt # The name of the optimization algorithm to use
     params: {} # The parameters for the optimizer
 ```
 
@@ -157,9 +157,13 @@ together and how they interact.
 !!! info end
 
     You can get a default RayTune operation template and the schema of its
-    parameters by running
-    `ado template operation --operator-name ray_tune --include-schema`. The
-    information output by this command should always be preferred over the
+    parameters by running:
+
+    ```shell
+    ado template operation --operator-name ray_tune --include-schema
+    ```
+
+    The information output by this command should always be preferred over the
     information presented here in case of inconsistencies.
 
 ### Trials versus Samples
@@ -182,15 +186,15 @@ which are all optional:
       (e.g., `"latency"`)
     - **"observed"**: Use [observed property identifiers](../../concepts/actuators.md#target-and-observed-properties)
       (e.g., `"actuator.experiment.latency"`)
-- `failed_metric_value` (default None)
-    - This will be used for the value of "metric' for any entities where it could
-    not be measured (for any reason)
-- `result_dump` (default None)
+- `failed_metric_value` (default NaN)
+    - This will be used for the value of "metric" for any entities where it could
+      not be measured (for any reason)
+- `result_dump` (default none)
     - If specified the best result found will be written to this file
 - `single_measurement_per_property` (default true)
     - If true
-     [memoization](#what-happens-if-i-apply-multiple-ray_tune-operations-to-a-space)
-     is used.
+      [memoization](#what-happens-if-i-apply-multiple-ray_tune-operations-to-a-space)
+      is used.
     - If false already measured entities will be re-measured.
 
 <!-- prettier-ignore-end -->

--- a/docs/user-guide/operators/working-with-operators.md
+++ b/docs/user-guide/operators/working-with-operators.md
@@ -39,32 +39,42 @@ ado get operators
 Example output:
 
 ```commandline
-┌───────┬─────────────────────────┬──────────────┐
-│ INDEX │ OPERATOR                │ TYPE         │
-├───────┼─────────────────────────┼──────────────┤
-│ 0     │ detect_anomalous_series │ characterize │
-│ 1     │ profile                 │ characterize │
-│ 2     │ trim                    │ characterize │
-│ 3     │ random_walk             │ explore      │
-│ 4     │ ray_tune                │ explore      │
-│ 5     │ rifferla                │ modify       │
-└───────┴─────────────────────────┴──────────────┘
+┌───────┬─────────────────────────┬─────────┬──────────────┐
+│ INDEX │ OPERATOR                │ VERSION │ TYPE         │
+├───────┼─────────────────────────┼─────────┼──────────────┤
+│ 0     │ detect_anomalous_series │ 1.0.5   │ characterize │
+│ 1     │ profile                 │ 2.0.4   │ characterize │
+│ 2     │ trim                    │ 2.0.3   │ characterize │
+│ 3     │ random_walk             │ 2.0.0   │ explore      │
+│ 4     │ ray_tune                │ 2.0.6   │ explore      │
+│ 5     │ rifferla                │ 2.0.6   │ modify       │
+└───────┴─────────────────────────┴─────────┴──────────────┘
 ```
 
 ## Using operators
 
 Using an operator involves the following steps:
 
-1. Find the input parameters for the operator:
-   - `ado template operation --operator-name $OPERATOR_NAME`
-2. Write an operation YAML for applying the operator.
-   - This involves setting specific values for its input parameters.
+1. Generate an operation template for the operator with default parameter values:
+
+      ```shell
+      ado template operation --operator-name $OPERATOR_NAME
+      ```
+
+2. Edit the generated YAML to configure the parameters to your liking.
 3. Create the operation:
-   - `ado create operation -f $YAML`
+
+      ```shell
+      ado create operation -f $OPERATION_FILE
+      ```
+
 4. Retrieve the results of the operation:
-   - `ado show related $OPERATION_IDENTIFIER`
-   - in addition `ado show measurements $OPERATION_IDENTIFIER` for explore
-     operations
+
+      ```shell
+      ado show related operation --use-latest
+      # For explore operations
+      ado show measurements operation --use-latest
+      ```
 
 These steps are covered in detail in [operations](../../resources/operation.md).
 


### PR DESCRIPTION
## Summary

This PR refreshes the documentation to reflect the current state of the ado CLI and codebase. Terminal output blocks, command examples, and YAML snippets across several pages have been updated to match what users actually see when running ado today, replacing outdated content that no longer matched real CLI behaviour.

## High-level Changes

- **CLI output blocks updated**: Terminal and command output examples in the user guide and developer guide now show current ado CLI output, including updated column names, version numbers, and actuator/operator listings.
- **Commands updated to recommended forms**: Documentation now consistently recommends the `--details` flag for `ado get actuators` and `ado get experiments`, and uses `--use-latest` in operator workflow steps.
- **YAML snippets replaced with live includes**: Hardcoded YAML examples for `pyproject.toml` and sample store configuration are now included directly from their source files, keeping those documentation pages automatically in sync.
- **Formatting fixes**: Various minor markdown formatting issues corrected, including admonition syntax, code block style directives, and list indentation.
- **ray-tune defaults updated**: Default parameter values in the ray-tune operator documentation corrected to match current behaviour (`NaN`, `null`, `bayesopt`).

## Impact

Documentation only — no source code or behaviour is changed. Users following the updated pages will now see commands and outputs that match the current version of ado.

---

## AI Disclosure

The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.