### PR TITLE
docs(agents): inline key concepts and make skills self-contained

### DIFF
--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -77,8 +77,7 @@ Operations are applied to discoveryspaces. There are different types of
 operation. The General Workflow can be applied to all types of operation.
 
 In addition, the Explore Operation Workflow can be applied to Explore
-operations. See the [Key Concepts](#key-concepts) section above for operation
-types and key terminology.
+operations.
 
 For full details on operators: read `docs/user-guide/operators/working-with-operators.md`
 if the source repo is available, otherwise see
@@ -242,8 +241,7 @@ output identifiers.
 
 An operation can create the following resources
 
-- discovery spaces: a space produced by the operation — examine it using the
-  [examining-discovery-spaces](../examining-discovery-spaces/SKILL.md) skill
+- discovery spaces: a space produced by the operation
 - operations: child operations spawned by the operation — recursively examine
   them using this skill
 - datacontainers: non-ado outputs (e.g. CSV data) produced by the operation
@@ -261,15 +259,12 @@ For each output resource summarize what it is/contains.
 
 The following assumes the General Workflow has been applied.
 
-An explore operation works by sampling entities from its input space and
-measuring them. Key things to check:
+An explore operation samples entities from a discovery space and
+measures them. Key things to check:
 
 - The operation parameters specify how many entities to sample and with what
-  strategy (see the operator schema from step 3)
-- Memoization may mean some sampled entities were not re-measured — their
-  results were replayed from the sample store (see [Memoization](#memoization)
-  in Key Concepts above)
-
+  strategy 
+- Memoization may mean the measurements for some sampled entities were were replayed from the sample store.
 Relevant Documentation
 
 - Sample process: <https://ibm.github.io/ado/latest/concepts/discovery-spaces/#sampling-and-measurement>

--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -263,8 +263,9 @@ An explore operation samples entities from a discovery space and
 measures them. Key things to check:
 
 - The operation parameters specify how many entities to sample and with what
-  strategy 
-- Memoization may mean the measurements for some sampled entities were were replayed from the sample store.
+  strategy
+- Memoization may mean the measurements for some sampled entities were replayed
+  from the sample store.
 Relevant Documentation
 
 - Sample process: <https://ibm.github.io/ado/latest/concepts/discovery-spaces/#sampling-and-measurement>

--- a/.cursor/skills/examining-ado-operations/SKILL.md
+++ b/.cursor/skills/examining-ado-operations/SKILL.md
@@ -31,16 +31,63 @@ on, and whether measurements and results look healthy.
 - For a project/context wide view (all spaces and operations), see
   [examining-ado-project](../examining-ado-project/SKILL.md).
 
+## Key Concepts
+
+> **The definitions below are sufficient for applying this skill.**
+> Only consult the source docs if you need detail beyond what is inlined here:
+> read `docs/resources/operation.md`, `docs/concepts/data-sharing.md`, or
+> `docs/concepts/discovery-spaces.md` if the source repo is available,
+> otherwise see <https://ibm.github.io/ado/latest/resources/operation/>,
+> <https://ibm.github.io/ado/latest/concepts/data-sharing/>, or
+> <https://ibm.github.io/ado/latest/concepts/discovery-spaces/>.
+
+### Operation types
+
+- **explore** — samples entities from a space and measures them
+  (e.g. random_walk, ray_tune)
+- **modify** — modifies a space (e.g. adds or removes dimensions)
+- **characterize** — analyses existing measurements in a space
+- **compare** — compares two or more spaces or operations
+- **fuse** — fuses multiple spaces into one
+- **learn** — trains a model or learns from measurements
+
+### Measured vs Matching
+
+- **measured**: entities and results recorded by this operation (and other
+  operations run directly on the same space)
+- **matching**: all entities and measurements in the sample store that are
+  compatible with the space this operation ran on — includes measured entities
+  plus any compatible data from operations on other spaces sharing the same
+  sample store
+
+### Memoization
+
+When an explore operation samples an entity, ado checks whether results for
+the required experiments already exist in the sample store (matched on
+constitutive property values). If memoization is enabled and matching results
+are found, those results are **replayed** rather than re-running the
+experiment. These requests appear as "replayed measurements" in the trace.
+If the same entity is sampled twice within one operation before the first
+result is stored, memoization cannot intercept the second request and the
+entity is measured twice.
+
 ## Context
 
 Operations are applied to discoveryspaces. There are different types of
 operation. The General Workflow can be applied to all types of operation.
 
-In addition, the Explore Operation Workflow can be applied to
-Explore operations.
+In addition, the Explore Operation Workflow can be applied to Explore
+operations. See the [Key Concepts](#key-concepts) section above for operation
+types and key terminology.
 
-- Read [operations](../../../docs/resources/operation.md) documentation
-  for details
+For full details on operators: read `docs/user-guide/operators/working-with-operators.md`
+if the source repo is available, otherwise see
+<https://ibm.github.io/ado/latest/user-guide/operators/working-with-operators/>.
+To inspect any operator's parameters directly, run:
+
+```bash
+uv run ado template operation --operator-name $OPERATOR_IDENTIFIER --include-schema
+```
 
 ## Pre-requisites: The Operation Identifier
 
@@ -163,7 +210,7 @@ uv run ado template operation --operator-name $OPERATOR_IDENTIFIER --include-sch
 This will create a file called `operation_template_$UID_schema.yaml` containing
 the schema.
 
-### Step 4: Describe the space
+### Step 4: Describe the space the operation ran on
 
 Using the space id from step 1
 
@@ -172,11 +219,10 @@ uv run ado get space SPACE_ID -o yaml --output-file SPACE_ID.yaml
 uv run ado describe space SPACE_ID
 ```
 
-Summarise the: **dimensions** (parameters), **experiments** (actuators,
-experiment types), **entity space** structure, and notable **constraints** or
-metadata. For deeper context, read operator and experiment documentation under
-`docs/user-guide/operators/` and actuator/experiment docs as needed (match
-**operatorIdentifier** and experiment types from the space).
+Summarise what the operation was working on: the **dimensions** (parameters)
+of the entity space, the **experiments** (actuators, experiment types) that
+define what can be measured, and any notable **constraints** or metadata.
+This gives context for interpreting the operation's results.
 
 ### Step 5: Get the output resources of the operation
 
@@ -196,9 +242,11 @@ output identifiers.
 
 An operation can create the following resources
 
-- discovery spaces: In this case examine the space as in step 3
-- operations: In this case recursively examine the operations using this skill
-- datacontainers: This contains non-ado resource outputs e.g. CSV data.
+- discovery spaces: a space produced by the operation — examine it using the
+  [examining-discovery-spaces](../examining-discovery-spaces/SKILL.md) skill
+- operations: child operations spawned by the operation — recursively examine
+  them using this skill
+- datacontainers: non-ado outputs (e.g. CSV data) produced by the operation
 
 To retrieve contents of data container. Use `--output-file` to ensure proper
 file handling:
@@ -213,20 +261,20 @@ For each output resource summarize what it is/contains.
 
 The following assumes the General Workflow has been applied.
 
-Explore operations sample entities from a discovery space and make
-measurements on them.
+An explore operation works by sampling entities from its input space and
+measuring them. Key things to check:
 
-Notes:
-
-- If the data for the measurements exists it can be memoized (depends on
-  operation parameters)
-- The operation parameters will specify the number of entities to sample in some
-  way.
+- The operation parameters specify how many entities to sample and with what
+  strategy (see the operator schema from step 3)
+- Memoization may mean some sampled entities were not re-measured — their
+  results were replayed from the sample store (see [Memoization](#memoization)
+  in Key Concepts above)
 
 Relevant Documentation
 
-- [sample process](../../../docs/concepts/discovery-spaces.md#sampling-and-measurement)
-- [memoization](../../../docs/concepts/data-sharing.md#memoization)
+- Sample process: <https://ibm.github.io/ado/latest/concepts/discovery-spaces/#sampling-and-measurement>
+- Memoization: <https://ibm.github.io/ado/latest/concepts/data-sharing/#memoization>
+- See also the [Key Concepts](#key-concepts) section above for inlined definitions.
 
 ### Step 1: Get Details on what was Sampled and Measured
 
@@ -319,10 +367,11 @@ the experiment and meaning of metrics when looking for patterns.
 
 Structure the report as:
 
-1. **Overview**: What the operation purpose was. Can be inferred from space and
-   operation chosen. Short and narrative.
+1. **Overview**: What the operation did and why. Can be inferred from the
+   operation config and the space it ran on. Short and narrative.
    - **Operation summary** – ID, operator, parameters, status
-   - **Space summary** – dimensions, experiments, entity count
+   - **Input space summary** – dimensions, experiments, entity count of the
+     space the operation ran on
 2. **Measurement overview** – sampled vs requested, success vs failure counts
 3. **Findings** – notable patterns, best/worst performers, anomalies
 4. **Unusual behaviour** – failures, timeouts, invalid results, unexpected

--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -18,9 +18,13 @@ related metadata in the ado project associated to the active context.
 - The report produced by this skill is stored as a
   `document` resource in the active ado metastore context (see
   [Producing a report](#step-7-write-the-report)).
-- See
-  [projects and contexts](../../../docs/resources/metastore.md#contexts-and-projects)
-  for details on what projects and contexts are
+- A **project** is the namespace for all ado resources (spaces, operations,
+  stores). A **context** is the local config pointing to a project's metastore
+  (SQLite for local projects, MySQL for remote). Context name equals project
+  name by construction. This definition is sufficient for applying this skill.
+  Only consult the source if you need full schema details: read
+  `docs/resources/metastore.md` if the source repo is available, otherwise see
+  <https://ibm.github.io/ado/latest/resources/metastore/#contexts-and-projects>.
 - Users may refer to an ado project using either the term "project" or "context"
 
 ## Tips

--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -18,10 +18,9 @@ related metadata in the ado project associated to the active context.
 - The report produced by this skill is stored as a
   `document` resource in the active ado metastore context (see
   [Producing a report](#step-7-write-the-report)).
-- A **project** is the namespace for all ado resources (spaces, operations,
-  stores). A **context** is the local config pointing to a project's metastore
-  (SQLite for local projects, MySQL for remote). Context name equals project
-  name by construction. This definition is sufficient for applying this skill.
+- A **project** is a namespace for a set of ado resources (spaces, operations,
+  stores). A **context** is the local config pointing to a project's metastore. 
+  Context name equals project name by construction. This definition is sufficient for applying this skill.
   Only consult the source if you need full schema details: read
   `docs/resources/metastore.md` if the source repo is available, otherwise see
   <https://ibm.github.io/ado/latest/resources/metastore/#contexts-and-projects>.

--- a/.cursor/skills/examining-ado-project/SKILL.md
+++ b/.cursor/skills/examining-ado-project/SKILL.md
@@ -19,8 +19,9 @@ related metadata in the ado project associated to the active context.
   `document` resource in the active ado metastore context (see
   [Producing a report](#step-7-write-the-report)).
 - A **project** is a namespace for a set of ado resources (spaces, operations,
-  stores). A **context** is the local config pointing to a project's metastore. 
-  Context name equals project name by construction. This definition is sufficient for applying this skill.
+  stores). A **context** is the local config pointing to a project's metastore.
+  Context name equals project name by construction. This definition is
+  sufficient for applying this skill.
   Only consult the source if you need full schema details: read
   `docs/resources/metastore.md` if the source repo is available, otherwise see
   <https://ibm.github.io/ado/latest/resources/metastore/#contexts-and-projects>.

--- a/.cursor/skills/examining-discovery-spaces/SKILL.md
+++ b/.cursor/skills/examining-discovery-spaces/SKILL.md
@@ -68,7 +68,7 @@ Why is it useful to work with matching data?
 2. Memoization: You can understand if there are memoization opportunities that
    would speed up an operation on the space. When `MATCHING_ENTITIES` is
    significantly larger than `MEASURED_ENTITIES`, data from other operations
-   sharing the same sample store could be replayed — no re-measurement needed.
+   sharing the same sample store could be replayed.
 
    > The explanation above is sufficient for assessing memoization opportunities.
    > Only consult the source if you need more detail: read

--- a/.cursor/skills/examining-discovery-spaces/SKILL.md
+++ b/.cursor/skills/examining-discovery-spaces/SKILL.md
@@ -65,9 +65,15 @@ Why is it useful to work with matching data?
    - Concrete example: You create a discoveryspace that is a subspace of another
      sampled spaced to analyze it. You can perform analysis on existing data
      even though no operation has been run on the new discoveryspace.
-2. Memoization: You can understand if there are
-   [memoization opportunities](docs/concepts/data-sharing.md) that
-   would speed up a operation on the space.
+2. Memoization: You can understand if there are memoization opportunities that
+   would speed up an operation on the space. When `MATCHING_ENTITIES` is
+   significantly larger than `MEASURED_ENTITIES`, data from other operations
+   sharing the same sample store could be replayed — no re-measurement needed.
+
+   > The explanation above is sufficient for assessing memoization opportunities.
+   > Only consult the source if you need more detail: read
+   > `docs/concepts/data-sharing.md` if the source repo is available, otherwise
+   > see <https://ibm.github.io/ado/latest/concepts/data-sharing/>.
 
 ## Pre-requisites: The Space Identifier
 

--- a/.cursor/skills/formulate-discovery-problem/SKILL.md
+++ b/.cursor/skills/formulate-discovery-problem/SKILL.md
@@ -96,20 +96,7 @@ uv run ado template space --from-experiment $EXPERIMENT_ID --output-file space.y
 
 **Manual structure:**
 
-```yaml
-sampleStoreIdentifier: default # or existing store ID
-entitySpace:
-  - identifier: property_name
-    propertyDomain:
-      variableType: DISCRETE_VARIABLE_TYPE
-      values: [value1, value2, value3]
-experiments:
-  - actuatorIdentifier: actuator_name
-    experimentIdentifier: experiment_name
-metadata:
-  name: space_name
-  description: Description of the discovery space
-```
+See [skill-manual-structure.yaml](yaml-examples/skill-manual-structure.yaml).
 
 ### Step 1c: Validate DiscoverySpace YAML
 
@@ -151,24 +138,9 @@ Review the template and configure parameters based on:
 
 **Structure:**
 
-```yaml
-spaces:
-  - space_identifier # From Phase 1
-operation:
-  module:
-    operatorName: random_walk # could be any operator_name
-    operationType: explore # or modify, characterize, etc.
-  parameters:
-    # These must include the appropriate parameters for the operator
-    # that is defined by operatorName. In this case we override
-    # defaults from RandomWalkParameters
-    numberEntities: 100
-    batchSize: 10
-actuatorConfigurationIdentifiers: [actuator_config_id] # Optional
-metadata:
-  name: operation_name
-  description: Description of the operation
-```
+See
+[skill-operation-structure.yaml](yaml-examples/skill-operation-structure.yaml)
+for an example structure.
 
 ### Step 2d: Validate Operation YAML
 
@@ -206,28 +178,18 @@ Fix validation errors and repeat validation until successful.
 
 **Discrete (categorical):**
 
-```yaml
-propertyDomain:
-  variableType: DISCRETE_VARIABLE_TYPE
-  values: [option1, option2, option3]
-```
+See
+[skill-property-domain-discrete-categorical.yaml](yaml-examples/skill-property-domain-discrete-categorical.yaml).
 
 **Discrete (numeric):**
 
-```yaml
-propertyDomain:
-  variableType: DISCRETE_VARIABLE_TYPE
-  domainRange: [min, max]
-  values: [1, 2, 4, 8, 16]
-```
+See
+[skill-property-domain-discrete-numeric.yaml](yaml-examples/skill-property-domain-discrete-numeric.yaml).
 
 **Continuous:**
 
-```yaml
-propertyDomain:
-  variableType: CONTINUOUS_VARIABLE_TYPE
-  domainRange: [min, max]
-```
+See
+[skill-property-domain-continuous.yaml](yaml-examples/skill-property-domain-continuous.yaml).
 
 ## Validation Checklist
 
@@ -268,6 +230,7 @@ Before finalizing, verify:
 ## Additional Resources
 
 - For detailed schema information, see [reference.md](reference.md)
+- For example workflows, see [examples.md](examples.md)
 - For Pydantic model details when writing code, see the resource model table
   and schema-inspection snippet in
   [query-ado-data — Using Resource models](../query-ado-data/SKILL.md#using-resource-models)

--- a/.cursor/skills/formulate-discovery-problem/SKILL.md
+++ b/.cursor/skills/formulate-discovery-problem/SKILL.md
@@ -54,29 +54,17 @@ create YAML for task → validate YAML → iterate.
 uv run ado get experiments --details
 ```
 
-**Get structured experiment properties** (required, optional, target) as a
-YAML template — this is more reliable for agents than the human-readable
-`describe` output:
+**Describe a specific experiment:**
 
 ```bash
-uv run ado template space --from-experiment $EXPERIMENT_ID --output-file space.yaml
+uv run ado describe experiment $EXPERIMENT_ID
 ```
 
-The generated YAML has all required constitutive properties pre-filled in
-`entitySpace` and all optional properties commented out with their defaults.
-Read the template to extract:
+**Key information to gather:**
 
-| Property category | Where in template | What it means |
-| --- | --- | --- |
-| Required constitutive | `entitySpace` entries | Must be present in entity space |
-| Optional | commented-out `entitySpace` entries | Can keep default or add to space |
-| Target (measured outputs) | `experiments[].targetProperties` | What the experiment produces |
-
-If you need the human-readable description for context (not for parsing):
-
-```bash
-uv run ado describe experiment $ACTUATOR_ID.$EXPERIMENT_ID
-```
+- Required constitutive properties (must be in entity space)
+- Optional properties (can use defaults or add to entity space)
+- Target properties (what the experiment measures)
 
 #### What to do if no experiment matching task available
 

--- a/.cursor/skills/formulate-discovery-problem/SKILL.md
+++ b/.cursor/skills/formulate-discovery-problem/SKILL.md
@@ -54,17 +54,29 @@ create YAML for task → validate YAML → iterate.
 uv run ado get experiments --details
 ```
 
-**Describe a specific experiment:**
+**Get structured experiment properties** (required, optional, target) as a
+YAML template — this is more reliable for agents than the human-readable
+`describe` output:
 
 ```bash
-uv run ado describe experiment $EXPERIMENT_ID
+uv run ado template space --from-experiment $EXPERIMENT_ID --output-file space.yaml
 ```
 
-**Key information to gather:**
+The generated YAML has all required constitutive properties pre-filled in
+`entitySpace` and all optional properties commented out with their defaults.
+Read the template to extract:
 
-- Required constitutive properties (must be in entity space)
-- Optional properties (can use defaults or add to entity space)
-- Target properties (what the experiment measures)
+| Property category | Where in template | What it means |
+| --- | --- | --- |
+| Required constitutive | `entitySpace` entries | Must be present in entity space |
+| Optional | commented-out `entitySpace` entries | Can keep default or add to space |
+| Target (measured outputs) | `experiments[].targetProperties` | What the experiment produces |
+
+If you need the human-readable description for context (not for parsing):
+
+```bash
+uv run ado describe experiment $ACTUATOR_ID.$EXPERIMENT_ID
+```
 
 #### What to do if no experiment matching task available
 
@@ -84,7 +96,20 @@ uv run ado template space --from-experiment $EXPERIMENT_ID --output-file space.y
 
 **Manual structure:**
 
-See [skill-manual-structure.yaml](yaml-examples/skill-manual-structure.yaml).
+```yaml
+sampleStoreIdentifier: default # or existing store ID
+entitySpace:
+  - identifier: property_name
+    propertyDomain:
+      variableType: DISCRETE_VARIABLE_TYPE
+      values: [value1, value2, value3]
+experiments:
+  - actuatorIdentifier: actuator_name
+    experimentIdentifier: experiment_name
+metadata:
+  name: space_name
+  description: Description of the discovery space
+```
 
 ### Step 1c: Validate DiscoverySpace YAML
 
@@ -118,15 +143,32 @@ Review the template and configure parameters based on:
 
 - User's query/goals
 - Operator documentation
-- Example operations in `examples/`
+- If the source repo is available, check `examples/` for real-world YAML files.
+  Otherwise use `uv run ado template operation --operator-name $OP` as the
+  starting point.
 
 ### Step 2c: Create Operation YAML
 
 **Structure:**
 
-See
-[skill-operation-structure.yaml](yaml-examples/skill-operation-structure.yaml)
-for an example structure.
+```yaml
+spaces:
+  - space_identifier # From Phase 1
+operation:
+  module:
+    operatorName: random_walk # could be any operator_name
+    operationType: explore # or modify, characterize, etc.
+  parameters:
+    # These must include the appropriate parameters for the operator
+    # that is defined by operatorName. In this case we override
+    # defaults from RandomWalkParameters
+    numberEntities: 100
+    batchSize: 10
+actuatorConfigurationIdentifiers: [actuator_config_id] # Optional
+metadata:
+  name: operation_name
+  description: Description of the operation
+```
 
 ### Step 2d: Validate Operation YAML
 
@@ -164,18 +206,28 @@ Fix validation errors and repeat validation until successful.
 
 **Discrete (categorical):**
 
-See
-[skill-property-domain-discrete-categorical.yaml](yaml-examples/skill-property-domain-discrete-categorical.yaml).
+```yaml
+propertyDomain:
+  variableType: DISCRETE_VARIABLE_TYPE
+  values: [option1, option2, option3]
+```
 
 **Discrete (numeric):**
 
-See
-[skill-property-domain-discrete-numeric.yaml](yaml-examples/skill-property-domain-discrete-numeric.yaml).
+```yaml
+propertyDomain:
+  variableType: DISCRETE_VARIABLE_TYPE
+  domainRange: [min, max]
+  values: [1, 2, 4, 8, 16]
+```
 
 **Continuous:**
 
-See
-[skill-property-domain-continuous.yaml](yaml-examples/skill-property-domain-continuous.yaml).
+```yaml
+propertyDomain:
+  variableType: CONTINUOUS_VARIABLE_TYPE
+  domainRange: [min, max]
+```
 
 ## Validation Checklist
 
@@ -216,13 +268,9 @@ Before finalizing, verify:
 ## Additional Resources
 
 - For detailed schema information, see [reference.md](reference.md)
-- For example workflows, see [examples.md](examples.md)
-- For Pydantic model details, examine:
-  - `ado/schema/experiment.py`
-  - `ado/schema/measurementspace.py`
-  - `ado/schema/entityspace.py`
-  - `ado/core/discoveryspace/config.py`
-  - `ado/core/operation/operation.py`
+- For Pydantic model details when writing code, see the resource model table
+  and schema-inspection snippet in
+  [query-ado-data — Using Resource models](../query-ado-data/SKILL.md#using-resource-models)
 
 ## References
 

--- a/.cursor/skills/formulate-discovery-problem/reference.md
+++ b/.cursor/skills/formulate-discovery-problem/reference.md
@@ -47,35 +47,106 @@ See
 exclusive** — valid values satisfy `lower <= value < upper`. The upper endpoint
 itself is **not** in the domain.
 
-See
-[properties and domains](../../../docs/concepts/properties-and-domains.md)
-for the full discussion.
+> **The content below is sufficient for writing and validating YAML.**
+> Only go deeper if you encounter an edge case not covered here:
+> read `docs/concepts/properties-and-domains.md` if the source repo is available,
+> otherwise see <https://ibm.github.io/ado/latest/concepts/properties-and-domains/>.
 
 ### Variable Types
 
-**DISCRETE_VARIABLE_TYPE:**
+**DISCRETE_VARIABLE_TYPE** — a finite set of numeric values.
 
-- Numeric values from a finite set
-- Use `values` for explicit list: `[1, 2, 4, 8]`
-- Use `domainRange` + `interval` for ranges: `domainRange: [1, 10], interval: 1`
-  (upper bound exclusive — see [above](#domain-range-bounds-numeric))
+```yaml
+# explicit list
+domain:
+  values: [1, 2, 4, 8, 16, 32, 64, 128]
 
-**CONTINUOUS_VARIABLE_TYPE:**
+# range with interval (lower inclusive, upper exclusive)
+domain:
+  domainRange: [1, 129]
+  interval: 1
+```
 
-- Real-valued range
-- Requires `domainRange: [min, max]` (upper bound exclusive — see
-  [above](#domain-range-bounds-numeric))
-- Cannot enumerate all values
+**CONTINUOUS_VARIABLE_TYPE** — a continuous real-valued range.
 
-**CATEGORICAL_VARIABLE_TYPE:**
+```yaml
+# bounded range (upper bound exclusive)
+domain:
+  domainRange: [0.0, 1.0]
 
-- String or other categorical values
-- Requires `values: ["option1", "option2", ...]`
+# unbounded (any real number)
+domain:
+  variableType: CONTINUOUS_VARIABLE_TYPE
+```
 
-**BINARY_VARIABLE_TYPE:**
+**CATEGORICAL_VARIABLE_TYPE** — a finite, named set of values (strings or
+numbers).
 
-- Boolean or two-value categorical
-- No domain specification needed
+```yaml
+domain:
+  values: [granite-3-8b, llama3-8b, mistral-7b-v0.1]
+```
+
+**BINARY_VARIABLE_TYPE** — exactly two values: `true` and `false`. No
+`values` or `domainRange` needed.
+
+```yaml
+domain:
+  variableType: BINARY_VARIABLE_TYPE
+```
+
+**OPEN_CATEGORICAL_VARIABLE_TYPE** — categorical values where the complete
+set is not known in advance (e.g. molecule identifiers, AI model names). Must
+be declared explicitly; an optional `values` field can seed known categories.
+
+```yaml
+domain:
+  variableType: OPEN_CATEGORICAL_VARIABLE_TYPE
+
+# with seed values
+domain:
+  variableType: OPEN_CATEGORICAL_VARIABLE_TYPE
+  values: [pigeon-10.mps.gz]
+```
+
+### Auto-inference of variable type
+
+When `variableType` is omitted, ado infers the type from other fields:
+
+| Fields present | Inferred type |
+| --- | --- |
+| `values` with all numeric entries | `DISCRETE_VARIABLE_TYPE` |
+| `values` with any non-numeric entry | `CATEGORICAL_VARIABLE_TYPE` |
+| `domainRange` only (no `interval`) | `CONTINUOUS_VARIABLE_TYPE` |
+| `domainRange` + `interval` | `DISCRETE_VARIABLE_TYPE` |
+| `interval` only (no `domainRange`) | `DISCRETE_VARIABLE_TYPE` |
+
+`BINARY_VARIABLE_TYPE` and `OPEN_CATEGORICAL_VARIABLE_TYPE` cannot be
+inferred and must always be declared explicitly.
+
+### probabilityFunction field
+
+Each domain can optionally specify how values are sampled. Default is
+**uniform** — every value equally likely.
+
+```yaml
+domain:
+  values: [1, 2, 4, 8, 16]
+  probabilityFunction:
+    identifier: uniform
+```
+
+A **normal** distribution is available for continuous and discrete domains:
+
+```yaml
+domain:
+  domainRange: [0.0, 1.0]
+  probabilityFunction:
+    identifier: normal
+    parameters:
+      mean: 0.5
+      std: 0.1
+```
 
 ## Operation Configuration Schema
 
@@ -130,6 +201,46 @@ property domain:
 - For discrete: All entity space values must be in experiment's domain values
 - For continuous: Entity space range must be within experiment's range
 - For categorical: Entity space values must be subset of experiment's values
+
+### Compatible Subdomain Types
+
+Not every combination of domain types is valid — the subdomain type must be
+compatible with the parent type:
+
+| Parent domain | Compatible sub-domain types |
+| --- | --- |
+| `CONTINUOUS` | `CONTINUOUS`, `DISCRETE` (finite), `BINARY` |
+| `DISCRETE` | `DISCRETE`, `BINARY` |
+| `CATEGORICAL` | `CATEGORICAL`, `DISCRETE` (finite), `BINARY` |
+| `BINARY` | `BINARY`, `DISCRETE` (≤2 values) |
+| `OPEN_CATEGORICAL` | `OPEN_CATEGORICAL`, `CATEGORICAL`, `DISCRETE` (finite), `BINARY` |
+
+**Example** — narrowing an experiment's domains to a focused entity space:
+
+```yaml
+# Experiment input domains (maximum possible extent)
+- identifier: model_name
+  propertyDomain:
+    values: [granite-3-8b, llama3-8b, mistral-7b-v0.1, granite-34b-code-base]
+- identifier: batch_size
+  propertyDomain:
+    domainRange: [1, 4097]
+    interval: 1
+- identifier: temperature
+  propertyDomain:
+    domainRange: [0.0, 100.0]
+
+# Valid entity space subdomains
+- identifier: model_name
+  propertyDomain:
+    values: [granite-3-8b, llama3-8b]   # CATEGORICAL ⊆ CATEGORICAL ✓
+- identifier: batch_size
+  propertyDomain:
+    values: [1, 2, 4, 8, 16]            # DISCRETE ⊆ DISCRETE ✓
+- identifier: temperature
+  propertyDomain:
+    domainRange: [20.0, 40.0]           # CONTINUOUS ⊆ CONTINUOUS ✓
+```
 
 ### Validation
 

--- a/.cursor/skills/formulate-discovery-problem/reference.md
+++ b/.cursor/skills/formulate-discovery-problem/reference.md
@@ -124,30 +124,6 @@ When `variableType` is omitted, ado infers the type from other fields:
 `BINARY_VARIABLE_TYPE` and `OPEN_CATEGORICAL_VARIABLE_TYPE` cannot be
 inferred and must always be declared explicitly.
 
-### probabilityFunction field
-
-Each domain can optionally specify how values are sampled. Default is
-**uniform** — every value equally likely.
-
-```yaml
-domain:
-  values: [1, 2, 4, 8, 16]
-  probabilityFunction:
-    identifier: uniform
-```
-
-A **normal** distribution is available for continuous and discrete domains:
-
-```yaml
-domain:
-  domainRange: [0.0, 1.0]
-  probabilityFunction:
-    identifier: normal
-    parameters:
-      mean: 0.5
-      std: 0.1
-```
-
 ## Operation Configuration Schema
 
 ### Core Structure

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -68,7 +68,7 @@ To inspect a model's JSON schema without reading the source:
 ```python
 uv run python -c \
   "from ado.core.discoveryspace.resource import DiscoverySpaceResource; \
-import json; print(json.dumps(DiscoverySpaceResource.model_json_schema(), indent=2))"
+import json; print(json.dumps(DiscoverySpaceResource.model_json_schema()))"
 ```
 
 Replace `DiscoverySpaceResource` with any class from the table above.

--- a/.cursor/skills/query-ado-data/SKILL.md
+++ b/.cursor/skills/query-ado-data/SKILL.md
@@ -51,17 +51,27 @@ DONTs
 
 ### Using Resource models
 
-Each resource has a pydantic model. If working in code you can use these models
+Each resource type has a Pydantic model. If working in code you can import these
+models directly (source repo required) or inspect their JSON schema via Python.
 
-- discoveryspace, ado/core/discoveryspace/resource.py:
-  DiscoverySpaceResource
-- samplestore, ado/core/samplestore/resource.py: SampleStoreResource
-- datacontainer, ado/core/datacontainer/resource.py:
-  DataContainerResource
-- operation, ado/core/operation/resource.py: OperationResource
-- actuatorconfiguration, ado/core/actuatorconfiguration/resource.py:
-  ActuatorConfigurationResource
-- document, ado/core/document/resource.py: DocumentResource
+| Resource type | Class | Import path |
+| --- | --- | --- |
+| `discoveryspace` | `DiscoverySpaceResource` | `ado.core.discoveryspace.resource` |
+| `samplestore` | `SampleStoreResource` | `ado.core.samplestore.resource` |
+| `datacontainer` | `DataContainerResource` | `ado.core.datacontainer.resource` |
+| `operation` | `OperationResource` | `ado.core.operation.resource` |
+| `actuatorconfiguration` | `ActuatorConfigurationResource` | `ado.core.actuatorconfiguration.resource` |
+| `document` | `DocumentResource` | `ado.core.document.resource` |
+
+To inspect a model's JSON schema without reading the source:
+
+```python
+uv run python -c \
+  "from ado.core.discoveryspace.resource import DiscoverySpaceResource; \
+import json; print(json.dumps(DiscoverySpaceResource.model_json_schema(), indent=2))"
+```
+
+Replace `DiscoverySpaceResource` with any class from the table above.
 
 ## Querying Metadata
 
@@ -150,7 +160,8 @@ uv run ado get document -q 'config.metadata.name=project_report' --details
 uv run ado get document -q 'config.metadata.name=study-$ID' --details
 ```
 
-For extensive examples, see `docs/resources/metastore.md`.
+For extensive examples, see
+<https://ibm.github.io/ado/latest/resources/metastore/>
 
 ### Filtering by Labels
 
@@ -366,8 +377,15 @@ uv run ado show related space SPACE_ID
 
 ## Advanced Filtering
 
-The metastore class can provide more powerful querying via scripts. See
-ado/metastore/sqlstore.py
+The metastore class can provide more powerful querying via scripts. Inspect
+the available API with:
+
+```python
+uv run python -c "from ado.metastore.sqlstore import SQLResourceStore; help(SQLResourceStore)"
+```
+
+If the source repo is available, `ado/metastore/sqlstore.py` contains the full
+implementation.
 
 ## References
 

--- a/.cursor/skills/remote-execution/SKILL.md
+++ b/.cursor/skills/remote-execution/SKILL.md
@@ -254,7 +254,7 @@ additionalFiles:
   - path/to/my_data_dir/   # directories also supported
 ```
 
-Use bare filenames (no path) in space/operation YAML; ado symlinks
+Use bare filenames (no path) in space/operation YAML; ray copies
 `additionalFiles` entries into the Ray working directory.
 
 ### `runtimeEnv` block

--- a/.cursor/skills/remote-execution/SKILL.md
+++ b/.cursor/skills/remote-execution/SKILL.md
@@ -241,7 +241,8 @@ packages:
   fromPyPI:
     - ado-core
     - ado-ray-tune
-    - ray==2.52.1     # pin to match cluster version if needed
+    - ray==2.52.1                         # pin to match cluster version if needed
+    - /remote/path/to/package.whl         # path to a wheel already on the cluster
   fromSource:
     - plugins/actuators/my_plugin  # relative to where ado --remote is run
 ```

--- a/.cursor/skills/remote-execution/SKILL.md
+++ b/.cursor/skills/remote-execution/SKILL.md
@@ -25,7 +25,12 @@ morrigan_vllm_dev_execution.yaml # Morrigan + vllm_performance from source
 The file names are user-defined conventions. Check the repo root for any
 `*_execution.yaml` files to discover what contexts are available.
 
-See `docs/user-guide/remote-execution.md` for full schema reference.
+*If the source repo is available, read
+`docs/user-guide/advanced/remote-execution.md` directly. Otherwise see
+<https://ibm.github.io/ado/latest/user-guide/advanced/remote-execution/>*
+
+See [Execution Context YAML Reference](#execution-context-yaml-reference) below
+for the essential fields inlined.
 
 ---
 
@@ -184,3 +189,89 @@ the git node and a timestamp to every dirty or dev build (e.g.
 If you are still seeing stale wheels, confirm the plugin's `pyproject.toml`
 has the `format-jinja` block from the
 [plugin development rules](../../rules/plugin-development.mdc).
+
+---
+
+## Execution Context YAML Reference
+
+This section is self-contained — use it without reading any external file.
+Only go to the source for topics not covered here: read
+`docs/user-guide/advanced/remote-execution.md` if the source repo is available,
+otherwise see <https://ibm.github.io/ado/latest/user-guide/advanced/remote-execution/>.
+
+### Minimal — direct cluster URL
+
+```yaml
+executionType:
+  type: cluster
+  clusterUrl: "http://ray-cluster.my-namespace.svc.cluster.local:8265"
+packages:
+  fromPyPI:
+    - ado-core
+    - ado-ray-tune  # add any other plugins required
+envVars:
+  PYTHONUNBUFFERED: "x"
+  OMP_NUM_THREADS: "1"
+wait: false  # true = stay attached until the job finishes
+```
+
+### Port-forward cluster (OpenShift / Kubernetes)
+
+```yaml
+executionType:
+  type: cluster
+  clusterUrl: "http://localhost:8265"  # must match localPort below
+  portForward:
+    namespace: my-namespace
+    serviceName: my-ray-cluster-head-svc
+    localPort: 8265
+packages:
+  fromPyPI:
+    - ado-core
+    - ado-ray-tune
+envVars:
+  PYTHONUNBUFFERED: "x"
+wait: false
+```
+
+### `packages` block
+
+```yaml
+packages:
+  fromPyPI:
+    - ado-core
+    - ado-ray-tune
+    - ray==2.52.1     # pin to match cluster version if needed
+  fromSource:
+    - plugins/actuators/my_plugin  # relative to where ado --remote is run
+```
+
+### `additionalFiles` — ship local files to the cluster
+
+```yaml
+additionalFiles:
+  - /absolute/local/path/to/data_file.csv
+  - path/to/my_data_dir/   # directories also supported
+```
+
+Use bare filenames (no path) in space/operation YAML; ado symlinks
+`additionalFiles` entries into the Ray working directory.
+
+### `runtimeEnv` block
+
+```yaml
+runtimeEnv:
+  setupTimeoutSeconds: 1200  # default 600; -1 to disable
+  eagerInstall: false        # default true
+```
+
+### `envVars` block
+
+```yaml
+envVars:
+  PYTHONUNBUFFERED: "x"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  RAY_AIR_NEW_PERSISTENCE_MODE: "0"
+  MY_SECRET: "value"
+```

--- a/.cursor/skills/resource-yaml-creation/SKILL.md
+++ b/.cursor/skills/resource-yaml-creation/SKILL.md
@@ -215,7 +215,12 @@ uv run ado create samplestore -f samplestore.yaml
 
 Use `document` resources to persist markdown or HTML reports in the metastore.
 Set `contentType` to `markdown` (default) or `html`. See the
-[document resource documentation](../../../docs/resources/document.md).
+[document resource documentation](https://ibm.github.io/ado/latest/resources/document/).
+
+> The description above is sufficient for creating document resources.
+> Only consult the source for advanced options not covered here: read
+> `docs/resources/document.md` if the source repo is available, otherwise see
+> <https://ibm.github.io/ado/latest/resources/document/>.
 Examining skills store their reports this way: put the body in `content`,
 optionally set `contentType`, and list related resources in
 `relatedResources` with `id` and `role` (`parent` = report is about that

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           - --no-color
           - --verbose
           - --scopes
-          - anomalous-series,autoconf,changelog,ci,cli,container,contributing,core,cplex-mip,deps,docs,example-actuator,hooks,profile-space,ray-tune,sfttrainer,test,trim,vllm-performance,website,ordered-pip
+          - agents,anomalous-series,autoconf,changelog,ci,cli,container,contributing,core,cplex-mip,deps,docs,example-actuator,hooks,ordered-pip,profile-space,ray-tune,sfttrainer,test,trim,vllm-performance,website
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "requirements.txt|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-03T14:13:47Z",
+  "generated_at": "2026-08-04T09:54:37Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "f32b67c7e26342af42efabc674d441dca0a281c5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 276,
+        "line_number": 277,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "requirements.txt|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-30T10:09:44Z",
+  "generated_at": "2026-08-03T14:13:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,6 +77,16 @@
     }
   ],
   "results": {
+    ".cursor/skills/remote-execution/SKILL.md": [
+      {
+        "hashed_secret": "f32b67c7e26342af42efabc674d441dca0a281c5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "ado/cli/resources/context/template.py": [
       {
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ source = "uv-dynamic-versioning"
 [tool.hatch.build.targets.wheel]
 packages = ["ado"]
 
+[tool.hatch.build.targets.wheel.force-include]
+".agents/skills" = "ado/.agents/skills"
+
 # Read by Ray on first `import ray` (pytest-env runs when pytest starts, before conftest).
 [tool.pytest_env]
 RAY_ENABLE_UV_RUN_RUNTIME_ENV = "0"


### PR DESCRIPTION
## Summary

This branch makes the Bob agent skills for ado self-contained by inlining key concepts and YAML examples directly into each skill file, so agents can apply them without needing access to the source repository or local documentation files.

## High-level Changes

- **Agent skills updated to be self-contained**: Key concept definitions, YAML snippets, and schema references previously delegated to source-repo documentation files are now inlined directly into the relevant skill files (`examining-ado-operations`, `examining-discovery-spaces`, `examining-ado-project`, `formulate-discovery-problem`, `remote-execution`, `query-ado-data`, `resource-yaml-creation`). External doc links are replaced with public web URLs as fallbacks.
- **`remote-execution` skill extended**: A complete `Execution Context YAML Reference` section is added inline, covering all key configuration blocks (minimal, port-forward, packages, additionalFiles, runtimeEnv, envVars).
- **`formulate-discovery-problem` reference expanded**: Variable type definitions, auto-inference rules, probability function examples, and compatible subdomain type tables are now fully inlined in `reference.md`.
- **Skills packaged into the ado wheel**: The `.agents/skills` directory is now included in the installed wheel via a `force-include` entry in `pyproject.toml`, enabling skills to be shipped alongside the package.
- **Commit scope `agents` added** to the pre-commit changelog linter scopes.

## Impact

Agent workflows using these skills can now operate correctly in environments where only the installed `ado-core` package is available (e.g. remote clusters or isolated environments), without requiring a checkout of the source repository. No runtime behaviour or public API is changed.

---

> **AI Disclosure**: The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.