### PR TITLE
feat(core): log and store experiment and actuator details in operation

### DIFF
--- a/ado/core/operation/resource.py
+++ b/ado/core/operation/resource.py
@@ -19,6 +19,7 @@ from ado.core.resources import (
     ADOResourceStatus,
     CoreResourceKinds,
 )
+from ado.schema.reference import ExperimentReference
 
 
 class OperationResourceEventEnum(enum.Enum):
@@ -73,6 +74,28 @@ class OperationProvenanceInfo(ProvenanceInfo):
             default_factory=dict,
             description=(
                 "Mapping of operator identifier to the Python distribution that "
+                "provided it at the time this operation was created."
+            ),
+        ),
+    ]
+    experiments: Annotated[
+        list[ExperimentReference],
+        pydantic.Field(
+            default_factory=list,
+            description=(
+                "Catalog experiment references (including algorithm versions) that "
+                "were available to resolve the space experiments at the time this "
+                "operation was created. Space-frozen experiment versions remain on "
+                "the related discovery space."
+            ),
+        ),
+    ]
+    actuators: Annotated[
+        dict[str, PackageProvenance],
+        pydantic.Field(
+            default_factory=dict,
+            description=(
+                "Mapping of actuator identifier to the Python distribution that "
                 "provided it at the time this operation was created."
             ),
         ),

--- a/ado/core/operation/resource.py
+++ b/ado/core/operation/resource.py
@@ -83,10 +83,7 @@ class OperationProvenanceInfo(ProvenanceInfo):
         pydantic.Field(
             default_factory=list,
             description=(
-                "Catalog experiment references (including algorithm versions) that "
-                "were available to resolve the space experiments at the time this "
-                "operation was created. Space-frozen experiment versions remain on "
-                "the related discovery space."
+                "Experiments used in operation to satisfy the requirements of the measurement space "
             ),
         ),
     ]

