### PR TITLE
docs(website): move resources section under user guide

### DIFF
--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -12,7 +12,8 @@
 
 **ado** comes with a CLI utility that is designed to be familiar for users of
 `kubectl` and `oc`. It allows creating and retrieving
-[resources](../resources/index.md), managing multiple backends, executing
+[resources](../resources/working-with-resources.md), managing
+multiple backends, executing
 [actuators](../user-guide/actuators/working-with-actuators.md), and more.
 
 This page provides documentation for every command that we support, presented in
@@ -130,7 +131,7 @@ ado context my-context
 ## ado create
 
 The **ado** CLI provides the _create_ command to create
-[resources](../resources/index.md) given a YAML file with their
+[resources](../resources/working-with-resources.md) given a YAML file with their
 configuration.
 
 The complete syntax of the `ado create` command is as follows:
@@ -255,7 +256,7 @@ ado create space -f ds.yaml --set "entitySpace[0].identifier=abcdef"
 ## ado delete
 
 The **ado** CLI provides the delete command to delete
-[resources](../resources/index.md) given their unique identifier.
+[resources](../resources/working-with-resources.md) given their unique identifier.
 
 The complete syntax of the `ado delete` command is as follows:
 

--- a/docs/concepts/core-concepts.md
+++ b/docs/concepts/core-concepts.md
@@ -63,10 +63,10 @@ rather than running it again. This transparent data sharing is a core feature of
 
     ---
 
-    Go to [resources](../resources/index.md) to learn more about working
+    Go to [resources](../resources/working-with-resources.md) to learn more about working
     with these core concepts in `ado`.
 
-    [ado resources :octicons-arrow-right-24:](../resources/index.md)
+    [ado resources :octicons-arrow-right-24:](../resources/working-with-resources.md)
 
 - :octicons-workflow-24:{ .lg .middle } **Try our examples**
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -3,16 +3,37 @@
 <!-- markdownlint-disable code-block-style -->
 <!-- markdownlint-disable-next-line first-line-h1 -->
 
-`ado` manages resources related to discovery, such as descriptions of spaces to
-explore, operations for exploration and analysis, and actuator configurations.
-With `ado`, you can create these resources, which are stored in a database (the
-[metastore](metastore.md)) along with their relationships to other resources.
-You can then describe, list, or delete these resources as needed.
+With the **ado** CLI
+you work with _resources_, _actuators and operators_, and
+_contexts_.
 
