### PR TITLE
docs: maintenance skill update

### DIFF
--- a/.agents/skills/ado-project-maintenance/SKILL.md
+++ b/.agents/skills/ado-project-maintenance/SKILL.md
@@ -113,17 +113,11 @@ Three labels make up the maintenance scheme.
 1. **Stale empty spaces**: no measured entities, older than a week.
 
    ```bash
-   uv run ado get spaces -o stats --details --output-file spaces-stats.txt
+   uv run ado show stats discoveryspace -o csv --output-file spaces-stats.csv
    ```
 
-   Then filter rows where `MEASURED_ENTITIES == 0`.
-
-   For each space use the value of `created` field
-   client-side to filter those older than a week
-
-   ```bash
-   uv run ado get space SPACE_ID -o yaml --output-file SPACE_ID.yaml
-   ```
+   Filter rows where `MEASURED_ENTITIES == 0`. Use the `AGE` column
+   (for example `7d0h` or greater) to keep only spaces older than a week.
 
    Deletion Reason: `empty-space-stale`.
 

--- a/.agents/skills/ado-project-maintenance/SKILL.md
+++ b/.agents/skills/ado-project-maintenance/SKILL.md
@@ -138,9 +138,12 @@ Three labels make up the maintenance scheme.
    `exit_state: error` and made zero measurements.
 
    ```bash
-   uv run ado get operations \
-     --filter 'status=[{"event":"finished","exit_state":"error"}]' -o stats
+   uv run ado show stats operation \
+     --filter 'status=[{"event":"finished","exit_state":"error"}]' \
+     -o csv --output-file operations-error-stats.csv
    ```
+
+   Filter rows where `MEASURED_ENTITIES == 0`.
 
    Deletion Reason: `error-no-entities`.
 

--- a/.agents/skills/ado-project-maintenance/SKILL.md
+++ b/.agents/skills/ado-project-maintenance/SKILL.md
@@ -202,7 +202,7 @@ Three labels make up the maintenance scheme.
 
    Deletion Reason: `superseded-project-report`.
 
-8. **Labeled `provisional`**: any resource carrying the `provisional` label
+8. **Labeled `provisional`**: any resource with label `provisional=true`
 
    Deletion Reason: `provisional`
 

--- a/.agents/skills/ado-project-maintenance/SKILL.md
+++ b/.agents/skills/ado-project-maintenance/SKILL.md
@@ -150,8 +150,8 @@ Three labels make up the maintenance scheme.
 
    Deletion Reason: `error-no-entities`.
 
-4. **Superseded operator runs**: multiple operations applying the same
-   operator to the same inputs, at different versions.
+4. **Superseded non-explore operator runs**: multiple operations
+   applying the same non-explore operator to the same inputs, at different versions.
 
    Group operations by `operatorIdentifier` (`ado/core/operation/resource.py`
    — form `name@MAJOR.MINOR.PATCH`, strict release semver only) plus input
@@ -167,7 +167,7 @@ Three labels make up the maintenance scheme.
    no single CLI filter that performs this grouping — do it as a
    script/manual pass over the YAML dump.
 
-   Deletion Reason: `superseded-operator-minor-version`.
+   Deletion Reason: `superseded-non-explore-operator-minor-version`.
 
 5. **Orphaned datacontainers**: datacontainers belonging to an operation
    that qualifies under conditions 2-4.
@@ -209,20 +209,7 @@ Three labels make up the maintenance scheme.
 
    Deletion Reason: `provisional`
 
-9. **Pre-release/testing operator package version**: an operation whose
-   `provenance.operators.<operatorIdentifier>.distributionVersion`
-    contains a pre-release, dev, or local segment (`a`, `b`, `rc`, `.dev`, `+`).
-
-   This field has no dedicated CLI filter so fetch operation YAML and
-   inspect it client-side:
-
-   ```bash
-   uv run ado get operations -o yaml --output-file operations.yaml
-   ```
-
-   Deletion Reason: `prerelease-operator-version`.
-
-10. **Old operations with status started and no-entities**
+9. **Old operations with status started and no-entities**
 
     Operations over a week old with status started, but which
     have not measured any entities, likely crashed in a way

--- a/.agents/skills/ado-project-maintenance/SKILL.md
+++ b/.agents/skills/ado-project-maintenance/SKILL.md
@@ -77,7 +77,7 @@ may be incorrect. This is operations which meet the following criteria
 - their status is started
 - they are over a week old
 - they have sampled entities successfully
-- their last recorded request (ado show trace) is more than a day ago
+- their last recorded request is more than a day ago
 
 These operations may have crashed in a way that meant the status
 could not be set.
@@ -208,9 +208,18 @@ Three labels make up the maintenance scheme.
 
 9. **Old operations with status started and no-entities**
 
-    Operations over a week old with status started, but which
-    have not measured any entities, likely crashed in a way
-    that failed to update the status field
+   Operations over a week old whose **current** status is started, but
+   which have not measured any entities. They likely crashed without a
+   finish event.
+
+   ```bash
+   uv run ado show stats operation -o csv --output-file operations-stats.csv
+   ```
+
+   Filter the `STATUS` column for rows where `STATUS == started`, `AGE`
+   is a week or more, and `MEASURED_ENTITIES == 0`.
+
+   Deletion Reason: `started-and-crashed-no-entities`.
 
 ## Related Skills
 

--- a/.agents/skills/resource-yaml-creation/SKILL.md
+++ b/.agents/skills/resource-yaml-creation/SKILL.md
@@ -43,10 +43,11 @@ to be meant for keeping long-term:
 ```yaml
 metadata:
   labels:
-    provisional: testing # or: debug, temporary
+    provisional: true
+    provisonal_reason: testing
 ```
 
-Canonical values:
+Use `provisional_reason` to record the reason with one of the following:
 
 - `testing` — created to test some new functionality.
 - `debug` — created to debug a problem.


### PR DESCRIPTION
Fix a variety of issues with maintenance skill: 

- superseeded should only apply to non-explore operators.
- remove pre-release condition as most operations are run from local repos
- more efficient provisional resource identification (label provisional=true)
- improve identification of operations with status started and no-entities
- use `ado show` to identify stale and empty spaces instead of `ado get` due to issues with parsing tables output by ado get