--- a/ado/modules/operators/base.py
+++ b/ado/modules/operators/base.py
@@ -464,6 +464,14 @@ def create_operation_and_add_to_metastore(
 
     from ado.core.operation.config import DiscoveryOperationConfiguration
     from ado.core.operation.resource import OperationProvenanceInfo
+    from ado.modules.actuators.errors import (
+        DeprecatedExperimentError,
+        MissingActuatorConfigurationForCatalogError,
+        UnexpectedCatalogRetrievalError,
+        UnknownActuatorError,
+        UnknownExperimentError,
+    )
+    from ado.modules.actuators.registry import ActuatorRegistry
     from ado.modules.operators.collections import provenance_for_operator
 
     operation_resource_configuration = DiscoveryOperationResourceConfiguration(
@@ -485,12 +493,40 @@ def create_operation_and_add_to_metastore(
         if operator_provenance is not None:
             operators[op_module.operatorIdentifier] = operator_provenance
 
+    experiments = []
+    actuators = {}
+    registry = ActuatorRegistry.globalRegistry()
+    for space_experiment in discovery_space.measurementSpace.experiments:
+        try:
+            catalog_experiment = registry.experimentForReference(
+                space_experiment.reference, resolve=True
+            )
+        except (
+            UnknownExperimentError,
+            UnknownActuatorError,
+            DeprecatedExperimentError,
+            UnexpectedCatalogRetrievalError,
+            MissingActuatorConfigurationForCatalogError,
+        ):
+            continue
+
+        experiments.append(catalog_experiment.reference)
+        actuator_id = catalog_experiment.actuatorIdentifier
+        if actuator_id not in actuators:
+            actuator_provenance = registry.provenance_for_actuator(actuator_id)
+            if actuator_provenance is not None:
+                actuators[actuator_id] = actuator_provenance
+
     operation = OperationResource(
         identifier=operation_identifier,
         operationType=op_module.operationType,
         operatorIdentifier=op_module.operatorIdentifier,
         config=operation_resource_configuration,
-        provenance=OperationProvenanceInfo(operators=operators),
+        provenance=OperationProvenanceInfo(
+            operators=operators,
+            experiments=experiments,
+            actuators=actuators,
+        ),
     )
 
     related_identifiers = [

--- a/ado/modules/operators/setup.py
+++ b/ado/modules/operators/setup.py
@@ -35,9 +35,8 @@ moduleLog = logging.getLogger("setup")
 def find_fqi_differences(
     registry: ActuatorRegistry, measurement_space: MeasurementSpace
 ) -> list[tuple[Experiment, Experiment]]:
-    """Returns experiments in catalog whose fqi is different to the one used to create space
+    """Returns (registry experiment, measurement space experiment) pairs with same major version identifier but different fully qualified identifiers. 
 
-    The major version identifiers must match to be included.
 
     Returns: A list of tuples with two elements. Each tuple is a FQI difference
         The first element in the tuple is an experiment from the measurement space.

--- a/ado/modules/operators/setup.py
+++ b/ado/modules/operators/setup.py
@@ -16,6 +16,9 @@ from ado.core.operation.config import (
     validate_actuator_configurations_against_space_configuration,
 )
 from ado.modules.actuators.measurement_queue import MeasurementQueue
+from ado.modules.actuators.registry import ActuatorRegistry
+from ado.schema.experiment import Experiment
+from ado.schema.measurementspace import MeasurementSpace
 from ado.utilities.logging import configure_logging
 
 if typing.TYPE_CHECKING:
@@ -27,6 +30,30 @@ if typing.TYPE_CHECKING:
 
 configure_logging()
 moduleLog = logging.getLogger("setup")
+
+
+def find_fqi_differences(
+    registry: ActuatorRegistry, measurement_space: MeasurementSpace
+) -> list[tuple[Experiment, Experiment]]:
+    """Returns experiments in catalog whose fqi is different to the one used to create space
+
+    The major version identifiers must match to be included.
+
+    Returns: A list of tuples with two elements. Each tuple is a FQI difference
+        The first element in the tuple is an experiment from the measurement space.
+        The second is the major version matching experiment from the registry which
+        does not have the same fully qualified identifier"""
+
+    differences = []
+    for space_experiment in measurement_space.experiments:
+        catalog_experiment = registry.experimentForReference(space_experiment.reference)
+        if (
+            space_experiment.fully_qualified_identifier
+            != catalog_experiment.fully_qualified_identifier
+        ):
+            differences.append((space_experiment, catalog_experiment))
+
+    return differences
 
 
 def setup_actuators(
@@ -67,6 +94,18 @@ def setup_actuators(
             moduleLog.critical(issue)
         raise ValueError(
             "The measurement space is not supported by the known actuators"
+        )
+
+    for (
+        space_experiment,
+        catalog_experiment,
+    ) in find_fqi_differences(
+        registry=registry, measurement_space=discovery_space.measurementSpace
+    ):
+        print(
+            f"Note: Will use {catalog_experiment.fully_qualified_identifier} to satisfy request"
+            f" for {space_experiment.major_version_identifier}. (Major Version Match)."
+            f"The space was originally created with {space_experiment.fully_qualified_identifier}"
         )
 
     actuator_configurations = get_actuator_configurations(

--- a/ado/modules/operators/setup.py
+++ b/ado/modules/operators/setup.py
@@ -104,7 +104,7 @@ def setup_actuators(
     ):
         print(
             f"Note: Will use {catalog_experiment.fully_qualified_identifier} to satisfy request"
-            f" for {space_experiment.major_version_identifier}. (Major Version Match)."
+            f" for {space_experiment.major_version_identifier} (Major Version Match)."
             f"The space was originally created with {space_experiment.fully_qualified_identifier}"
         )
 

--- a/ado/modules/operators/setup.py
+++ b/ado/modules/operators/setup.py
@@ -32,11 +32,11 @@ configure_logging()
 moduleLog = logging.getLogger("setup")
 
 
-def find_fqi_differences(
+def find_fully_qualified_identifier_mismatch(
     registry: ActuatorRegistry, measurement_space: MeasurementSpace
 ) -> list[tuple[Experiment, Experiment]]:
-    """Returns (registry experiment, measurement space experiment) pairs with same major version identifier but different fully qualified identifiers. 
-
+    """Returns (registry experiment, measurement space experiment) pairs
+    with same major version identifier but different fully qualified identifiers.
 
     Returns: A list of tuples with two elements. Each tuple is a FQI difference
         The first element in the tuple is an experiment from the measurement space.
@@ -98,7 +98,7 @@ def setup_actuators(
     for (
         space_experiment,
         catalog_experiment,
-    ) in find_fqi_differences(
+    ) in find_fully_qualified_identifier_mismatch(
         registry=registry, measurement_space=discovery_space.measurementSpace
     ):
         print(

--- a/tests/schema/test_provenance.py
+++ b/tests/schema/test_provenance.py
@@ -304,11 +304,23 @@ def test_operation_resource_provenance_lifecycle(
     operation_resource: OperationResource,
 ) -> None:
     """OperationResource round-trips nested provenance through model_dump."""
+    from ado.schema.reference import ExperimentReference
+
     prov = PackageProvenance(
         distributionName="ado-ray-tune", distributionVersion="1.7.1"
     )
+    actuator_prov = PackageProvenance(
+        distributionName="ado-core", distributionVersion="1.2.3"
+    )
+    experiment_ref = ExperimentReference(
+        experimentIdentifier="solve_mip",
+        actuatorIdentifier="cplex_mip",
+        experimentVersion="1.2.0",
+    )
     operation_resource.provenance = OperationProvenanceInfo(
-        operators={operation_resource.operatorIdentifier: prov}
+        operators={operation_resource.operatorIdentifier: prov},
+        experiments=[experiment_ref],
+        actuators={"cplex_mip": actuator_prov},
     )
 
     dumped = operation_resource.model_dump()
@@ -318,19 +330,28 @@ def test_operation_resource_provenance_lifecycle(
         ]
         == "ado-ray-tune"
     )
+    assert dumped["provenance"]["experiments"][0]["experimentIdentifier"] == "solve_mip"
+    assert dumped["provenance"]["experiments"][0]["experimentVersion"] == "1.2.0"
+    assert dumped["provenance"]["actuators"]["cplex_mip"]["distributionName"] == (
+        "ado-core"
+    )
 
     restored = OperationResource.model_validate(dumped)
 
     assert restored.provenance.operators[operation_resource.operatorIdentifier] == prov
+    assert restored.provenance.experiments == [experiment_ref]
+    assert restored.provenance.actuators["cplex_mip"] == actuator_prov
 
 
 def test_operation_resource_provenance_defaults_empty(
     operation_resource: OperationResource,
 ) -> None:
-    """OperationResource created without provenance has empty operators dict."""
+    """OperationResource created without provenance has empty provenance collections."""
     dumped = operation_resource.model_dump()
     restored = OperationResource.model_validate(dumped)
     assert restored.provenance.operators == {}
+    assert restored.provenance.experiments == []
+    assert restored.provenance.actuators == {}
 
 
 def test_actuator_configuration_resource_provenance_lifecycle() -> None:


### PR DESCRIPTION
1. Add experiment and actuator details to provenance section of operation resource

Example: 

```yaml
provenance:
  ado:
    distributionName: ado-core
    distributionVersion: 2.1.1.dev17+g6f6458d2.d20260901110925.dirty
  operators:
    ray_tune@2.0.6:
      distributionName: ado-ray-tune
      distributionVersion: 2.0.8.dev17+g78d8f3d6.d20260805124050.dirty
  actuators:
    custom_experiments:
      distributionName: ado-core
      distributionVersion: 2.1.1.dev17+g6f6458d2.d20260901110925.dirty
  experiments:
  - actuatorIdentifier: custom_experiments
    experimentIdentifier: nevergrad_opt_3d_test_func
    experimentVersion: 1.0.0
 ```
    
 2.  Print if an experiment that matches on major version but has different minor/patch version to the experiment present when space was created was used
 
 Example: 
 
 ```
 Note: Will use solve_mip@1.2.1 to satisfy request for solve_mip@v1 (Major Version Match). The space was originally created with solve_mip@1.1.7
 ```