### PR TITLE
fix(core): ensure correct identifier is used in prints for parameterized experiments

### DIFF
--- a/ado/schema/measurementspace.py
+++ b/ado/schema/measurementspace.py
@@ -184,13 +184,14 @@ class MeasurementSpace:
 
         content = []
 
-        def parameterization_string(e: Experiment | ParameterizedExperiment) -> str:
-
+        def parameterization_string(
+            e: Experiment | ParameterizedExperiment,
+        ) -> str | None:
+            """Return the parameterization suffix, or None for a base Experiment."""
             return (
-                None
-                if isinstance(e, Experiment)
-                # The [1:] is to cut the initial hyphen
-                else identifier_for_parameterized_experiment("", e.parameterization)[1:]
+                identifier_for_parameterized_experiment("", e.parameterization)[1:]
+                if isinstance(e, ParameterizedExperiment)
+                else None
             )
 
         # Experiments overview table

--- a/tests/schema/test_measurementspace.py
+++ b/tests/schema/test_measurementspace.py
@@ -1019,6 +1019,47 @@ def test_measurementspace_rich_print(
     print(measurement_space_from_single_parameterized_experiment)
 
 
+def test_measurementspace_rich_print_shows_parameterization(
+    measurement_space_from_single_parameterized_experiment: MeasurementSpace,
+) -> None:
+    """The experiments overview table includes parameterization, not None.
+
+    ParameterizedExperiment subclasses Experiment, so isinstance(e, Experiment)
+    must not be used to decide the parameterization column.
+    """
+    from ado.schema.reference import identifier_for_parameterized_experiment
+    from ado.utilities.rich import render_to_string
+
+    ms = measurement_space_from_single_parameterized_experiment
+    experiment = ms.experiments[0]
+    assert isinstance(experiment, ParameterizedExperiment)
+    parameterization = identifier_for_parameterized_experiment(
+        "", experiment.parameterization
+    )[1:]
+    base_identifier = f"{experiment.actuatorIdentifier}.{experiment.identifier}"
+
+    rendered = render_to_string(ms.__rich__(), width=200)
+    table_row = next(line for line in rendered.splitlines() if base_identifier in line)
+    assert parameterization in table_row
+
+
+def test_measurementspace_rich_print_unparameterized(
+    measurement_space_direct: MeasurementSpace,
+) -> None:
+    """The experiments overview table shows None for an unparameterized experiment."""
+    from ado.utilities.rich import render_to_string
+
+    ms = measurement_space_direct
+    experiment = ms.experiments[0]
+    assert type(experiment) is Experiment
+    base_identifier = f"{experiment.actuatorIdentifier}.{experiment.identifier}"
+
+    rendered = render_to_string(ms.__rich__(), width=200)
+    table_row = next(line for line in rendered.splitlines() if base_identifier in line)
+    cells = [cell.strip() for cell in table_row.split("┃")]
+    assert cells[-1] == "None"
+
+
 def test_measurementspace_rich_print_multiple(
     measurement_space_from_multiple_parameterized_experiments: MeasurementSpace,
 ) -> None:


### PR DESCRIPTION
If an experiment was parameterized, the parameterization column of the Experiments table showed None instead of the parameterization as expected. 