### PR TITLE
fix(core): validate and symlink remote execution wheels in packages.fromPyPI

### DIFF
--- a/.agents/skills/remote-execution/SKILL.md
+++ b/.agents/skills/remote-execution/SKILL.md
@@ -254,7 +254,7 @@ packages:
 additionalFiles:
   - /absolute/local/path/to/data_file.csv
   - path/to/my_data_dir/   # directories also supported
-  - dist/my_local_pkg-1.0.0-py3-none-any.whl # local wheel to upload
+  - my_wheels/my_local_pkg-1.0.0-py3-none-any.whl # local wheel to upload
 ```
 
 > [!NOTE] Local wheels
@@ -262,6 +262,12 @@ additionalFiles:
 > Local wheel files must be listed in `additionalFiles` to be uploaded, and
 > their bare filename specified in `packages.fromPyPI`. Multiple files in
 > `additionalFiles` cannot share the same basename.
+>
+> **Do not place custom wheels inside `dist/`** when any `fromSource` entry
+> targets the parent of the `dist/` directory. The build step runs
+> `uv build --wheel -o dist --clear`, which deletes the contents of `dist/`
+> before writing the new wheel. Store extra wheels in a separate directory
+> (e.g. `my_wheels/`).
 
 Use bare filenames (no path) in space/operation YAML; ray copies
 `additionalFiles` entries into the Ray working directory.

--- a/.agents/skills/remote-execution/SKILL.md
+++ b/.agents/skills/remote-execution/SKILL.md
@@ -243,6 +243,7 @@ packages:
     - ado-ray-tune
     - ray==2.52.1                         # pin to match cluster version if needed
     - /remote/path/to/package.whl         # path to a wheel already on the cluster
+    - my_local_pkg-1.0.0-py3-none-any.whl # local wheel (bare name, listed in additionalFiles)
   fromSource:
     - plugins/actuators/my_plugin  # relative to where ado --remote is run
 ```
@@ -253,7 +254,14 @@ packages:
 additionalFiles:
   - /absolute/local/path/to/data_file.csv
   - path/to/my_data_dir/   # directories also supported
