### PR TITLE
docs(agents): add standalone run_experiment skill

### DIFF
--- a/.agents/skills/conduct-empirical-study/SKILL.md
+++ b/.agents/skills/conduct-empirical-study/SKILL.md
@@ -17,7 +17,7 @@ of entities: executing experiments to answer research questions, benchmarking, o
 any task where data must be collected across a parameter space.
 
 For measuring **one** entity/point (functional check), use
-`run_experiment` — see [using-ado-cli](../using-ado-cli/SKILL.md) — not this
+`run_experiment` — see [run-experiment](../run-experiment/SKILL.md) — not this
 workflow.
 
 ## Workflow Overview

--- a/.agents/skills/plugin-development/SKILL.md
+++ b/.agents/skills/plugin-development/SKILL.md
@@ -236,7 +236,8 @@ uv run ado get operators
 and confirm the plugin is installed
 
 - **Experiment execution**: Use the `run_experiment` tool to verify
-  custom_experiment or actuator experiments can execute successfully
+  custom_experiment or actuator experiments can execute successfully — see
+  [run-experiment](../run-experiment/SKILL.md)
 
 For example:
 

--- a/.agents/skills/run-experiment/SKILL.md
+++ b/.agents/skills/run-experiment/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: run-experiment
+description: >-
+  Use the run_experiment tool to execute one experiment on a single point
+  (entity) without creating a discoveryspace or operation. Use when smoke
+  testing or functionally validating an actuator, custom experiment, or actuator
+  configuration; debugging experiment execution or entity validation; or when a
+  single measurement is wanted without ado metastore tracking. For campaigns
+  over many entities, see define-experiment-campaign; for the ado CLI itself,
+  see using-ado-cli.
+---
+
+# Running an experiment on a single point
+
+`run_experiment` is a **separate CLI entry point**, not an `ado` subcommand.
+There is no `ado run_experiment`. It runs one entity through one or more
+experiments and prints the result — nothing is written to the metastore.
+
+Use it for:
+
+- Smoke testing an actuator or custom experiment after installing a plugin
+- Debugging experiment execution or entity validation
+- Taking a single measurement when tracking is not needed
+
+For measuring multiple entities, create a `discoveryspace` and an
+`operation` instead — see
+[define-experiment-campaign](../define-experiment-campaign/SKILL.md).
+
+## Usage
+
+```bash
+uv run run_experiment PATH_TO_POINT_YAML
+```
+
+Ray is started locally and shut down automatically; no metastore or remote
+cluster is required.
+
+## Point YAML
+
+The point.yaml has two top level fields:
+
+- `entity` is a map of constitutive property name/value pairs.
+These are the input parameter name/value combinations to the experiment.
+- `experiments` is a
+list of experiment references to run on that entity.
+
+```yaml
+entity:
+  mass: 8
+  volume: 4
+experiments:
+  - actuatorIdentifier: custom_experiments
+    experimentIdentifier: calculate_density
+    experimentVersion: 1.0.0 # Omit if the experiment has no version
+```
+
+Get the identifiers to use with:
+
+```bash
+# Actuators and the experiments they provide
+uv run ado get actuators --details
+
+# Required and optional consitutive properties of one experiment
+uv run ado describe experiment ACTUATOR_ID.EXPERIMENT_ID
+```
+
+## Options
+
+Verify with `uv run run_experiment --help` before writing a command.
+
+<!-- markdownlint-disable line-length -->
+
+| Option                                 | Purpose                                                                                           |
+|----------------------------------------| ------------------------------------------------------------------------------------------------- |
+| `--no-validate`                        | Skip entity validation. Needed when the experiment is not installed locally                       |
+| `--actuator-config-id ID`              | Apply an actuatorconfiguration from the active context's metastore. Repeat for multiple actuators |
+| `--remote ENDPOINT`                    | Execute via an ado REST API endpoint instead of locally                                           |
+| `--timeout SECONDS`                    | Timeout for a remote experiment (default 300)                                                     |
+| `--request-timeout SECONDS`            | Timeout for individual web requests to a remote endpoint (default 60)                             |
+| `--verify-certs` / `--no-verify-certs` | SSL certificate verification of remote hosts (default `--no-verify-certs`)                        |
+
+<!-- markdownlint-enable line-length -->
+
+## Interpreting the output
+
+`run_experiment` prints the point, whether the entity validated, and then the
+result as a pandas Series holding the request and entity identifiers, the
+entity's constitutive property values, and the experiment's target output
+properties.
+
+- **"Entity is not valid"**: the entity is missing a required constitutive
+  property, or a value is outside the property's domain. Check the requirements
+  with `uv run ado describe experiment ACTUATOR_ID.EXPERIMENT_ID`.
+- **"Failed to initialize actuator"**: the actuator raised during startup —
+  usually a missing dependency or bad actuator configuration.
+- **"Measurement request failed unexpectedly"**: the experiment itself raised.
+  Re-run with `LOGLEVEL=10` set to see the actuator traceback.
+
+## Related Resources
+
+- [define-experiment-campaign](../define-experiment-campaign/SKILL.md) — running
+  experiments over many entities with a discoveryspace and operation
+- [using-ado-cli](../using-ado-cli/SKILL.md) — the `ado` CLI: syntax, flags, and
+  shortcuts
+- [plugin-development](../plugin-development/SKILL.md) — plugin testing
+  checklist, where `run_experiment` is the experiment execution check
+- [docs/user-guide/advanced/run-experiment.md](../../../docs/user-guide/advanced/run-experiment.md)
+  — user documentation for this tool

