### PR TITLE
docs: add outdated version warning banner to website

### DIFF
--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,13 @@
+<!--
+ Copyright IBM Corporation 2025, 2026
+ SPDX-License-Identifier: MIT
+-->
+
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ copyright: Copyright IBM Research.
 extra:
   version:
     provider: mike
+    default: latest
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/ibm/ado


### PR DESCRIPTION
## Summary

Adds an "outdated version" warning banner to the ado documentation website so that users browsing older published versions are automatically prompted to navigate to the latest one.

## High-level Changes

- **New MkDocs theme template** (`docs/theme/main.html`): overrides the `outdated` block to display a banner with a link to the latest docs whenever a non-latest version is being viewed.
- **`mkdocs.yml` update**: sets `default: latest` under the `mike` version provider so the versioning system knows which version is canonical, enabling the banner to appear correctly.

## Impact

Users visiting any older version of the documentation will now see a visible warning banner directing them to the latest version. There is no impact on the codebase, APIs, or runtime behaviour.

---

> **AI Disclosure:** The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.