+  - dist/my_local_pkg-1.0.0-py3-none-any.whl # local wheel to upload
 ```
+
+> [!NOTE] Local wheels
+>
+> Local wheel files must be listed in `additionalFiles` to be uploaded, and
+> their bare filename specified in `packages.fromPyPI`. Multiple files in
+> `additionalFiles` cannot share the same basename.
 
 Use bare filenames (no path) in space/operation YAML; ray copies
 `additionalFiles` entries into the Ray working directory.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "requirements.txt|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T12:09:20Z",
+  "generated_at": "2026-09-09T14:18:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "f32b67c7e26342af42efabc674d441dca0a281c5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 285,
+        "line_number": 291,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "requirements.txt|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-04T12:28:04Z",
+  "generated_at": "2026-09-09T12:09:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "f32b67c7e26342af42efabc674d441dca0a281c5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 277,
+        "line_number": 285,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ado/cli/utils/remote/dispatch.py
+++ b/ado/cli/utils/remote/dispatch.py
@@ -625,7 +625,19 @@ def _dispatch_to_cluster(
         rewritten_args = _copy_files_and_rewrite_args(ado_args, working_dir)
         remote_ado_args = ["-c", context_filename, *rewritten_args]
 
-        # 3. Symlink any additionalFiles into the working directory.
+        # 3. Build wheels for fromSource plugins.
+        #    This runs uv build --clear, which wipes each plugin's dist/ directory.
+        #    additionalFiles symlinks must be created AFTER this step so their
+        #    targets are not deleted before Ray uploads the working directory.
+        if remote_context.packages.fromSource:
+            status.stop()
+        wheel_names = _build_source_wheels(
+            remote_context.packages.fromSource,
+            working_dir,
+            repo_root,
+        )
+
+        # 4. Symlink any additionalFiles into the working directory.
         #    Collect basenames already present to detect collisions.
         seen_basenames: set[str] = {f.name for f in working_dir.iterdir()}
         _symlink_additional_files(
@@ -633,15 +645,6 @@ def _dispatch_to_cluster(
             cwd,
             working_dir,
             seen_basenames,
-        )
-
-        # 4. Build wheels for fromSource plugins
-        if remote_context.packages.fromSource:
-            status.stop()
-        wheel_names = _build_source_wheels(
-            remote_context.packages.fromSource,
-            working_dir,
-            repo_root,
         )
         seen_basenames.update(wheel_names)
 

--- a/ado/cli/utils/remote/dispatch.py
+++ b/ado/cli/utils/remote/dispatch.py
@@ -413,48 +413,70 @@ def _build_source_wheels(
     return wheel_names
 
 
-def identify_and_copy_local_wheels(
+def _process_pypi_packages(
     from_pypi: list[str],
+    additional_files: list[str],
     cwd: Path,
     working_dir: Path,
     seen_basenames: set[str],
-) -> tuple[list[str], list[str]]:
-    """Identify local wheel paths in the fromPyPI YAML section and copy into the working directory.
+) -> list[str]:
+    """Process fromPyPI packages for Ray runtime_env.yaml and symlink local wheels if needed.
 
-    Entries that resolve to existing .whl files are copied into the working dir
-    so they are distributed to all Ray nodes. Other entries are passed through
-    unchanged into the Ray runtime ``uv`` list (PyPI requirements, version
-    pins, or paths such as ``/data/.../*.whl`` that must exist where ``uv``
-    installs on the cluster).
+    For each entry ending in .whl that is not an absolute path:
+    1. Checks if it was listed in additionalFiles (and thus already symlinked into working_dir).
+    2. If not in additionalFiles, checks if the wheel file exists in cwd. If it does, symlinks it
+       into working_dir.
+    3. If not found in either additionalFiles or cwd, raises FileNotFoundError.
+    4. Prefixes the entry with ``${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/``.
+
+    Absolute wheel paths and standard PyPI package specs are passed through unchanged.
 
     Args:
-        from_pypi: The fromPyPI package list.
+        from_pypi: The fromPyPI package list from RemoteExecutionContext.
+        additional_files: The additionalFiles list from RemoteExecutionContext.
         cwd: Directory for resolving relative paths.
-        working_dir: Destination for copied wheels.
+        working_dir: Ray working directory for symlinking local wheels.
         seen_basenames: Basenames already in working_dir; updated in-place.
 
     Returns:
-        Tuple of (pypi_packages, local_wheel_basenames). pypi_packages has local
-        wheel paths replaced with RAY_RUNTIME_ENV_CREATE_WORKING_DIR refs;
-        local_wheel_basenames are the basenames of copied wheels.
+        List of package specs for Ray runtime_env.yaml.
     """
     pypi_packages: list[str] = []
-    local_wheel_basenames: list[str] = []
+    additional_basenames = {Path(f).name for f in additional_files}
 
     for entry in from_pypi:
-        path = Path(entry)
-        if not path.is_absolute():
-            path = (cwd / path).resolve()
+        if entry.lower().endswith(".whl"):
+            path = Path(entry)
+            wheel_name = path.name
 
-        if path.suffix.lower() == ".whl" and path.is_file():
-            _copy_file_checked(path, working_dir, seen_basenames)
-            local_wheel_basenames.append(path.name)
-            pypi_packages.append(f"${{RAY_RUNTIME_ENV_CREATE_WORKING_DIR}}/{path.name}")
-            log.debug("Copied local wheel %s for runtime env", path.name)
+            if path.is_absolute():
+                # Non-local cluster absolute path (e.g. /data/wheels/pkg.whl on the remote cluster)
+                pypi_packages.append(entry)
+                continue
+            # Check if wheel exists locally (relative to cwd)
+            local_path = (cwd / path).resolve()
+
+            if local_path.is_file():
+                if wheel_name not in seen_basenames:
+                    (working_dir / wheel_name).symlink_to(local_path)
+                    seen_basenames.add(wheel_name)
+                    log.debug("Symlinked local wheel: %s", wheel_name)
+                pypi_packages.append(
+                    f"${{RAY_RUNTIME_ENV_CREATE_WORKING_DIR}}/{wheel_name}"
+                )
+            elif wheel_name in additional_basenames:
+                # Staged via additionalFiles
+                pypi_packages.append(
+                    f"${{RAY_RUNTIME_ENV_CREATE_WORKING_DIR}}/{wheel_name}"
+                )
+            else:
+                raise FileNotFoundError(
+                    f"Cannot locate wheel file '{entry}' in additionalFiles or relative to current working directory '{cwd}'."
+                )
         else:
             pypi_packages.append(entry)
 
-    return pypi_packages, local_wheel_basenames
+    return pypi_packages
 
 
 def _write_runtime_env(
@@ -471,10 +493,6 @@ def _write_runtime_env(
     *remote_context* into a ``runtime_env.yaml`` compatible with
     ``ray job submit --runtime-env``.
 
-    Local wheel paths in fromPyPI are copied to the working dir and rewritten
-    to use RAY_RUNTIME_ENV_CREATE_WORKING_DIR so they are available on all
-    nodes (worker nodes do not have access to cluster paths like /tmp/ray/).
-
     Args:
         remote_context: The remote execution context describing packages and env vars.
         wheel_names: Basenames of wheel files from fromSource, present in working dir.
@@ -483,8 +501,9 @@ def _write_runtime_env(
         working_dir: Ray working directory for copying local wheels.
         seen_basenames: Basenames already in working_dir; updated when copying wheels.
     """
-    uv_packages, _ = identify_and_copy_local_wheels(
+    uv_packages = _process_pypi_packages(
         remote_context.packages.fromPyPI,
+        remote_context.additionalFiles,
         cwd,
         working_dir,
         seen_basenames,
@@ -494,7 +513,7 @@ def _write_runtime_env(
         for wheel_name in wheel_names
     )
 
-    runtime_env: dict[str, list[str] | dict[str, str]] = {}
+    runtime_env: dict[str, list[str] | dict[str, str] | dict[str, int | bool]] = {}
     if uv_packages:
         runtime_env["uv"] = uv_packages
 

--- a/ado/core/remotecontext/config.py
+++ b/ado/core/remotecontext/config.py
@@ -1,9 +1,12 @@
 # Copyright IBM Corporation 2025, 2026
 # SPDX-License-Identifier: MIT
 
+import warnings
+from pathlib import PurePath
 from typing import Annotated, Literal
 
 import pydantic
+from typing_extensions import Self
 
 from ado.utilities.pydantic import validate_rfc_1123
 
@@ -242,3 +245,76 @@ class RemoteExecutionContext(pydantic.BaseModel):
             default_factory=list,
         ),
     ]
+
+    @pydantic.model_validator(mode="after")
+    def validate_and_normalize_wheels(self) -> Self:
+        """Validate wheel entries in packages.fromPyPI and additionalFiles.
+
+        Ensures that:
+        1. Entries in additionalFiles do not have duplicate basenames.
+        2. Wheel entries in packages.fromPyPI do not use relative subpaths.
+        3. Wheel entries prefixed with ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/ emit a
+           UserWarning and are rewritten to the bare wheel filename.
+        4. Local wheel entries not in additionalFiles emit a warning.
+        """
+        prefix = "${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/"
+
+        # Check duplicate basenames in additionalFiles
+        seen_additional_basenames: set[str] = set()
+        for add_file in self.additionalFiles:
+            name = PurePath(add_file).name
+            if name in seen_additional_basenames:
+                raise ValueError(
+                    f"Conflicting duplicate basename in additionalFiles: '{name}' "
+                    f"from entry '{add_file}'."
+                )
+            seen_additional_basenames.add(name)
+
+        normalized_from_pypi: list[str] = []
+        for entry in self.packages.fromPyPI:
+            if entry.lower().endswith(".whl"):
+                # If prefixed with ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/, warn and strip
+                if entry.startswith(prefix):
+                    warnings.warn(
+                        f"Prefix '{prefix}' in packages.fromPyPI for '{entry}' is "
+                        "unnecessary and will be automatically managed by ado. "
+                        "Removing prefix. For wheels from other local directories, "
+                        "include them in additionalFiles.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    wheel_name = entry[len(prefix) :]
+                else:
+                    wheel_name = entry
+
+                pure_path = PurePath(wheel_name)
+                # Check if it is an absolute path
+                if pure_path.is_absolute():
+                    normalized_from_pypi.append(wheel_name)
+                    continue
+
+                # If relative path has directories, warn to use bare wheel name + additionalFiles
+                if pure_path.parent != PurePath("."):
+                    warnings.warn(
+                        f"Wheel '{entry}' in packages.fromPyPI contains a relative "
+                        "directory path. Consider specifying a bare wheel name "
+                        f"'{pure_path.name}' and listing '{entry}' in additionalFiles instead.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                elif wheel_name not in seen_additional_basenames:
+                    # Bare wheel: warn if not present in additionalFiles
+                    warnings.warn(
+                        f"Wheel '{wheel_name}' in packages.fromPyPI is not listed in "
+                        "additionalFiles. If it is located in the working directory, it will "
+                        "be used; otherwise, include it in additionalFiles.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+
+                normalized_from_pypi.append(wheel_name)
+            else:
+                normalized_from_pypi.append(entry)
+
+        self.packages.fromPyPI = normalized_from_pypi
+        return self

--- a/ado/core/remotecontext/config.py
+++ b/ado/core/remotecontext/config.py
@@ -252,16 +252,33 @@ class RemoteExecutionContext(pydantic.BaseModel):
 
         Ensures that:
         1. Entries in additionalFiles do not have duplicate basenames.
-        2. Wheel entries in packages.fromPyPI do not use relative subpaths.
-        3. Wheel entries prefixed with ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/ emit a
+        2. Entries in additionalFiles do not point into the dist/ directory of a
+           fromSource package (uv build --clear deletes that directory before upload).
+        3. Wheel entries in packages.fromPyPI do not use relative subpaths.
+        4. Wheel entries prefixed with ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/ emit a
            UserWarning and are rewritten to the bare wheel filename.
-        4. Local wheel entries not in additionalFiles emit a warning.
+        5. Local wheel entries not in additionalFiles emit a warning.
         """
         prefix = "${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/"
 
-        # Check duplicate basenames in additionalFiles
+        # Build the set of dist/ directories that will be wiped by uv build --clear
+        from_source_dist_paths: set[PurePath] = {
+            PurePath(src) / "dist" for src in self.packages.fromSource
+        }
+
+        # Check duplicate basenames in additionalFiles and fromSource dist/ collision
         seen_additional_basenames: set[str] = set()
         for add_file in self.additionalFiles:
+            add_path = PurePath(add_file)
+            for dist_path in from_source_dist_paths:
+                if add_path.is_relative_to(dist_path):
+                    raise ValueError(
+                        f"additionalFiles entry '{add_file}' is inside the dist/ "
+                        f"directory of fromSource package '{dist_path.parent}'. "
+                        "uv build --clear will delete this file before it can be "
+                        "uploaded. Store the file outside the fromSource package's "
+                        "dist/ directory and update additionalFiles accordingly."
+                    )
             name = PurePath(add_file).name
             if name in seen_additional_basenames:
                 raise ValueError(

--- a/docs/user-guide/advanced/remote-execution.md
+++ b/docs/user-guide/advanced/remote-execution.md
@@ -241,11 +241,15 @@ any plugins required in the `packages.fromPyPI` section of your
 
 > [!NOTE] Wheel paths and `fromPyPI`
 >
-> Entries in `fromPyPI` that resolve to an existing `.whl` file on the machine
-> running `ado --remote` will be transferred to the remote cluster. Other
-> entries are forwarded unchanged to the cluster's `uv` install step. This
-> includes paths that were not present on submitting machine - these will be
-> interpreted as paths to wheels that are on the remote filesystem.
+> - **Absolute paths**: Resolved directly on the remote cluster's filesystem
+>   (e.g., `/data/pkg.whl`). Use `additionalFiles` to reference absolute paths
+>   on your local machine along with an entry in `fromPyPI` with the bare
+>   wheel name.
+> - **Local wheels**: List the local path in `additionalFiles` to upload it, and
+>   specify the **bare filename** (e.g., `my_pkg.whl`) in `fromPyPI`.
+> - **No duplicate filenames**: Entries in `additionalFiles` cannot share the
+>   same basename (e.g., `dist1/pkg.whl` and `dist2/pkg.whl`), or validation will
+>   fail.
 
 ### Dynamic installation from source
 

--- a/tests/ado/test_remote_submission.py
+++ b/tests/ado/test_remote_submission.py
@@ -763,6 +763,25 @@ def test_remote_dispatch_wheel_only_in_additional_files(
     assert loaded["uv"] == ["ado-core"]
 
 
+def test_additional_files_in_from_source_dist_raises() -> None:
+    """additionalFiles entry inside a fromSource package's dist/ raises ValidationError.
+
+    When a fromSource package is built, uv build --clear wipes its dist/
+    directory. Any additionalFiles entry pointing into that same dist/ will
+    be deleted before Ray can upload it, so validation must reject this.
+    """
+    raw = {
+        "executionType": {"type": "cluster", "clusterUrl": "http://localhost:8265"},
+        "packages": {
+            "fromSource": ["plugins/my_plugin"],
+            "fromPyPI": ["dep_wheel-1.0-py3-none-any.whl"],
+        },
+        "additionalFiles": ["plugins/my_plugin/dist/dep_wheel-1.0-py3-none-any.whl"],
+    }
+    with pytest.raises(pydantic.ValidationError, match="fromSource"):
+        RemoteExecutionContext.model_validate(raw)
+
+
 def test_write_runtime_env_with_ray_config(tmp_path: pathlib.Path) -> None:
     """runtimeEnv maps to Ray config keys in runtime_env.yaml."""
     ctx = RemoteExecutionContext(

--- a/tests/ado/test_remote_submission.py
+++ b/tests/ado/test_remote_submission.py
@@ -8,6 +8,7 @@ import subprocess
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
+import pydantic
 import pytest
 import yaml
 from typer.testing import CliRunner
@@ -621,13 +622,13 @@ def test_write_runtime_env_env_vars_only(tmp_path: pathlib.Path) -> None:
 
 
 def test_write_runtime_env_local_wheel_in_pypi(tmp_path: pathlib.Path) -> None:
-    """Local .whl paths in fromPyPI are copied to working_dir and rewritten."""
+    """Local .whl paths in fromPyPI are symlinked to working_dir and rewritten."""
     local_whl = tmp_path / "my_local-1.0-py3-none-any.whl"
     local_whl.write_bytes(b"fake wheel")
 
     ctx = RemoteExecutionContext(
         executionType=ClusterExecutionType(clusterUrl="http://localhost:8265"),
-        packages=PackageConfiguration(fromPyPI=[str(local_whl), "ado-core"]),
+        packages=PackageConfiguration(fromPyPI=[local_whl.name, "ado-core"]),
     )
     dest = tmp_path / "runtime_env.yaml"
     working_dir = tmp_path / "working"
@@ -639,6 +640,127 @@ def test_write_runtime_env_local_wheel_in_pypi(tmp_path: pathlib.Path) -> None:
     assert "ado-core" in loaded["uv"]
     assert f"${{RAY_RUNTIME_ENV_CREATE_WORKING_DIR}}/{local_whl.name}" in loaded["uv"]
     assert str(local_whl) not in loaded["uv"]
+
+
+def test_remote_context_validation_whl_prefix_rewritten() -> None:
+    """Entry with ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/ is rewritten to bare wheel name."""
+    raw = {
+        "executionType": {"type": "cluster", "clusterUrl": "http://localhost:8265"},
+        "packages": {
+            "fromPyPI": [
+                "${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/my_wheel-0.9.7-py3-none-any.whl",
+                "ado-core",
+            ]
+        },
+        "additionalFiles": ["dist/my_wheel-0.9.7-py3-none-any.whl"],
+    }
+    ctx = RemoteExecutionContext.model_validate(raw)
+    assert ctx.packages.fromPyPI == [
+        "my_wheel-0.9.7-py3-none-any.whl",
+        "ado-core",
+    ]
+
+
+def test_remote_context_validation_relative_subpath_emits_warning() -> None:
+    """Entry in fromPyPI with relative subpath emits a UserWarning."""
+    raw = {
+        "executionType": {"type": "cluster", "clusterUrl": "http://localhost:8265"},
+        "packages": {
+            "fromPyPI": [
+                "dist/my_wheel-0.9.7-py3-none-any.whl",
+            ]
+        },
+    }
+    with pytest.warns(UserWarning, match="contains a relative directory path"):
+        ctx = RemoteExecutionContext.model_validate(raw)
+    assert ctx.packages.fromPyPI == ["dist/my_wheel-0.9.7-py3-none-any.whl"]
+
+
+def test_remote_context_validation_bare_wheel_not_in_additional_files() -> None:
+    """Bare wheel in fromPyPI without matching additionalFiles entry is valid."""
+    raw = {
+        "executionType": {"type": "cluster", "clusterUrl": "http://localhost:8265"},
+        "packages": {
+            "fromPyPI": [
+                "my_wheel-0.9.7-py3-none-any.whl",
+            ]
+        },
+    }
+    RemoteExecutionContext.model_validate(raw)
+
+
+def test_remote_context_validation_additional_files_conflict_raises() -> None:
+    """Duplicate/conflicting filenames in additionalFiles raise ValidationError."""
+    raw = {
+        "executionType": {"type": "cluster", "clusterUrl": "http://localhost:8265"},
+        "additionalFiles": [
+            "dist1/my_wheel-0.9.7-py3-none-any.whl",
+            "dist2/my_wheel-0.9.7-py3-none-any.whl",
+        ],
+    }
+    with pytest.raises(pydantic.ValidationError, match="duplicate basename"):
+        RemoteExecutionContext.model_validate(raw)
+
+
+def test_remote_dispatch_wheel_in_additional_files(tmp_path: pathlib.Path) -> None:
+    """Bare wheel in fromPyPI matching additionalFiles is symlinked and in runtime_env."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    wheel_file = dist_dir / "my_wheel-0.9.7-py3-none-any.whl"
+    wheel_file.write_bytes(b"wheel content")
+
+    ctx = RemoteExecutionContext(
+        executionType=ClusterExecutionType(clusterUrl="http://localhost:8265"),
+        packages=PackageConfiguration(
+            fromPyPI=["my_wheel-0.9.7-py3-none-any.whl", "ado-core"]
+        ),
+        additionalFiles=["dist/my_wheel-0.9.7-py3-none-any.whl"],
+    )
+    dest = tmp_path / "runtime_env.yaml"
+    working_dir = tmp_path / "working"
+    working_dir.mkdir()
+
+    seen_basenames: set[str] = set()
+    _symlink_additional_files(
+        ctx.additionalFiles, tmp_path, working_dir, seen_basenames
+    )
+    _write_runtime_env(ctx, [], dest, tmp_path, working_dir, seen_basenames)
+
+    assert (working_dir / wheel_file.name).is_symlink()
+    loaded = yaml.safe_load(dest.read_text())
+    assert f"${{RAY_RUNTIME_ENV_CREATE_WORKING_DIR}}/{wheel_file.name}" in loaded["uv"]
+    assert "ado-core" in loaded["uv"]
+
+    assert len(loaded["uv"]) == 2
+
+
+def test_remote_dispatch_wheel_only_in_additional_files(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Wheel only in additionalFiles is symlinked but NOT in runtime_env uv."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    extra_wheel = dist_dir / "extra-1.0-py3-none-any.whl"
+    extra_wheel.write_bytes(b"extra wheel content")
+
+    ctx = RemoteExecutionContext(
+        executionType=ClusterExecutionType(clusterUrl="http://localhost:8265"),
+        packages=PackageConfiguration(fromPyPI=["ado-core"]),
+        additionalFiles=["dist/extra-1.0-py3-none-any.whl"],
+    )
+    dest = tmp_path / "runtime_env.yaml"
+    working_dir = tmp_path / "working"
+    working_dir.mkdir()
+
+    seen_basenames: set[str] = set()
+    _symlink_additional_files(
+        ctx.additionalFiles, tmp_path, working_dir, seen_basenames
+    )
+    _write_runtime_env(ctx, [], dest, tmp_path, working_dir, seen_basenames)
+
+    assert (working_dir / extra_wheel.name).is_symlink()
+    loaded = yaml.safe_load(dest.read_text())
+    assert loaded["uv"] == ["ado-core"]
 
 
 def test_write_runtime_env_with_ray_config(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
Contributes to #1405