### PR TITLE
docs(agents): clarify experimentVersion field requirements in define-experiment-campaign

### DIFF
--- a/.agents/skills/define-experiment-campaign/SKILL.md
+++ b/.agents/skills/define-experiment-campaign/SKILL.md
@@ -112,6 +112,11 @@ uv run ado describe experiment $EXPERIMENT_ID
 - Required constitutive properties (must be in entity space)
 - Optional properties (can use defaults or add to entity space)
 - Target properties (what the experiment measures)
+- Experiment version (`VERSION` column of `ado get experiments`; also shown by
+  `ado describe experiment`)
+
+Copy `VERSION` into the experiment reference's `experimentVersion` field. Omit
+`experimentVersion` only if the catalog version is `None`.
 
 #### What to do if no experiment matching task available
 
@@ -128,6 +133,10 @@ uv run ado describe experiment $EXPERIMENT_ID
 ```bash
 uv run ado template space --from-experiment $EXPERIMENT_ID --output-file space.yaml
 ```
+
+`--from-experiment` fills `experimentVersion` from the catalog. Keep that field
+when editing the template. If writing YAML by hand, set it from the `VERSION`
+column as above.
 
 **Manual structure:**
 
@@ -199,6 +208,9 @@ Fix validation errors and repeat validation until successful.
    user's query. Explain why.
 4. **Default values** - Only change default values of optional properties if
    necessary. Explain why.
+5. **Set experimentVersion** - Required when the experiment has a version. Use
+   the exact `VERSION` string from the catalog. Do not embed the version in
+   `experimentIdentifier`.
 
 ### Entity Space Refinement Rules
 
@@ -236,6 +248,7 @@ Before finalizing, verify:
 - Optional properties only added if necessary (with explanation)
 - Default values only changed if necessary (with explanation)
 - Domain refinements explained
+- `experimentVersion` matches the catalog `VERSION` (omitted only if `None`)
 - DiscoverySpace YAML validates (`--dry-run`)
 - Operation YAML validates (`--dry-run`)
 - All ado CLI commands and options are valid (uv run ado [COMMAND] --help)
@@ -257,6 +270,20 @@ Before finalizing, verify:
 - **Solution:** Remove properties from entity space that aren't required by any
   experiment
 
+**Issue:** Validation error "Unknown experiment" / "fully_qualified_version"
+
+- **Solution:** The experiment has a version but `experimentVersion` is missing.
+  Set it to the `VERSION` column of `ado get experiments`.
+
+**Issue:** Validation error "Experiment version mismatch"
+
+- **Solution:** `experimentVersion` must match the catalog version exactly.
+
+**Issue:** Validation error "experimentIdentifier must not contain '@'"
+
+- **Solution:** Put the bare experiment id in `experimentIdentifier` and the
+  SemVer string in `experimentVersion`.
+
 **Issue:** Operation validation fails
 
 - **Solution:** Check operator parameters match schema. Use `--include-schema`
@@ -266,6 +293,10 @@ Before finalizing, verify:
 
 - For detailed schema information, see [reference.md](reference.md)
 - For example workflows, see [examples.md](examples.md)