-The resources are:
+**Actuators and operators**
+provide capabilities, and **resources** define how you use them.
+You store the resources in projects along with the measurement data.
+To access a particular project you have a **context** which describes
+its location and access credentials.
+
+This section covers the different resource types, writing
+resource definitions, and using the CLI to create resources from
+the definitions and work with the results.
+
+For more on actuators, operators and contexts see their dedicated sections
+
+- [Working with Actuators](../user-guide/actuators)
+- [Working with Operators](../user-guide/operators)
+- [Projects & Contexts](metastore.md#contexts-and-projects)
+
+## Resource Types
+
+You use the `ado` CLI to create, list, inspect or delete resources.
+To create a resources you first defined it in a YAML files. On
+creation the resource definition is stored in a database (the
+[metastore](metastore.md)).
+
+The current `ado` resources are:
 
 - **[samplestore](sample-stores.md)**: A database for storing entities and
-  measurement results
+  measurement results.
 - **[discoveryspace](discovery-spaces.md)**: Describes a set of entities along
   with the experiment protocols that should be applied to them
 - **[operation](operation.md)**: An instance of applying an operator to a
@@ -24,12 +45,20 @@ The resources are:
 - **[document](document.md)**: A markdown or HTML report or note stored in the
   metastore, optionally linked to related resources.
 
+Creating some resource triggers other events to occur. In particular
+
+- creating a `samplestore` resource results in specific
+piece of storage being created.
+- creating an operation resource causes an operation to execute.
+The operation may sample and measure entities in a space or
+could perform an analysis, potentially returning new resources
+
 > [!NOTE]
 >
 > Some resources take other resources as input, for example `operations` take
 > `discoveryspaces` as input.
 
-## Naming Conventions: Concepts versus Resources
+### Naming Conventions: Concepts versus Resources
 
 `ado` resources are directly related to `ado`
 [concepts](../concepts/core-concepts.md) and usually have the same name. To
@@ -39,22 +68,6 @@ adopt the following conventions.
 When we refer to concepts, upper case nouns like "Sample Store", "Actuator" are
 used. However, for the corresponding resources lower case is used, with no
 spaces, so `samplestore` and `actuator`.
-
-We also apply the same approach to `entities`, although these are not properly
-resources. See [below](#where-are-the-entities) for more.
-
-## `actuators`, `operators` and `contexts`
-
-Many `ado` commands work with `actuators`, `operators` and `contexts` as if they
-were resources. However, they are not true resources and are not stored in the
-metastore.
-
-- For more on `actuators` see
-  [working with actuators](../user-guide/actuators/working-with-actuators.md).
-- For more on `operators` see
-  [working with operators](../user-guide/operators/working-with-operators.md).
-- For more on `contexts` see the
-  [metastore docs](metastore.md#contexts-and-projects)
 
 ## Common CLI commands for interacting with resources
 
@@ -179,20 +192,6 @@ from ado.core import kindmap
 with open("resource.yaml") as f:
     resource = kindmap["discoveryspace"].model_validate(yaml.safe_load(f))
 ```
-
-## Where are the entities?
-
-Note that `entities` are not a resource `ado` manages. Instead, you work at the
-level of sets of `entities` i.e. a `discoveryspace`.
-
-- A `discoveryspace` defines a set of `entities`
-- Applying certain `operations` to a `discoveryspace` results in `entities`
-  being sampled from the space and measurements being applied to them
-- The sampled entities and measurement results are stored in a `samplestore`
-
-You can think of `discoveryspaces`, `samplestores` and `operations` as being
-(different) "containers" of Entities. `ado` also provides commands to `show` the
-Entities that are in those containers.
 
 ## What's next
 

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable code-block-style -->
 <!-- markdownlint-disable-next-line first-line-h1 -->
 `ado` uses a SQL database to store
-[resource definitions](index.md#common-features-of-resources)
+[resource definitions](working-with-resources.md#common-features-of-resources)
 and [SQLSampleStores](sample-stores.md#sqlsamplestore). When you execute `ado`
 commands like `get` or `describe` they are interacting with this metastore.
 
@@ -157,7 +157,7 @@ existing database.
 
 The [`ado get`](../cli-reference/index.md#ado-get) CLI command lets you easily
 retrieve and search
-[resource definitions](index.md#common-features-of-resources)
+[resource definitions](working-with-resources#common-features-of-resources)
 in the metastore in a variety of ways.
 
 ### Searching for similar spaces
@@ -223,7 +223,8 @@ will retrieve all operations that have the label `labelone` with the value
 
 For more advanced searches, `ado` provides the `--filter` option to find
 resources based on the contents of their
-[stored representation](index.md#common-features-of-resources). This option
+[stored representation](working-with-resources.md#common-features-of-resources).
+This option
 can be specified multiple times and in conjunction with the `-l` option to find
 resources that match all the specified filters.
 

--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -163,8 +163,8 @@ missing, the `create` operation will fail with a relevant error.
 ### `operation` resource specific fields
 
 `operation` resources have two additional top-level fields in addition to common
-ones described in [resources](index.md#common-features-of-resources) These
-are (with example values):
+ones described in [resources](working-with-resources.md#common-features-of-resources).
+These are (with example values):
 
 ```yaml
 operationType: characterize # characterize, modify, etc.
@@ -192,7 +192,7 @@ See [datacontainers](datacontainer.md) for more details.
 ## `operation` status update events
 
 In addition to the
-[status update events common to all resources](index.md#resource-status)
+[status update events common to all resources](working-with-resources.md#resource-status)
 `operations` define two more events: `started` and `finished`.
 
 The finished event also has a custom field `exit_state` which described how the

--- a/docs/resources/sample-stores.md
+++ b/docs/resources/sample-stores.md
@@ -304,7 +304,7 @@ caution. When a sample store is deleted:
   These will be measurements that were copied into the `samplestore` i.e., not
   generated through `ado` operations. All results from `ado` operations would
   have already been subject to
-  [standard deletion constraints](index.md#deleting-resources).
+  [standard deletion constraints](working-with-resources.md#deleting-resources).
 - **The corresponding database tables will be dropped**.
 
 This is especially critical when the sample store was populated externally, such

--- a/docs/resources/working-with-resources.md
+++ b/docs/resources/working-with-resources.md
@@ -19,8 +19,8 @@ the definitions and work with the results.
 
 For more on actuators, operators and contexts see their dedicated sections
 
-- [Working with Actuators](../user-guide/actuators)
-- [Working with Operators](../user-guide/operators)
+- [Working with Actuators](../user-guide/actuators/working-with-actuators.md)
+- [Working with Operators](../user-guide/operators/working-with-operators.md)
 - [Projects & Contexts](metastore.md#contexts-and-projects)
 
 ## Resource Types

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,15 @@ nav:
   - User Guide:
       - Getting Started: user-guide/getting-started.md
       - ado and Agents: user-guide/ado-and-agents.md
+      - Resources:
+          - resources/index.md
+          - The metastore: resources/metastore.md
+          - samplestore: resources/sample-stores.md
+          - discoveryspace: resources/discovery-spaces.md
+          - operation: resources/operation.md
+          - actuatorconfiguration: resources/actuatorconfig.md
+          - datacontainer: resources/datacontainer.md
+          - document: resources/document.md
       - Actuators:
           - Working with actuators: user-guide/actuators/working-with-actuators.md
           - Actuator Guides:
@@ -198,13 +207,4 @@ nav:
       - Entities and Entity Spaces: concepts/entity-spaces.md
       - Discovery Spaces: concepts/discovery-spaces.md
       - Shared Sample Stores: concepts/data-sharing.md
-  - Resources:
-      - resources/index.md
-      - The metastore: resources/metastore.md
-      - samplestore: resources/sample-stores.md
-      - discoveryspace: resources/discovery-spaces.md
-      - operation: resources/operation.md
-      - actuatorconfiguration: resources/actuatorconfig.md
-      - datacontainer: resources/datacontainer.md
-      - document: resources/document.md
   - CLI Reference: cli-reference/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,13 +141,13 @@ plugins:
   - gh-admonitions:
 nav:
   - Home:
-      - Home: index.md
+      - Home: working-with-resources.md
       - Roadmap: roadmap.md
   - User Guide:
       - Getting Started: user-guide/getting-started.md
       - ado and Agents: user-guide/ado-and-agents.md
       - Resources:
-          - resources/index.md
+          - Working with resources: resources/working-with-resources.md
           - The metastore: resources/metastore.md
           - samplestore: resources/sample-stores.md
           - discoveryspace: resources/discovery-spaces.md
@@ -183,7 +183,7 @@ nav:
           - Contributing: developer-guide/contributing.md
           - Developing ado: developer-guide/developing.md
   - Examples:
-      - user-guide/examples/index.md
+      - user-guide/examples/working-with-resources.md
       - Tutorials:
           - "The basics: your first ado experiment campaign": user-guide/examples/tutorials/density-example.md
           - "Beyond the basics: ado with real data": user-guide/examples/tutorials/random-walk.md
@@ -207,4 +207,4 @@ nav:
       - Entities and Entity Spaces: concepts/entity-spaces.md
       - Discovery Spaces: concepts/discovery-spaces.md
       - Shared Sample Stores: concepts/data-sharing.md
-  - CLI Reference: cli-reference/index.md
+  - CLI Reference: cli-reference/working-with-resources.md


### PR DESCRIPTION
This is a first part of two step improvement of the documentation. 

Currently the user-guide contains no informations on the how to create resources or use CLI to work with them as this is all under "Resources" top level tab. It also does not introduce the  ado CLI, what you use it for (working with resources, listing catalogs of operators and actuators, managing projects)  or talk about projects/contexts. Note this is different to ado CLI reference. 

This first part of the change is to move "Resources" under "User Guide" with some minor additional framing to the index page to talk about the fact that ado CLI works with resources, operators, actuators and projects (info currently no where) 

The second part will be to 
- Add a page introducing the ado CLI - this should extend from what in this PR is currently in resource/index.md - and that links to the other sections
- Make project & contexts docs, currently in resource/metastore.md more prominent 

Outline of User Guide should be possibly
- Getting Started
- ado and Agents
- The ado CLI (Phase 2)
   - Projects and Contexts (Phase 2)
- Resources (Phase 1)
    ... # Resource docs
- Operators
    ... # Operator docs
- Actuators
   ... # Actuator docs

