### PR TITLE
docs(cli): clarify MEASURED_ENTITIES includes failed measurements

### DIFF
--- a/.agents/skills/query-ado-data/SKILL.md
+++ b/.agents/skills/query-ado-data/SKILL.md
@@ -115,11 +115,10 @@ uv run ado get datacontainer DATACONTAINER_ID -o stats --no-trunc
 ```
 
 **Operations** extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-`FAILED_RESULTS`, `MEASURED_ENTITIES` (distinct entities with at least one
-result).
+`FAILED_RESULTS`, `MEASURED_ENTITIES` (includes failed measurements).
 
 **Discovery Spaces** extra columns: `EXPERIMENTS`, `OPERATIONS`,
-`EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
+`EXPLORE_OPERATIONS`, `MEASURED_ENTITIES` (includes failed measurements).
 
 **Sample Stores** extra columns: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
 

--- a/.agents/skills/query-ado-data/SKILL.md
+++ b/.agents/skills/query-ado-data/SKILL.md
@@ -115,10 +115,12 @@ uv run ado get datacontainer DATACONTAINER_ID -o stats --no-trunc
 ```
 
 **Operations** extra columns: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-`FAILED_RESULTS`, `MEASURED_ENTITIES` (includes failed measurements).
+`FAILED_RESULTS`, `MEASURED_ENTITIES` (entities with at least one measurement,
+whether successful, failed, or both).
 
 **Discovery Spaces** extra columns: `EXPERIMENTS`, `OPERATIONS`,
-`EXPLORE_OPERATIONS`, `MEASURED_ENTITIES` (includes failed measurements).
+`EXPLORE_OPERATIONS`, `MEASURED_ENTITIES` (entities with at least one
+measurement, whether successful, failed, or both).
 
 **Sample Stores** extra columns: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
 

--- a/ado/cli/commands/get.py
+++ b/ado/cli/commands/get.py
@@ -133,7 +133,7 @@ def get_resource(
             "--output",
             "-o",
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
-            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES — includes failed measurements), for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES), for sample stores (ENTITIES, RESULTS, EXPERIMENTS), and for data containers (TABLES, LOCATIONS, KEY_VALUES, DATA_BYTES). Not all formats may be supported by all resources.",
+            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES), for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES), for sample stores (ENTITIES, RESULTS, EXPERIMENTS), and for data containers (TABLES, LOCATIONS, KEY_VALUES, DATA_BYTES). MEASURED_ENTITIES counts entities with at least one measurement, whether successful, failed, or both. Not all formats may be supported by all resources.",
         ),
     ] = AdoGetSupportedOutputFormats.TABLE.value,
     exclude_default: Annotated[

--- a/ado/cli/commands/get.py
+++ b/ado/cli/commands/get.py
@@ -133,7 +133,7 @@ def get_resource(
             "--output",
             "-o",
             rich_help_panel=OUTPUT_CONFIGURATION_OPTIONS,
-            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES), for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES), for sample stores (ENTITIES, RESULTS, EXPERIMENTS), and for data containers (TABLES, LOCATIONS, KEY_VALUES, DATA_BYTES). Not all formats may be supported by all resources.",
+            help="Output information in a different format. The 'json', 'raw', and 'yaml' formats will output the entire resource. The 'name' format outputs only resource identifiers (similar to kubectl get -o name). The 'stats' format augments the default table with statistics columns: for operations (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES — includes failed measurements), for discovery spaces (EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS, MEASURED_ENTITIES), for sample stores (ENTITIES, RESULTS, EXPERIMENTS), and for data containers (TABLES, LOCATIONS, KEY_VALUES, DATA_BYTES). Not all formats may be supported by all resources.",
         ),
     ] = AdoGetSupportedOutputFormats.TABLE.value,
     exclude_default: Annotated[

--- a/ado/cli/resources/discovery_space/show_stats.py
+++ b/ado/cli/resources/discovery_space/show_stats.py
@@ -27,8 +27,8 @@ def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> Non
 
     Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE)
     plus lightweight stats columns (EXPERIMENTS, OPERATIONS,
-    EXPLORE_OPERATIONS, MEASURED_ENTITIES — includes failed measurements)
-    and heavy stats columns
+    EXPLORE_OPERATIONS, MEASURED_ENTITIES — entities with at least one
+    measurement, whether successful, failed, or both) and heavy stats columns
     (SIZE_OF_ENTITY_SPACE, UNMEASURED_ENTITIES, MATCHING_ENTITIES,
     MATCHING_WITH_MEASUREMENTS, ENTITIES_WITH_ALL_MEASUREMENTS,
     ENTITIES_WITH_PARTIAL_MEASUREMENTS,

--- a/ado/cli/resources/discovery_space/show_stats.py
+++ b/ado/cli/resources/discovery_space/show_stats.py
@@ -27,7 +27,8 @@ def show_discovery_space_stats(parameters: AdoShowStatsCommandParameters) -> Non
 
     Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE)
     plus lightweight stats columns (EXPERIMENTS, OPERATIONS,
-    EXPLORE_OPERATIONS, MEASURED_ENTITIES) and heavy stats columns
+    EXPLORE_OPERATIONS, MEASURED_ENTITIES — includes failed measurements)
+    and heavy stats columns
     (SIZE_OF_ENTITY_SPACE, UNMEASURED_ENTITIES, MATCHING_ENTITIES,
     MATCHING_WITH_MEASUREMENTS, ENTITIES_WITH_ALL_MEASUREMENTS,
     ENTITIES_WITH_PARTIAL_MEASUREMENTS,

--- a/ado/cli/resources/operation/show_stats.py
+++ b/ado/cli/resources/operation/show_stats.py
@@ -28,8 +28,8 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
     Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE,
     SPACE, STATUS, EXIT_STATE) plus result-level stats columns
     (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES
-    — includes failed measurements)
-    and request-level stats columns (TOTAL_REQUESTS, FAILED_REQUESTS,
+    — entities with at least one measurement, whether successful, failed,
+    or both) and request-level stats columns (TOTAL_REQUESTS, FAILED_REQUESTS,
     SUCCESSFUL_REQUESTS).
 
     Args:

--- a/ado/cli/resources/operation/show_stats.py
+++ b/ado/cli/resources/operation/show_stats.py
@@ -27,7 +27,8 @@ def show_operation_stats(parameters: AdoShowStatsCommandParameters) -> None:
 
     Outputs all standard ``ado get`` table columns (IDENTIFIER, NAME, AGE,
     SPACE, STATUS, EXIT_STATE) plus result-level stats columns
-    (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES)
+    (TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS, MEASURED_ENTITIES
+    — includes failed measurements)
     and request-level stats columns (TOTAL_REQUESTS, FAILED_REQUESTS,
     SUCCESSFUL_REQUESTS).
 

--- a/ado/cli/utils/resources/formatters.py
+++ b/ado/cli/utils/resources/formatters.py
@@ -261,7 +261,8 @@ def format_ado_get_stats_for_operations(
     Returns:
         The same DataFrame with extra columns appended.
         Always appended: ``TOTAL_RESULTS``, ``SUCCESSFUL_RESULTS``,
-        ``FAILED_RESULTS``, ``MEASURED_ENTITIES`` (includes failed measurements).
+        ``FAILED_RESULTS``, ``MEASURED_ENTITIES`` (entities with at least one
+        measurement, whether successful, failed, or both).
         Appended when *include_request_columns* is ``True``:
         ``TOTAL_REQUESTS``, ``FAILED_REQUESTS``, ``SUCCESSFUL_REQUESTS``.
         Operations with no recorded measurements show ``0`` in all stats
@@ -398,7 +399,8 @@ def format_ado_get_stats_for_spaces(
     Returns:
         The same DataFrame with extra columns appended.
         Lightweight columns: ``EXPERIMENTS``, ``OPERATIONS``,
-        ``EXPLORE_OPERATIONS``, ``MEASURED_ENTITIES`` (includes failed measurements).
+        ``EXPLORE_OPERATIONS``, ``MEASURED_ENTITIES`` (entities with at least
+        one measurement, whether successful, failed, or both).
         Heavy columns (only when ``include_heavy=True``):
         ``SIZE_OF_ENTITY_SPACE``, ``UNMEASURED_ENTITIES``,
         ``MATCHING_ENTITIES``, ``MATCHING_WITH_MEASUREMENTS``,

--- a/ado/cli/utils/resources/formatters.py
+++ b/ado/cli/utils/resources/formatters.py
@@ -261,7 +261,7 @@ def format_ado_get_stats_for_operations(
     Returns:
         The same DataFrame with extra columns appended.
         Always appended: ``TOTAL_RESULTS``, ``SUCCESSFUL_RESULTS``,
-        ``FAILED_RESULTS``, ``MEASURED_ENTITIES``.
+        ``FAILED_RESULTS``, ``MEASURED_ENTITIES`` (includes failed measurements).
         Appended when *include_request_columns* is ``True``:
         ``TOTAL_REQUESTS``, ``FAILED_REQUESTS``, ``SUCCESSFUL_REQUESTS``.
         Operations with no recorded measurements show ``0`` in all stats
@@ -398,7 +398,7 @@ def format_ado_get_stats_for_spaces(
     Returns:
         The same DataFrame with extra columns appended.
         Lightweight columns: ``EXPERIMENTS``, ``OPERATIONS``,
-        ``EXPLORE_OPERATIONS``, ``MEASURED_ENTITIES``.
+        ``EXPLORE_OPERATIONS``, ``MEASURED_ENTITIES`` (includes failed measurements).
         Heavy columns (only when ``include_heavy=True``):
         ``SIZE_OF_ENTITY_SPACE``, ``UNMEASURED_ENTITIES``,
         ``MATCHING_ENTITIES``, ``MATCHING_WITH_MEASUREMENTS``,

--- a/ado/cli/utils/resources/handlers.py
+++ b/ado/cli/utils/resources/handlers.py
@@ -373,7 +373,7 @@ def _handle_stats_format(
 
     Supported for:
     - operations (columns: TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS,
-      MEASURED_ENTITIES)
+      MEASURED_ENTITIES — includes failed measurements)
     - discovery spaces (columns: EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS,
       MEASURED_ENTITIES)
     - sample stores (columns: ENTITIES, RESULTS, EXPERIMENTS)

--- a/ado/cli/utils/resources/handlers.py
+++ b/ado/cli/utils/resources/handlers.py
@@ -373,7 +373,8 @@ def _handle_stats_format(
 
     Supported for:
     - operations (columns: TOTAL_RESULTS, SUCCESSFUL_RESULTS, FAILED_RESULTS,
-      MEASURED_ENTITIES — includes failed measurements)
+      MEASURED_ENTITIES — entities with at least one measurement, whether
+      successful, failed, or both)
     - discovery spaces (columns: EXPERIMENTS, OPERATIONS, EXPLORE_OPERATIONS,
       MEASURED_ENTITIES)
     - sample stores (columns: ENTITIES, RESULTS, EXPERIMENTS)

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -548,9 +548,9 @@ Where:
     - The `stats` format augments the default `table` output with additional
       statistics columns. Supported resource types and their columns are:
         - **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-          `FAILED_RESULTS`, `MEASURED_ENTITIES`.
+          `FAILED_RESULTS`, `MEASURED_ENTITIES` (includes failed measurements).
         - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`,