+- For experiment versioning and memoization, see
+  `docs/resources/discovery-spaces.md` (section "Setting the experiment
+  version") if the source repo is available, otherwise
+  <https://ibm.github.io/ado/latest/resources/discovery-spaces/>
 - For Pydantic model details when writing code, see the resource model table and
   schema-inspection snippet in
   [query-ado-data — Using Resource models](../query-ado-data/SKILL.md#using-resource-models)

--- a/.agents/skills/define-experiment-campaign/examples.md
+++ b/.agents/skills/define-experiment-campaign/examples.md
@@ -17,6 +17,7 @@ uv run ado describe experiment TrainerActuator.train_model
 
 **Experiment details:**
 
+- Version: `1.0.0` (set as `experimentVersion`)
 - Required: `learning_rate`, `batch_size`
 - Optional: `optimizer` (default: "sgd"), `epochs` (default: 10)
 - Targets: `accuracy`, `loss`
@@ -55,10 +56,12 @@ uv run ado create operation -f operation.yaml --dry-run
 
 ```bash
 uv run ado describe experiment TrainerActuator.train_model
+# Version: 1.0.0
 # Required: learning_rate, batch_size
 # Targets: accuracy, loss
 
 uv run ado describe experiment EvaluatorActuator.evaluate_model
+# Version: 1.0.0
 # Required: accuracy (ObservedProperty from train_model)
 # Targets: test_accuracy, test_loss
 ```
@@ -89,6 +92,7 @@ with different learning rates"
 
 ```bash
 uv run ado describe experiment TrainerActuator.train_model
+# Version: 1.0.0
 # Required: learning_rate, batch_size
 # Optional: optimizer (default: "sgd")
 ```
@@ -119,6 +123,7 @@ learning rates"
 
 ```bash
 uv run ado describe experiment TrainerActuator.train_model
+# Version: 1.0.0
 # Optional: optimizer (default: "sgd")
 ```
 
@@ -147,6 +152,7 @@ uv run ado create space -f space.yaml --dry-run
 
 ```bash
 uv run ado describe experiment TrainerActuator.train_model
+# Version: 1.0.0
 # Required: learning_rate (domain: [0.0001, 1.0])
 ```
 
@@ -240,3 +246,22 @@ ValueError: Identified an entity space dimension that is not required for any ex
 
 **Fix:** Remove properties not required by any experiment, or add an experiment
 that requires it.
+
+### Error: missing or wrong experimentVersion
+
+**Error message:**
+
+```text
+Unknown experiment in configuration ... using mode fully_qualified_version.
+Available versions in catalog: 1.0.0.
+```
+
+or
+
+```text
+Experiment version mismatch in configuration: ... Reference requires version
+'train_model@1.0.1' but catalog provides 'train_model@1.0.0'.
+```
+
+**Fix:** Set `experimentVersion` to the catalog `VERSION`. Omit the field only
+if `VERSION` is `None`. Do not put `@1.0.0` in `experimentIdentifier`.

--- a/.agents/skills/define-experiment-campaign/reference.md
+++ b/.agents/skills/define-experiment-campaign/reference.md
@@ -31,8 +31,18 @@ Detailed reference information for formulating problems in ado.
 
 ### Experiment Reference Format
 
+Each experiment entry needs `actuatorIdentifier` and `experimentIdentifier`.
+Add `experimentVersion` when the catalog `VERSION` is not `None` (a
+`MAJOR.MINOR.PATCH` SemVer string). Do not put `@version` in
+`experimentIdentifier`.
+
 See
 [reference-experiment-format.yaml](yaml-examples/reference-experiment-format.yaml).
+
+For version matching, memoization keys, and the errors raised when the field is
+missing or wrong, see `docs/resources/discovery-spaces.md` (section "Setting
+the experiment version") if the source repo is available, otherwise
+<https://ibm.github.io/ado/latest/resources/discovery-spaces/>.
 
 ## Entity Space Property Schema
 

--- a/.agents/skills/define-experiment-campaign/yaml-examples/example1-space.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/example1-space.yaml
@@ -13,6 +13,7 @@ entitySpace:
 experiments:
   - actuatorIdentifier: TrainerActuator
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0
 metadata:
   name: hyperparameter_optimization
   description: Optimize learning rate and batch size for model training

--- a/.agents/skills/define-experiment-campaign/yaml-examples/example2-space.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/example2-space.yaml
@@ -13,8 +13,10 @@ entitySpace:
 experiments:
   - actuatorIdentifier: TrainerActuator
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0
   - actuatorIdentifier: EvaluatorActuator
     experimentIdentifier: evaluate_model
+    experimentVersion: 1.0.0
 metadata:
   name: train_and_evaluate
   description: Train models and evaluate on test set

--- a/.agents/skills/define-experiment-campaign/yaml-examples/example3-space.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/example3-space.yaml
@@ -17,6 +17,7 @@ entitySpace:
 experiments:
   - actuatorIdentifier: TrainerActuator
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0
 metadata:
   name: optimizer_comparison
   description: Compare optimizers with different learning rates

--- a/.agents/skills/define-experiment-campaign/yaml-examples/example4-space.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/example4-space.yaml
@@ -13,6 +13,7 @@ entitySpace:
 experiments:
   - actuatorIdentifier: TrainerActuator
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0
     parameterization:
       - property:
           identifier: optimizer

--- a/.agents/skills/define-experiment-campaign/yaml-examples/example5-space.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/example5-space.yaml
@@ -13,6 +13,7 @@ entitySpace:
 experiments:
   - actuatorIdentifier: TrainerActuator
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0
 metadata:
   name: fine_tune_lr
   description: Fine-tune learning rate around 0.01

--- a/.agents/skills/define-experiment-campaign/yaml-examples/reference-experiment-format.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/reference-experiment-format.yaml
@@ -3,6 +3,7 @@
 experiments:
   - actuatorIdentifier: actuator_id
     experimentIdentifier: experiment_id
+    experimentVersion: 1.0.0 # Required if ado get experiments shows a VERSION
     parameterization: # Optional - only if customizing optional properties
       - property:
           identifier: property_name

--- a/.agents/skills/define-experiment-campaign/yaml-examples/reference-pattern1-simple-space.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/reference-pattern1-simple-space.yaml
@@ -9,3 +9,4 @@ entitySpace:
 experiments:
   - actuatorIdentifier: trainer
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0

--- a/.agents/skills/define-experiment-campaign/yaml-examples/reference-pattern2-multiple-experiments.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/reference-pattern2-multiple-experiments.yaml
@@ -9,5 +9,7 @@ entitySpace:
 experiments:
   - actuatorIdentifier: trainer
     experimentIdentifier: train_model # Measures: accuracy
+    experimentVersion: 1.0.0
   - actuatorIdentifier: evaluator
     experimentIdentifier: evaluate_model # Requires: accuracy (from train_model)
+    experimentVersion: 1.0.0

--- a/.agents/skills/define-experiment-campaign/yaml-examples/reference-pattern3-parameterized.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/reference-pattern3-parameterized.yaml
@@ -3,6 +3,7 @@
 experiments:
   - actuatorIdentifier: trainer
     experimentIdentifier: train_model
+    experimentVersion: 1.0.0
     parameterization:
       - property:
           identifier: optimizer

--- a/.agents/skills/define-experiment-campaign/yaml-examples/skill-manual-structure.yaml
+++ b/.agents/skills/define-experiment-campaign/yaml-examples/skill-manual-structure.yaml
@@ -9,6 +9,7 @@ entitySpace:
 experiments:
   - actuatorIdentifier: actuator_name
     experimentIdentifier: experiment_name
+    experimentVersion: 1.0.0 # Omit if the experiment has no version
 metadata:
   name: space_name
   description: Description of the discovery space


### PR DESCRIPTION
Neither the skill or the examples referenced experimentVersion field leading to issues with some agents/model combinations. 