--- a/.agents/skills/using-ado-cli/SKILL.md
+++ b/.agents/skills/using-ado-cli/SKILL.md
@@ -3,12 +3,11 @@ name: using-ado-cli
 description: >-
   Reference for ado CLI command syntax, flags, and usage patterns — get, create,
   edit, show, describe, output flags (-o, --output-file), convenience flags
-  (--use-latest KIND, --set, --with), debugging with -l, and run_experiment. Use
-  when writing, verifying, or debugging ado CLI commands; looking up correct
-  command syntax or flags; running or smoke-testing an experiment on a single
-  entity/point (run_experiment); or when unsure which ado command or flag to
-  use. For listing catalogs or answering data questions, use the query-ado-data
-  skill.
+  (--use-latest KIND, --set, --with), and debugging with -l. Use when writing,
+  verifying, or debugging ado CLI commands; looking up correct command syntax or
+  flags; or when unsure which ado command or flag to use. For listing catalogs
+  or answering data questions, use the query-ado-data skill. For running a
+  single experiment on one point, use the run-experiment skill.
 ---
 
 # Using the ado CLI
@@ -72,32 +71,6 @@ These plausible-sounding commands do not exist in ado. Do not write them:
 
 **Key principle**: `ado create operation` both _defines_ and _starts_ the
 operation in a single command. There is no separate "run" step.
-
-## Point Testing with run_experiment
-
-`run_experiment` is a **separate CLI entry point** (not an `ado` subcommand) for
-running a single entity through an experiment locally, without creating a space
-or operation. Use it for functional validation (smoke test) of experiments or to
-measure one point.
-
-```bash
-uv run run_experiment PATH_TO_POINT_YAML
-```
-
-A point YAML has the form:
-
-```yaml
-entity:
-  param_a: value_a
-  param_b: value_b
-
-experiments:
-  - actuatorIdentifier: custom_experiments
-    experimentIdentifier: my_experiment
-```
-
-It prints the result as a pandas Series and exits. No metastore or Ray cluster
-needed beyond a local Ray instance (started automatically).
 
 ## Core Commands
 
@@ -395,4 +368,6 @@ uv run ado create operation -f operation.yaml --use-latest space
   [resource-yaml-creation](../resource-yaml-creation/)
 - For creating discoveryspace and operation YAML files, see
   [define-experiment-campaign](../define-experiment-campaign/)
+- For running a single point through an experiment with the separate
+  `run_experiment` tool, see [run-experiment](../run-experiment/SKILL.md)
 - For general development guidelines, see [AGENTS.md](../../../AGENTS.md)

--- a/ado/utilities/run_experiment.py
+++ b/ado/utilities/run_experiment.py
@@ -248,6 +248,7 @@ def run(
     timeout: Annotated[
         int,
         typer.Option(
+            "--timeout",
             metavar="TIMEOUT",
             help="Timeout for the remote experiment in seconds. If not given the default is 300 seconds",
         ),

--- a/docs/user-guide/advanced/run-experiment.md
+++ b/docs/user-guide/advanced/run-experiment.md
@@ -24,7 +24,7 @@
 
 ```bash
 run_experiment <point_file.yaml> [--remote <ENDPOINT>] [--timeout <SECONDS>] [--no-validate] \
-               [--actuator-configuration-id <identifier>] [--verify-certs | --no-verify-certs] \
+               [--actuator-config-id <identifier>] [--verify-certs | --no-verify-certs] \
                [--request-timeout <timeout-in-seconds>]
 ```
 
@@ -38,7 +38,7 @@ run_experiment <point_file.yaml> [--remote <ENDPOINT>] [--timeout <SECONDS>] [--
 - `--timeout <SECONDS>`: Timeout for remote execution (default: 300 seconds).
 - `--no-validate`: Skip entity validation before execution.
   This is useful if the experiment is not installed locally but is available remotely.
-- `--actuator-configuration-id`: Actuator configuration identifiers to use
+- `--actuator-config-id`: Actuator configuration identifiers to use
   in the experiment. Can be specified multiple times.
 - `--verify-certs`, `--no-verify-certs`: Enable or disable SSL certificate verification
   of remote hosts. (default: `--no-verify-certs`).

--- a/tests/actuators/test_run_experiment.py
+++ b/tests/actuators/test_run_experiment.py
@@ -4,6 +4,8 @@
 """CLI tests for the run_experiment command."""
 
 import pytest
+import typer.core
+import typer.main
 from typer.testing import CliRunner
 
 from ado.utilities.run_experiment import app
@@ -20,4 +22,24 @@ def test_run_experiment_point_yaml_succeeds(point_file: str) -> None:
     """run_experiment <point.yaml> must exit 0 and report a valid measurement."""
     runner = CliRunner()
     result = runner.invoke(app, [point_file])
+    assert result.exit_code == 0, result.output
+
+
+def test_run_experiment_option_names_are_lowercase() -> None:
+    """Every option must be lowercase, so a metavar cannot leak into its name."""
+    command = typer.main.get_command(app)
+    options = [
+        option
+        for parameter in command.params
+        if isinstance(parameter, typer.core.TyperOption)
+        for option in parameter.opts + parameter.secondary_opts
+    ]
+    assert options
+    assert [option for option in options if option != option.lower()] == []
+
+
+def test_run_experiment_timeout_option_is_recognised() -> None:
+    """--timeout must be accepted, as documented."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["--timeout", "5", "--help"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
Agents with less capable models were often missing run_experiment and how to execute it, or hallucinating its CLI. This is because it was in `using-ado-cli` which some models took to mean the "ado` tool and its subcommands." regardless of what the front-matter or skill said. 

Keeping this separate to the issue if we should move run_experiment under `ado` or not. 

Moving it to a separate tool outside of using-ado-cli which now descibes just `ado` command. 

This PR also changes the `--TIMEOUT` option to `--timeout` (which is what is documented in the website). 