### PR TITLE
fix(cli): improve edge-case handling when rendering timedeltas

### DIFF
--- a/ado/cli/utils/resources/formatters.py
+++ b/ado/cli/utils/resources/formatters.py
@@ -1008,14 +1008,27 @@ def timedelta_to_string(total_seconds: float) -> str:
     if math.isnan(total_seconds):
         return "NaT"
     if total_seconds < SECONDS_IN_A_MINUTE:
-        return f"{round(total_seconds)}s"
+        seconds = round(total_seconds)
+        if seconds == 60:
+            return "1m0s"
+        return f"{seconds}s"
     if total_seconds < SECONDS_IN_AN_HOUR:
-        minutes, seconds = divmod(total_seconds, SECONDS_IN_A_MINUTE)
-        return f"{int(minutes)}m{round(seconds)}s"
+        minutes, remainder = divmod(total_seconds, SECONDS_IN_A_MINUTE)
+        seconds = round(remainder)
+        if seconds == 60:
+            minutes += 1
+            seconds = 0
+        return f"{int(minutes)}m{seconds}s"
     if total_seconds < SECONDS_IN_A_DAY:
         hours, remainder = divmod(total_seconds, SECONDS_IN_AN_HOUR)
-        minutes = remainder / SECONDS_IN_A_MINUTE
-        return f"{int(hours)}h{round(minutes)}m"
+        minutes = round(remainder / SECONDS_IN_A_MINUTE)
+        if minutes == 60:
+            hours += 1
+            minutes = 0
+        return f"{int(hours)}h{minutes}m"
     days, remainder = divmod(total_seconds, SECONDS_IN_A_DAY)
-    hours = remainder / SECONDS_IN_AN_HOUR
-    return f"{int(days)}d{round(hours)}h"
+    hours = round(remainder / SECONDS_IN_AN_HOUR)
+    if hours == 24:
+        days += 1
+        hours = 0
+    return f"{int(days)}d{hours}h"

--- a/tests/ado/get/test_ado_get_stats.py
+++ b/tests/ado/get/test_ado_get_stats.py
@@ -31,6 +31,35 @@ _CREATED_7_DAYS_AGO = datetime.datetime.now(datetime.timezone.utc) - datetime.ti
 _EXPECTED_AGE = "7d0h"
 
 
+def test_timedelta_to_string_boundary_rounding() -> None:
+    """timedelta_to_string must not produce overflow values when rounding carries over."""
+    from ado.cli.utils.resources.formatters import timedelta_to_string
+
+    # 59.5s rounds to 60s → should be 1m0s, not 60s
+    assert timedelta_to_string(59.5) == "1m0s"
+    # Unambiguous sub-minute case
+    assert timedelta_to_string(30.0) == "30s"
+
+    # 4m 59.5s rounds seconds to 60 → should be 5m0s, not 4m60s
+    assert timedelta_to_string(4 * 60 + 59.5) == "5m0s"
+    # Unambiguous sub-hour case
+    assert timedelta_to_string(4 * 60 + 30.0) == "4m30s"
+
+    # 2h 59m 30s rounds minutes to 60 → should be 3h0m, not 2h60m
+    assert timedelta_to_string(2 * 3600 + 59 * 60 + 30.0) == "3h0m"
+    # Unambiguous sub-day case
+    assert timedelta_to_string(2 * 3600 + 30 * 60) == "2h30m"
+
+    # 189 days + 23h 59m 30s rounds hours to 24 → should be 190d0h, not 189d24h
+    assert (
+        timedelta_to_string(float(189 * 86400 + 23 * 3600 + 59 * 60 + 30)) == "190d0h"
+    )
+    # Exactly 190 days stays 190d0h
+    assert timedelta_to_string(float(190 * 86400)) == "190d0h"
+    # Unambiguous multi-day case
+    assert timedelta_to_string(float(189 * 86400 + 3600)) == "189d1h"
+
+
 @requires_sqlite_3_38
 def test_ado_get_operations_stats_columns_present(
     tmp_path: pathlib.Path,


### PR DESCRIPTION

## Summary

Fixes a rounding edge-case bug in the CLI duration formatter (`timedelta_to_string`) where values just below a unit boundary (e.g. 59.5 s) could round up into an invalid value (e.g. `60s`, `4m60s`, `2h60m`, `189d24h`). The fix carries over the overflow into the next unit, and a targeted test suite is added to cover all four boundary levels.

## High-level Changes

- **`ado/cli/utils/resources/formatters.py`** — `timedelta_to_string` now checks for rounding overflow at each time unit boundary (seconds → minutes, minutes → hours, hours → days) and promotes to the next unit instead of emitting an out-of-range value.
- **`tests/ado/get/test_ado_get_stats.py`** — New `test_timedelta_to_string_boundary_rounding` test covering all four overflow boundaries and their unambiguous non-overflow counterparts.

## Impact

Purely a display-layer fix. No data model, API, or stored resource is affected. Users may notice that durations very close to a unit boundary now render with the correct next-unit format (e.g. `1m0s` instead of `60s`).

---

> **AI Disclosure** — The code and this PR description were generated using [IBM Bob](https://bob.ibm.com/) and reviewed manually.