-          `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES`.
+          `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES` (includes failed measurements).
         - **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
         - **Data Containers**: `TABLES`, `LOCATIONS`, `KEY_VALUES`,
           `DATA_BYTES`.
@@ -1256,10 +1256,11 @@ The statistics columns produced per resource type are:
 <!-- prettier-ignore-start -->
 
 - **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
-  `MEASURED_ENTITIES`, `TOTAL_REQUESTS`, `FAILED_REQUESTS`,
-  `SUCCESSFUL_REQUESTS`.
+  `MEASURED_ENTITIES` (includes failed measurements), `TOTAL_REQUESTS`,
+  `FAILED_REQUESTS`, `SUCCESSFUL_REQUESTS`.
 - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`,
-  `MEASURED_ENTITIES`, `SIZE_OF_ENTITY_SPACE`, `UNMEASURED_ENTITIES`,
+  `MEASURED_ENTITIES` (includes failed measurements), `SIZE_OF_ENTITY_SPACE`,
+  `UNMEASURED_ENTITIES`,
   `MATCHING_ENTITIES`, `MATCHING_WITH_MEASUREMENTS`,
   `ENTITIES_WITH_ALL_MEASUREMENTS`, `ENTITIES_WITH_PARTIAL_MEASUREMENTS`,
   `MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS`.

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -548,9 +548,11 @@ Where:
     - The `stats` format augments the default `table` output with additional
       statistics columns. Supported resource types and their columns are:
         - **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`,
-          `FAILED_RESULTS`, `MEASURED_ENTITIES` (includes failed measurements).
+          `FAILED_RESULTS`, `MEASURED_ENTITIES` (entities with at least one
+          measurement, whether successful, failed, or both).
         - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`,
-          `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES` (includes failed measurements).
+          `EXPLORE_OPERATIONS`, `MEASURED_ENTITIES` (entities with at least one
+          measurement, whether successful, failed, or both).
         - **Sample Stores**: `ENTITIES`, `RESULTS`, `EXPERIMENTS`.
         - **Data Containers**: `TABLES`, `LOCATIONS`, `KEY_VALUES`,
           `DATA_BYTES`.
@@ -1256,11 +1258,12 @@ The statistics columns produced per resource type are:
 <!-- prettier-ignore-start -->
 
 - **Operations**: `TOTAL_RESULTS`, `SUCCESSFUL_RESULTS`, `FAILED_RESULTS`,
-  `MEASURED_ENTITIES` (includes failed measurements), `TOTAL_REQUESTS`,
-  `FAILED_REQUESTS`, `SUCCESSFUL_REQUESTS`.
+  `MEASURED_ENTITIES` (entities with at least one measurement, whether
+  successful, failed, or both), `TOTAL_REQUESTS`, `FAILED_REQUESTS`,
+  `SUCCESSFUL_REQUESTS`.
 - **Discovery Spaces**: `EXPERIMENTS`, `OPERATIONS`, `EXPLORE_OPERATIONS`,
-  `MEASURED_ENTITIES` (includes failed measurements), `SIZE_OF_ENTITY_SPACE`,
-  `UNMEASURED_ENTITIES`,
+  `MEASURED_ENTITIES` (entities with at least one measurement, whether
+  successful, failed, or both), `SIZE_OF_ENTITY_SPACE`, `UNMEASURED_ENTITIES`,
   `MATCHING_ENTITIES`, `MATCHING_WITH_MEASUREMENTS`,
   `ENTITIES_WITH_ALL_MEASUREMENTS`, `ENTITIES_WITH_PARTIAL_MEASUREMENTS`,
   `MATCHING_ENTITIES_WITH_ALL_MEASUREMENTS`.


### PR DESCRIPTION
## Summary

Clarifies that the `MEASURED_ENTITIES` stats column counts all entities that have at least one measurement result, **including entities whose measurements failed**. Previously this was undocumented, causing users to misinterpret the figure as counting only successful measurements.

## High-level Changes

- **CLI help text**: Updated the `--output` / `-o` flag description for `ado get` to note that `MEASURED_ENTITIES` includes failed measurements.
- **Public documentation**: Updated the CLI reference (`docs/cli-reference/index.md`) to clarify the same for both Operations and Discovery Spaces stats tables.
- **Docstrings**: Updated internal Python docstrings across the stats formatters, handlers, and show-stats modules to reflect the clarification.
- **Agent skill**: Updated the `query-ado-data` skill to carry the same note.

## Impact

Purely documentation/docstring change — no behaviour is altered. Users reading the CLI help or the reference docs will now have an accurate understanding of what `MEASURED_ENTITIES` counts, preventing misinterpretation of operation and discovery space statistics.

---

> **AI Disclosure**: The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.